### PR TITLE
Add xbroadcast expression and broadcast helper.

### DIFF
--- a/docs/source/xbroadcast.rst
+++ b/docs/source/xbroadcast.rst
@@ -4,16 +4,9 @@
 
    The full license is in the file LICENSE, distributed with this software.
 
-Containers and views
-====================
+xbroadcast
+==========
 
-.. toctree::
-
-   xcontainer
-   xarray
-   xarray_adaptor
-   xtensor
-   xtensor_adaptor
-   xview
-   xfunction
-   xbroadcast
+.. doxygenclass:: xt::xbroadcast
+   :project: xtensor
+   :members:

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -344,7 +344,7 @@ namespace xt
     inline auto xbroadcast<E, X, LV>::xbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         // Could check if (broadcastable(shape, m_shape)
-        return cxbegin(shape);
+        return xiterator<const_stepper, S>(stepper_begin(shape), shape);
     }
 
     /**
@@ -357,7 +357,7 @@ namespace xt
     inline auto xbroadcast<E, X, LV>::xend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         // Could check if (broadcastable(shape, m_shape)
-        return cxend(shape);
+        return xiterator<const_stepper, S>(stepper_end(shape), shape);
     }
 
     /**
@@ -370,7 +370,7 @@ namespace xt
     inline auto xbroadcast<E, X, LV>::cxbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         // Could check if (broadcastable(shape, m_shape)
-        return cxbegin(shape);
+        return xiterator<const_stepper, S>(stepper_begin(shape), shape);
     }
 
     /**
@@ -383,7 +383,7 @@ namespace xt
     inline auto xbroadcast<E, X, LV>::cxend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         // Could check if (broadcastable(shape, m_shape)
-        return cxend(shape);
+        return xiterator<const_stepper, S>(stepper_end(shape), shape);
     }
     //@}
 
@@ -400,7 +400,7 @@ namespace xt
     inline auto xbroadcast<E, X, LV>::stepper_end(const S& shape) const noexcept -> const_stepper
     {
         // Could check if (broadcastable(shape, m_shape)
-        return m_e.stepper_begin(shape);
+        return m_e.stepper_end(shape);
     }
 
     /**

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -1,0 +1,286 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XBROADCAST_HPP
+#define XBROADCAST_HPP
+
+#include <utility>
+#include <initializer_list>
+#include <vector>
+#include <algorithm>
+
+#include "xtensor/xutils.hpp"
+#include "xtensor/xexpression.hpp"
+#include "xtensor/xiterator.hpp"
+
+namespace xt
+{
+
+    /**************
+     * xbroadcast *
+     **************/
+
+    /**
+     * @class xbroadcast
+     * @brief Broadcast an xexpression to a specified shape.
+     *
+     * Th xbroadcast class implements the broadcasting of an xexpression
+     * to a specified shape
+     *
+     * @tparam E the type of the xexpression to broadcast
+     * @tparam S the type of the shape.
+     */
+    template <class E, class X>
+    class xbroadcast : public xexpression<xbroadcast<E, X>>
+    {
+
+    public:
+
+        using self_type = xbroadcast<E, X>;
+
+        using value_type = typename E::value_type;
+        using reference = typename E::reference;
+        using const_reference = typename E::const_reference;
+        using pointer = typename E::pointer;
+        using const_pointer = typename E::const_pointer;
+        using size_type = typename E::size_type;
+        using difference_type = typename E::difference_type;
+        
+        using shape_type = promote_shape_t<typename E::shape_type, X>;
+        using strides_type = promote_strides_t<typename E::strides_type, X>;
+        using closure_type = const self_type;
+
+        using const_stepper = typename E::const_stepper;
+        using const_iterator = xiterator<const_stepper, shape_type>;
+        using const_storage_iterator = const_iterator;
+
+        template <class S>
+        xbroadcast(E e, S s) noexcept;
+
+        size_type dimension() const noexcept;
+        const shape_type & shape() const noexcept;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& strides) const noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        template <class S>
+        xiterator<const_stepper, S> xbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xend(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxend(const S& shape) const noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+        const_storage_iterator storage_begin() const noexcept;
+        const_storage_iterator storage_end() const noexcept;
+
+        const_storage_iterator storage_cbegin() const noexcept;
+        const_storage_iterator storage_cend() const noexcept;
+
+    private:
+
+        E m_e;
+        shape_type m_shape;
+    };
+
+    template <class E, class S>
+    inline auto broadcast(E e, S s)
+    {
+        return xbroadcast<get_xexpression_type<E>, S>(std::forward<E>(e), std::forward<S>(s));
+    }
+
+    template <class E, class I>
+    inline auto broadcast(E e, std::initializer_list<I> s)
+    {
+        return xbroadcast<get_xexpression_type<E>, std::vector<I>>(std::forward<E>(e), std::vector<I>(s));
+    }
+
+    /*****************************
+     * xbroadcast implementation *
+     *****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xbroadcast broadcasting the specified expression to the given
+     * shape
+     *
+     * @param e the expression to broadcast
+     * @param s the shape to apply
+     */
+    template <class E, class X>
+    template <class S>
+    inline xbroadcast<E, X>::xbroadcast(E e, S s) noexcept
+        : m_e(std::move(e)), m_shape(std::move(s))
+    {
+        xt::broadcast_shape(e.shape(), m_shape);
+    }
+    //@}
+
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::shape() const noexcept -> const shape_type &
+    {
+        return m_shape;
+    }
+
+    template <class E, class X>
+    template <class... Args>
+    inline auto xbroadcast<E, X>::operator()(Args... args) const -> const_reference
+    {
+        return detail::get_element(m_e, args...);
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::operator[](const xindex& index) const -> const_reference
+    {
+        // TODO:: depile
+        return m_e[index];
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline bool xbroadcast<E, X>::broadcast_shape(S& shape) const
+    { 
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline bool xbroadcast<E, X>::is_trivial_broadcast(const S& strides) const noexcept
+    {
+        return dimension() == m_e.dimension() && std::equal(m_shape.cbegin(), m_shape.cend(), m_e.shape().cbegin()) &&
+               m_e.is_trivial_broadcast(strides);
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::begin() const noexcept -> const_iterator
+    {
+        return cxbegin(shape());
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::end() const noexcept -> const_iterator
+    {
+        return cxend(shape());
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::cbegin() const noexcept -> const_iterator
+    {
+        return cxbegin(shape());
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::cend() const noexcept -> const_iterator
+    {
+        return cxend(shape());
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::xbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return cxbegin(shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::xend(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return cxend(shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::cxbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return cxbegin(shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::cxend(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return cxend(shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return m_e.stepper_begin(shape);
+    }
+
+    template <class E, class X>
+    template <class S>
+    inline auto xbroadcast<E, X>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        // Could check if (broadcastable(shape, m_shape)
+        return m_e.stepper_begin(shape);
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::storage_begin() const noexcept -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::storage_end() const noexcept -> const_storage_iterator
+    {
+        return cend();
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::storage_cbegin() const noexcept -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    template <class E, class X>
+    inline auto xbroadcast<E, X>::storage_cend() const noexcept -> const_storage_iterator
+    {
+        return cend();
+    }
+
+}
+
+#endif
+

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief standard mathematical functions for xexpressions
+ */
+
+#ifndef XBUILDER_HPP
+#define XBUILDER_HPP
+
+#include <initializer_list>
+#include <utility>
+#include <vector>
+
+#include "xfunction.hpp"
+#include "xbroadcast.hpp"
+#include "xmath.hpp"
+
+namespace xt
+{
+
+    /********
+     * ones *
+     ********/
+
+    template <class T, class S>
+    inline auto ones(S shape) noexcept
+    {
+        return broadcast(T(1), std::forward<S>(shape));
+    }
+
+    template <class T, class I>
+    inline auto ones(std::initializer_list<I> shape) noexcept
+    {
+        return ones<T>(std::vector<I>(shape));
+    }
+
+    /*********
+     * zeros *
+     *********/
+
+    template <class T, class S>
+    inline auto zeros(S shape) noexcept
+    {
+        return broadcast(T(0), std::forward<S>(shape));
+    }
+    
+    template <class T, class I>
+    inline auto zeros(std::initializer_list<I> shape) noexcept
+    {
+        return zeros<T>(std::vector<I>(shape));
+    }
+
+}
+#endif
+

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -28,6 +28,12 @@ namespace xt
      * ones *
      ********/
 
+    /**
+     * @function ones
+     * @brief Returns an \ref xexpression containing ones of the specified shape.
+     *
+     * @tparam shape the shape of the returned expression.
+     */
     template <class T, class S>
     inline auto ones(S shape) noexcept
     {
@@ -37,6 +43,7 @@ namespace xt
     template <class T, class I>
     inline auto ones(std::initializer_list<I> shape) noexcept
     {
+        // TODO: In the case of an initializer_list, use an array instead of a vector.
         return ones<T>(std::vector<I>(shape));
     }
 
@@ -44,6 +51,12 @@ namespace xt
      * zeros *
      *********/
 
+    /**
+     * @function ones
+     * @brief Returns an \ref xexpression containing zeros of the specified shape.
+     *
+     * @tparam shape the shape of the returned expression.
+     */
     template <class T, class S>
     inline auto zeros(S shape) noexcept
     {
@@ -53,6 +66,7 @@ namespace xt
     template <class T, class I>
     inline auto zeros(std::initializer_list<I> shape) noexcept
     {
+        // TODO: In the case of an initializer_list, use an array instead of a vector.
         return zeros<T>(std::vector<I>(shape));
     }
 

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -19,7 +19,6 @@
 
 #include "xfunction.hpp"
 #include "xbroadcast.hpp"
-#include "xmath.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -62,8 +62,8 @@ namespace xt
         using stepper = xstepper<D>;
         using const_stepper = xstepper<const D>;
 
-        using iterator = xiterator<stepper>;
-        using const_iterator = xiterator<const_stepper>;
+        using iterator = xiterator<stepper, shape_type>;
+        using const_iterator = xiterator<const_stepper, shape_type>;
 
         using storage_iterator = typename container_type::iterator;
         using const_storage_iterator = typename container_type::const_iterator;
@@ -106,13 +106,19 @@ namespace xt
         const_iterator cbegin() const noexcept;
         const_iterator cend() const noexcept;
 
-        iterator xbegin(const shape_type& shape) noexcept;
-        iterator xend(const shape_type& shape) noexcept;
+        template <class S>
+        xiterator<stepper, S> xbegin(const S& shape) noexcept;
+        template <class S>
+        xiterator<stepper, S> xend(const S& shape) noexcept;
 
-        const_iterator xbegin(const shape_type& shape) const noexcept;
-        const_iterator xend(const shape_type& shape) const noexcept;
-        const_iterator cxbegin(const shape_type& shape) const noexcept;
-        const_iterator cxend(const shape_type& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xend(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxend(const S& shape) const noexcept;
 
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
@@ -537,7 +543,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class D>
-    inline auto xcontainer<D>::xbegin(const shape_type& shape) noexcept -> iterator
+    template <class S>
+    inline auto xcontainer<D>::xbegin(const S& shape) noexcept -> xiterator<stepper, S>
     {
         return iterator(stepper_begin(shape), shape);
     }
@@ -548,7 +555,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class D>
-    inline auto xcontainer<D>::xend(const shape_type& shape) noexcept -> iterator
+    template <class S>
+    inline auto xcontainer<D>::xend(const S& shape) noexcept -> xiterator<stepper, S>
     {
         return iterator(stepper_end(shape), shape);
     }
@@ -559,7 +567,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class D>
-    inline auto xcontainer<D>::xbegin(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xcontainer<D>::xbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return const_iterator(stepper_begin(shape), shape);
     }
@@ -570,7 +579,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class D>
-    inline auto xcontainer<D>::xend(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xcontainer<D>::xend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return const_iterator(stepper_end(shape), shape);
     }
@@ -581,7 +591,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class D>
-    inline auto xcontainer<D>::cxbegin(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xcontainer<D>::cxbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return xbegin(shape);
     }
@@ -592,7 +603,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class D>
-    inline auto xcontainer<D>::cxend(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xcontainer<D>::cxend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return xend(shape);
     }

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -449,7 +449,7 @@ namespace xt
     /**
      * Broadcast the shape of the container to the specified parameter.
      * @param shape the result shape
-     * @return a boolean indicating whether the broadcast is trivial
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class D>
     template <class S>
@@ -459,9 +459,9 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see wether
-     * the broadcast is trivial.
-     * @return a boolean indicating whether the broadcast is trivial
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class D>
     template <class S>

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -104,7 +104,8 @@ namespace xt
 
     // Workaround for buggy error C2210 in VS2015 when using condtional_t
     template <class E>
-    using get_xexpression_type = typename std::conditional<is_xexpression<E>::value, E, xscalar<E>>::type;
+    using get_xexpression_type = typename std::conditional<is_xexpression<typename std::remove_reference<E>::type>::value,
+                                                           typename std::remove_reference<E>::type, xscalar<E>>::type;
 
     /*******************
      * get_xexpression *

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -20,6 +20,10 @@ namespace xt
 
     using xindex = std::vector<std::size_t>;
 
+    /***************************
+     * xexpression declaration *
+     ***************************/
+
     /**
      * @class xexpression
      * @brief Base class for xexpressions
@@ -139,6 +143,42 @@ namespace xt
 
     template <class E>
     using get_value_type = typename detail::get_value_type_impl<E>::type;
+    
+    /***************
+     * get_element *
+     ***************/
+
+    namespace detail
+    {
+        template <class E>
+        inline typename E::reference get_element(E& e)
+        {
+            return e();
+        }
+
+        template <class E, class S, class... Args>
+        inline typename E::reference get_element(E& e, S i, Args... args)
+        {
+            if(sizeof...(Args) >= e.dimension())
+                return get_element(e, args...);
+            return e(i, args...);
+        }
+
+        template <class E>
+        inline typename E::const_reference get_element(const E& e)
+        {
+            return e();
+        }
+
+        template <class E, class S, class... Args>
+        inline typename E::const_reference get_element(const E& e, S i, Args... args)
+        {
+            if(sizeof...(Args) >= e.dimension())
+                return get_element(e, args...);
+            return e(i, args...);
+        }
+    }
+
 }
 
 #endif

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -351,7 +351,6 @@ namespace xt
     {
         return access_impl(index, std::make_index_sequence<sizeof...(E)>());
     }
-
     //@}
     
     /**
@@ -361,7 +360,7 @@ namespace xt
     /**
      * Broadcast the shape of the function to the specified parameter.
      * @param shape the result shape
-     * @return a boolean indicating whether the broadcast is trivial
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class F, class R, class... E>
     template <class S>
@@ -373,9 +372,9 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see wether
-     * the broadcast is trivial.
-     * @return a boolean indicating whether the broadcast is trivial
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class F, class R, class... E>
     template <class S>
@@ -501,7 +500,7 @@ namespace xt
      * @name Storage iterators
      */
     /**
-     * Returns a constant iterator to the first element of the buffer
+     * Returns an iterator to the first element of the buffer
      * containing the elements of the function.
      */
     template <class F, class R, class... E>
@@ -522,6 +521,10 @@ namespace xt
         return build_storage_iterator(f, std::make_index_sequence<sizeof...(E)>());
     }
 
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
     template <class F, class R, class... E>
     inline auto xfunction<F, R, E...>::storage_cbegin() const noexcept -> const_storage_iterator
     {

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -114,7 +114,7 @@ namespace xt
         using closure_type = const self_type;
 
         using const_stepper = xfunction_stepper<F, R, E...>;
-        using const_iterator = xiterator<const_stepper>;
+        using const_iterator = xiterator<const_stepper, shape_type>;
         using const_storage_iterator = xf_storage_iterator<F, R, E...>;
 
         template <class Func>
@@ -139,10 +139,14 @@ namespace xt
         const_iterator cbegin() const noexcept;
         const_iterator cend() const noexcept;
 
-        const_iterator xbegin(const shape_type& shape) const noexcept;
-        const_iterator xend(const shape_type& shape) const noexcept;
-        const_iterator cxbegin(const shape_type& shape) const noexcept;
-        const_iterator cxend(const shape_type& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xend(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxend(const S& shape) const noexcept;
 
         template <class S>
         const_stepper stepper_begin(const S& shape) const noexcept;
@@ -281,23 +285,6 @@ namespace xt
     /****************************
      * xfunction implementation *
      ****************************/
-
-    namespace detail
-    {
-        template <class E>
-        inline typename E::const_reference get_element(const E& e)
-        {
-            return e();
-        }
-
-        template <class E, class S, class... Args>
-        inline typename E::const_reference get_element(const E& e, S i, Args... args)
-        {
-            if(sizeof...(Args) >= e.dimension())
-                return get_element(e, args...);
-            return e(i, args...);
-        }
-    }
 
     /**
      * @name Constructor
@@ -451,7 +438,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class F, class R, class... E>
-    inline auto xfunction<F, R, E...>::xbegin(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xfunction<F, R, E...>::xbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return const_iterator(stepper_begin(shape), shape);
     }
@@ -462,7 +450,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class F, class R, class... E>
-    inline auto xfunction<F, R, E...>::xend(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xfunction<F, R, E...>::xend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return const_iterator(stepper_end(shape), shape);
     }
@@ -473,7 +462,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class F, class R, class... E>
-    inline auto xfunction<F, R, E...>::cxbegin(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xfunction<F, R, E...>::cxbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return xbegin(shape);
     }
@@ -484,7 +474,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class F, class R, class... E>
-    inline auto xfunction<F, R, E...>::cxend(const shape_type& shape) const noexcept -> const_iterator
+    template <class S>
+    inline auto xfunction<F, R, E...>::cxend(const S& shape) const noexcept -> xiterator<const_stepper, S>
     {
         return xend(shape);
     }

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -51,7 +51,7 @@ namespace xt
         using const_stepper = xscalar_stepper<T>;
         using const_storage_iterator = xscalar_iterator<T>;
 
-        xscalar(const T& value) noexcept;
+        xscalar(T value) noexcept;
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
@@ -82,7 +82,7 @@ namespace xt
 
     private:
 
-        const T& m_value;
+        value_type m_value;
     };
 
     /*******************
@@ -175,8 +175,8 @@ namespace xt
      **************************/
 
     template <class T>
-    inline xscalar<T>::xscalar(const T& value) noexcept
-        : m_value(value)
+    inline xscalar<T>::xscalar(T value) noexcept
+        : m_value(std::move(value))
     {
     }
 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -392,7 +392,7 @@ namespace xt
     /**
      * Broadcast the shape of the view to the specified parameter.
      * @param shape the result shape
-     * @return a boolean indicating whether the broadcast is trivial
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class E, class... S>
     template <class ST>
@@ -402,9 +402,9 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the view to see wether
-     * the broadcast is trivial.
-     * @return a boolean indicating whether the broadcast is trivial
+     * Compares the specified strides with those of the view to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class E, class... S>
     template <class ST>

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -113,13 +113,19 @@ namespace xt
         const_iterator cbegin() const;
         const_iterator cend() const;
 
-        iterator xbegin(const shape_type& shape);
-        iterator xend(const shape_type& shape);
+        template <class ST>
+        xiterator<stepper, ST> xbegin(const ST& shape);
+        template <class ST>
+        xiterator<stepper, ST> xend(const ST& shape);
 
-        const_iterator xbegin(const shape_type& shape) const;
-        const_iterator xend(const shape_type& shape) const;
-        const_iterator cxbegin(const shape_type& shape) const;
-        const_iterator cxend(const shape_type& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> xbegin(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> xend(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> cxbegin(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> cxend(const ST& shape) const;
 
         template <class ST>
         stepper stepper_begin(const ST& shape);
@@ -561,7 +567,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::xbegin(const shape_type& shape) -> iterator
+    template <class ST>
+    inline auto xview<E, S...>::xbegin(const ST& shape) -> xiterator<stepper, ST>
     {
         return iterator(stepper_begin(shape), shape);
     }
@@ -572,7 +579,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::xend(const shape_type& shape) -> iterator
+    template <class ST>
+    inline auto xview<E, S...>::xend(const ST& shape) -> xiterator<stepper, ST>
     {
         return iterator(stepper_end(shape), shape);
     }
@@ -583,7 +591,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::xbegin(const shape_type& shape) const -> const_iterator
+    template <class ST>
+    inline auto xview<E, S...>::xbegin(const ST& shape) const -> xiterator<const_stepper, ST>
     {
         return const_iterator(stepper_begin(shape), shape);
     }
@@ -594,7 +603,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::xend(const shape_type& shape) const -> const_iterator
+    template <class ST>
+    inline auto xview<E, S...>::xend(const ST& shape) const -> xiterator<const_stepper, ST>
     {
         return const_iterator(stepper_end(shape), shape);
     }
@@ -605,7 +615,8 @@ namespace xt
      * @param shape the shape used for braodcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::cxbegin(const shape_type& shape) const -> const_iterator
+    template <class ST>
+    inline auto xview<E, S...>::cxbegin(const ST& shape) const -> xiterator<const_stepper, ST>
     {
         return xbegin(shape);
     }
@@ -616,7 +627,8 @@ namespace xt
      * @param shape the shape used for broadcasting
      */
     template <class E, class... S>
-    inline auto xview<E, S...>::cxend(const shape_type& shape) const -> const_iterator
+    template <class ST>
+    inline auto xview<E, S...>::cxend(const ST& shape) const -> xiterator<const_stepper, ST>
     {
         return xend(shape);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(XTENSOR_INCLUDE ../include)
 set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE}/xtensor/xarray.hpp
     ${XTENSOR_INCLUDE}/xtensor/xassign.hpp
+    ${XTENSOR_INCLUDE}/xtensor/xbroadcast.hpp
     ${XTENSOR_INCLUDE}/xtensor/xcontainer.hpp
     ${XTENSOR_INCLUDE}/xtensor/xexception.hpp
     ${XTENSOR_INCLUDE}/xtensor/xexpression.hpp
@@ -84,6 +85,8 @@ set(XTENSOR_TESTS
     test_xadaptor_semantic.cpp
     test_xarray.cpp
     test_xarray_adaptor.cpp
+    test_xbroadcast.cpp
+    test_xbuilder.cpp
     test_xcontainer_semantic.cpp
     test_xfunction.cpp
     test_xiterator.cpp

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -8,11 +8,24 @@
 
 #include "gtest/gtest.h"
 #include "xtensor/xbroadcast.hpp"
+#include "xtensor/xarray.hpp"
 
 namespace xt
 {
     TEST(xbroadcast, broadcast)
     {
+        xarray<double> m1
+          {{1, 2, 3},
+           {4, 5, 6}};
+
+        auto m1_broadcast = broadcast(m1, {1, 2, 3});
+        ASSERT_EQ(1.0, m1_broadcast(0, 0, 0));
+        ASSERT_EQ(4.0, m1_broadcast(0, 1, 0));
+        ASSERT_EQ(5.0, m1_broadcast(0, 1, 1));
+
+        double f = *(m1_broadcast.begin());
+        xarray<double> m1_assigned = m1_broadcast;
+        ASSERT_EQ(5.0, m1_assigned(0, 1, 1));
     }
 }
 

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -1,0 +1,18 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xbroadcast.hpp"
+
+namespace xt
+{
+    TEST(xbroadcast, broadcast)
+    {
+    }
+}
+

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -1,0 +1,24 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xarray.hpp"
+
+namespace xt
+{
+    using std::size_t;
+
+    TEST(xbuilder, ones)
+    {
+        std::vector<size_t> shape = {1, 2};
+        auto lazy_ones = ones<double>(shape);
+        xarray<double> assigned_ones = lazy_ones;
+        ASSERT_EQ(2, lazy_ones.dimension());
+    }
+}

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -20,5 +20,6 @@ namespace xt
         auto lazy_ones = ones<double>(shape);
         xarray<double> assigned_ones = lazy_ones;
         ASSERT_EQ(2, lazy_ones.dimension());
+        ASSERT_EQ(1, lazy_ones(0, 1));
     }
 }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -22,7 +22,10 @@ namespace xt
         ASSERT_EQ(2, lazy_ones.dimension());
         ASSERT_EQ(1, lazy_ones(0, 1));
 
-        xarray<double> m {{ 1, 2, 3}, {4, 5, 6}};
-        auto b = broadcast(m, std::array<size_t, 3>{1, 2, 3});
+        xarray<double> m1 {{ 1, 2, 3}, {4, 5, 6}};
+        auto b = broadcast(m1, std::array<size_t, 3>{1, 2, 3});
+
+        xarray<double> m2 {{ 1, 2, 3}, {4, 5, 6}};
+        auto b2 = broadcast(m2, {1, 2, 3});
     }
 }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -16,16 +16,10 @@ namespace xt
 
     TEST(xbuilder, ones)
     {
-        std::vector<size_t> shape = {1, 2};
-        auto lazy_ones = ones<double>(shape);
-        xarray<double> assigned_ones = lazy_ones;
-        ASSERT_EQ(2, lazy_ones.dimension());
-        ASSERT_EQ(1, lazy_ones(0, 1));
-
-        xarray<double> m1 {{ 1, 2, 3}, {4, 5, 6}};
-        auto b = broadcast(m1, std::array<size_t, 3>{1, 2, 3});
-
-        xarray<double> m2 {{ 1, 2, 3}, {4, 5, 6}};
-        auto b2 = broadcast(m2, {1, 2, 3});
+        auto m = ones<double>({1, 2});
+        ASSERT_EQ(2, m.dimension());
+        ASSERT_EQ(1.0, m(0, 1));
+        xarray<double> m_assigned = m;
+        ASSERT_EQ(1.0, m_assigned(0, 1));
     }
 }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -21,5 +21,8 @@ namespace xt
         xarray<double> assigned_ones = lazy_ones;
         ASSERT_EQ(2, lazy_ones.dimension());
         ASSERT_EQ(1, lazy_ones(0, 1));
+
+        xarray<double> m {{ 1, 2, 3}, {4, 5, 6}};
+        auto b = broadcast(m, std::array<size_t, 3>{1, 2, 3});
     }
 }

--- a/test/test_xiterator.cpp
+++ b/test/test_xiterator.cpp
@@ -193,5 +193,12 @@ namespace xt
         }
     }
 
+    TEST(xiterator, broadcast)
+    {
+        EXPECT_TRUE(broadcastable(std::vector<size_t>({3, 2, 1}), std::vector<size_t>({1, 2, 1})));
+        EXPECT_TRUE(broadcastable(std::vector<size_t>({3, 2, 1}), std::vector<size_t>({1, 1})));
+        EXPECT_TRUE(broadcastable(std::vector<size_t>({1, 1}), std::vector<size_t>({2, 2, 1})));
+        EXPECT_FALSE(broadcastable(std::vector<size_t>({3, 2, 1}), std::vector<size_t>({2, 2, 1})));
+    }
 }
 


### PR DESCRIPTION
Adding more details here for the record now that we have new contributors (ping @wolfv )

1. On shape types

    - The `shape_type` of `xarray` has a runtime-determined length and is heap-allocated. Currently it is `std::vector`.

      The `shape_type` of `xtensor` has compile-time determined length and is stack-allocated. Currently it is `std::array`. This makes xtensor slightly more efficient than xarray.

   - Hence, for efficiency reasons, anytime the dimension can be known at compile time, the shape type is actually std::array. We do this for `xfunction`, `xscalar`, and now `xbroadcast` using the *`promote_shape` mechanism*:

        The promoted shape type of `n` shapes of type std::array is std::array. As soon as there is anything else than an std::array, we promote it to `std::vector`. Here, in `broadcast(expr, shape)`, the shape_type of the resulting `xbroadcast` expression is the promoted shape of `expr:shape_type` and the type of `shape`.

        This allows an expression involving multiple operations only involving statically known dimensions to have a stack-allocated shape, by bubbling up the `shape_type` with the promote_shape mechanism...

2. On `xbegin` and `xend`

    - This PR, in addition to adding the `xbroadcast` expression fixes a bug in the current mechanism of `xbegin` and `xend` and const counterparts to these methods:

        So `xbegin` and `xend` provide iterator pairs that broadcast on the specified shape. However, it became crucial to be able to broadcast of a `std::vector` shape even when the underlying expression's shape_type is `std::array`. Hence, we needed to make these template methods. The returned iterator type also depend on the broadcasting shape type, and is also template. *This type will coincide with the expression's `iterator` internal type if the passed shaped has the internal `shape_type`...*

3. `xbroadcast`

    `xbroadcast<E, S>` is the expression type returned by the `broadcast` function, which is a lazy form of [numpy.broadcast](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast.html)

    The `broadcast` function make use of a `forward_shape<R, A>` template function where R stands for the return type and A the argument type. If A is equal to R, the function is identity (on const references). If R is a vector and A is an array, a new vector is built and A is copied into R.

4. Regarding the array builders

    `ones<double>()` returns a xbroadcast on a single xscalar wrapper which can be assigned to an array or a tensor.