### PR TITLE
xall() implementation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    installation
    usage

--- a/docs/source/xview.rst
+++ b/docs/source/xview.rst
@@ -10,3 +10,15 @@ xview
 .. doxygenclass:: xt::xview
    :project: xtensor
    :members:
+
+.. doxygenfunction:: xt::make_xview
+   :project: xtensor
+
+.. doxygenfunction:: xt::range(T, T)
+   :project: xtensor
+
+.. doxygenfunction:: xt::range(T, T, T)
+   :project: xtensor
+
+.. doxygenfunction:: xt::all
+   :project: xtensor

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -78,6 +78,13 @@ namespace xt
         size_type m_size;
     };
 
+    /**
+     * Returns a slice representing an interval, to
+     * be used as an argument of make_xview function.
+     * @param min the first index of the interval
+     * @param max the last index of the interval
+     * @sa make_xview
+     */
     template <class T>
     inline auto range(T min, T max)
     {
@@ -111,6 +118,14 @@ namespace xt
         size_type m_step;
     };
 
+    /**
+     * Returns a slice representing an interval, to
+     * be used as an argument of make_xview function.
+     * @param min the first index of the interval
+     * @param max the last index of the interval
+     * @param step the space between two indices
+     * @sa make_xview
+     */
     template <class T>
     inline auto range(T min, T max, T step)
     {
@@ -146,6 +161,11 @@ namespace xt
     {
     };
 
+    /**
+     * Returns a slice representing a full dimension,
+     * to be used as an argument of make_xview function.
+     * @sa make_xview
+     */
     inline auto all()
     {
         return xall_tag();

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -142,6 +142,15 @@ namespace xt
         size_type m_size;
     };
 
+    struct xall_tag
+    {
+    };
+
+    inline auto all()
+    {
+        return xall_tag();
+    }
+
     /******************************************************
      * homogeneous get_size for integral types and slices *
      ******************************************************/
@@ -189,6 +198,44 @@ namespace xt
     {
         return slice.derived_cast()(0);
     }
+
+    /****************************************
+     * homogeneous get_slice_implementation *
+     ****************************************/
+
+    template <class E, class SL>
+    inline auto get_slice_implementation(E& /*e*/, SL&& slice, std::size_t /*index*/)
+    {
+        return std::forward<SL>(slice);
+    }
+
+    template <class E>
+    inline auto get_slice_implementation(E& e, xall_tag, std::size_t index)
+    {
+        return xall<typename E::size_type>(e.shape()[index]);
+    }
+
+    /******************************
+     * homogeneous get_slice_type *
+     ******************************/
+
+    namespace detail
+    {
+        template <class E, class SL>
+        struct get_slice_type_impl
+        {
+            using type = SL;
+        };
+
+        template <class E>
+        struct get_slice_type_impl<E, xall_tag>
+        {
+            using type = xall<typename E::size_type>;
+        };
+    }
+
+    template <class E, class SL>
+    using get_slice_type = typename detail::get_slice_type_impl<E, std::remove_reference_t<SL>>::type;
 
     /*************************
      * xslice implementation *

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -39,7 +39,7 @@ namespace xt
      * @brief Dense multidimensional container with tensor
      * semantic and fixed dimension.
      *
-     * The xtnesor class implements a dense multidimensional container
+     * The xtensor class implements a dense multidimensional container
      * with tensor semantic and fixed dimension
      *
      * @tparam T The type of objects stored in the container.

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -46,6 +46,8 @@ namespace xt
      *
      * @tparam E the expression type to adapt
      * @tparam S the slices type describing the shape adaptation
+     *
+     * @sa make_xview
      */
     template <class E, class... S>
     class xview : public xview_semantic<xview<E, S...>>
@@ -258,8 +260,11 @@ namespace xt
     //@{
     /**
      * Constructs a view on the specified xexpression.
+     * Users should not call directly this constructor but
+     * use the make_xview function instead.
      * @param e the xexpression to adapt
      * @param slices the slices list describing the view
+     * @sa make_xview
      */
     template <class E, class... S>
     template <class... SL>
@@ -448,6 +453,15 @@ namespace xt
         }
     }
 
+    /**
+     * Constructs and returns a view on the specified xexpression. Users
+     * should not directly construct the slices but call helper functions
+     * instead.
+     * @param e the xexpression to adapt
+     * @param slices the slices list describing the view
+     * @sa range 
+     * @sa all
+     */
     template <class E, class... S>
     inline xview<E, get_slice_type<E, S>...> make_xview(E& e, S&&... slices)
     {

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -47,6 +47,17 @@ namespace xt
         auto view5 = make_xview(view4, 1);
         EXPECT_EQ(0, view5.dimension());
         EXPECT_EQ(0, view5.shape().size());
+
+        auto view6 = make_xview(a, 1, all());
+        EXPECT_EQ(a(1, 0), view6(0));
+        EXPECT_EQ(a(1, 1), view6(1));
+        EXPECT_EQ(a(1, 2), view6(2));
+        EXPECT_EQ(a(1, 3), view6(3));
+
+        auto view7 = make_xview(a, all(), 2);
+        EXPECT_EQ(a(0, 2), view7(0));
+        EXPECT_EQ(a(1, 2), view7(1));
+        EXPECT_EQ(a(2, 2), view7(2));
     }
 
     TEST(xview, three_dimensional)


### PR DESCRIPTION
This PR fixes the problem of xall slice whose constructor requires the dimension of the underlying array.