### PR TITLE
Single index type

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -57,7 +57,6 @@ namespace xt
         using difference_type = typename container_type::difference_type;
 
         using shape_type = typename inner_types::shape_type;
-        using index_type = shape_type;
         using strides_type = typename inner_types::strides_type;
 
         using stepper = xstepper<D>;
@@ -87,8 +86,8 @@ namespace xt
         template <class... Args>
         const_reference operator()(Args... args) const;
 
-        reference operator[](const index_type& index);
-        const_reference operator[](const index_type& index) const;
+        reference operator[](const xindex& index);
+        const_reference operator[](const xindex& index) const;
 
         container_type& data();
         const container_type& data() const;
@@ -159,7 +158,7 @@ namespace xt
         template <size_t dim = 0, class... Args>
         size_type data_offset(size_type i, Args... args) const;
 
-        size_type data_offset(const index_type& index) const;
+        size_type data_offset(const xindex& index) const;
 
         shape_type m_shape;
         strides_type m_strides;
@@ -238,7 +237,7 @@ namespace xt
     }
 
     template <class D>
-    inline auto xcontainer<D>::data_offset(const index_type& index) const -> size_type
+    inline auto xcontainer<D>::data_offset(const xindex& index) const -> size_type
     {
         // VS2015 workaround : index.begin() + index.size() - m_strides.size()
         // doesn't compile
@@ -397,7 +396,7 @@ namespace xt
      * than the number of dimensions of the container.
      */
     template <class D>
-    inline auto xcontainer<D>::operator[](const index_type& index) -> reference
+    inline auto xcontainer<D>::operator[](const xindex& index) -> reference
     {
         return data()[data_offset(index)];
     }
@@ -409,7 +408,7 @@ namespace xt
     * than the number of dimensions of the container.
     */
     template <class D>
-    inline auto xcontainer<D>::operator[](const index_type& index) const -> const_reference
+    inline auto xcontainer<D>::operator[](const xindex& index) const -> const_reference
     {
         return data()[data_offset(index)];
     }

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -10,11 +10,15 @@
 #define XEXPRESSION_HPP
 
 #include <type_traits>
+#include <cstddef>
+#include <vector>
 
 #include "xutils.hpp"
 
 namespace xt
 {
+
+    using xindex = std::vector<std::size_t>;
 
     /**
      * @class xexpression

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -74,7 +74,6 @@ namespace xt
         using difference_type = std::common_type_t<typename E::difference_type...>; //detail::common_difference_type<E...>;
 
         using shape_type = std::vector<size_type>;
-        using index_type = shape_type;
         using strides_type = std::vector<size_type>;
         using closure_type = const self_type;
 
@@ -91,7 +90,7 @@ namespace xt
         template <class... Args>
         const_reference operator()(Args... args) const;
 
-        const_reference operator[](const index_type& index) const;
+        const_reference operator[](const xindex& index) const;
 
         template <class S>
         bool broadcast_shape(S& shape) const;
@@ -124,7 +123,7 @@ namespace xt
         const_reference access_impl(std::index_sequence<I...>, Args... args) const;
 
         template <std::size_t... I>
-        const_reference access_impl(const index_type& index, std::index_sequence<I...>) const;
+        const_reference access_impl(const xindex& index, std::index_sequence<I...>) const;
 
         template <class Func, std::size_t... I>
         const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const;
@@ -320,7 +319,7 @@ namespace xt
     }
 
     template <class F, class R, class... E>
-    inline auto xfunction<F, R, E...>::operator[](const index_type& index) const -> const_reference
+    inline auto xfunction<F, R, E...>::operator[](const xindex& index) const -> const_reference
     {
         return access_impl(index, std::make_index_sequence<sizeof...(E)>());
     }
@@ -501,7 +500,7 @@ namespace xt
 
     template <class F, class R, class... E>
     template <std::size_t... I>
-    inline auto xfunction<F, R, E...>::access_impl(const index_type& index, std::index_sequence<I...>) const -> const_reference
+    inline auto xfunction<F, R, E...>::access_impl(const xindex& index, std::index_sequence<I...>) const -> const_reference
     {
         return m_f(std::get<I>(m_e)[index]...);
     }

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -44,8 +44,8 @@ namespace xt
         using difference_type = std::ptrdiff_t;
 
         using self_type = xscalar<T>;
-        using shape_type = std::vector<size_type>;
-        using strides_type = std::vector<size_type>;
+        using shape_type = std::array<size_type, 0>;
+        using strides_type = std::array<size_type, 0>;
 
         using closure_type = const self_type;
         using const_stepper = xscalar_stepper<T>;
@@ -63,11 +63,16 @@ namespace xt
         template <class... Args>
         const_reference operator()(Args... args) const;
 
-        bool broadcast_shape(shape_type& shape) const;
-        bool is_trivial_broadcast(const strides_type& strides) const;
+        template <class S>
+        bool broadcast_shape(S& shape) const;
 
-        const_stepper stepper_begin(const shape_type& shape) const;
-        const_stepper stepper_end(const shape_type& shape) const;
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const;
 
         const_storage_iterator storage_begin() const;
         const_storage_iterator storage_end() const;
@@ -210,25 +215,29 @@ namespace xt
     }
 
     template <class T>
-    inline bool xscalar<T>::broadcast_shape(shape_type&) const
+    template <class S>
+    inline bool xscalar<T>::broadcast_shape(S&) const
     {
         return true;
     }
 
     template <class T>
-    inline bool xscalar<T>::is_trivial_broadcast(const strides_type&) const
+    template <class S>
+    inline bool xscalar<T>::is_trivial_broadcast(const S&) const
     {
         return true;
     }
 
     template <class T>
-    inline auto xscalar<T>::stepper_begin(const shape_type&) const -> const_stepper
+    template <class S>
+    inline auto xscalar<T>::stepper_begin(const S&) const -> const_stepper
     {
         return const_stepper(this);
     }
 
     template <class T>
-    inline auto xscalar<T>::stepper_end(const shape_type& shape) const -> const_stepper
+    template <class S>
+    inline auto xscalar<T>::stepper_end(const S& shape) const -> const_stepper
     {
         return const_stepper(this);
     }

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -224,7 +224,7 @@ namespace xt
     template <class V1, class V2>
     void indexed_assign_array(V1& dst, const V2& src)
     {
-        typename V1::index_type index = dst.shape();
+        xindex index(dst.dimension());
         for (std::size_t i = 0; i < dst.shape()[0]; ++i)
         {
             index[0] = i;

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -106,8 +106,7 @@ namespace xt
     TEST(xfunction, indexed_access)
     {
         xfunction_features f;
-        using index_type = xarray<int>::index_type;
-        index_type index = f.m_a.shape();
+        xindex index(f.m_a.dimension());
         index[0] = f.m_a.shape()[0] - 1;
         index[1] = f.m_a.shape()[1] - 1;
         index[2] = f.m_a.shape()[2] - 1;
@@ -122,7 +121,7 @@ namespace xt
         {
             SCOPED_TRACE("different shape");
             int a = (f.m_a + f.m_b)[index];
-            index_type index2 = index;
+            xindex index2 = index;
             index2[1] = 0;
             int b = f.m_a[index] + f.m_b[index2];
             EXPECT_EQ(a, b);
@@ -130,7 +129,7 @@ namespace xt
 
         {
             SCOPED_TRACE("different dimensions");
-            index_type index2 = f.m_c.shape();
+            xindex index2(f.m_c.dimension());
             index2[0] = 1;
             index2[1] = index[0];
             index2[2] = index[1];


### PR DESCRIPTION
- Single `index_type` over entire library.
- xscalar's `shape_type` is an `array`.