### PR TITLE
Make broadcast more efficient in case of initializer lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,15 @@ matrix:
           packages:
             - clang-3.7
       env: COMPILER=clang CLANG=3.7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+      env: COMPILER=clang CLANG=3.8
     - os: osx
       osx_image: xcode8
       compiler: clang

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -10,7 +10,6 @@
 #define XBROADCAST_HPP
 
 #include <utility>
-#include <initializer_list>
 #include <vector>
 #include <algorithm>
 
@@ -28,8 +27,8 @@ namespace xt
     template <class E, class S>
     auto broadcast(E&& e, const S& s);
 
-    template <class E>
-    auto broadcast(E&& e, std::initializer_list<std::size_t> s);
+    template <class E, class I, std::size_t L>
+    auto broadcast(E&& e, const I(&s)[L]);
 
     /**************
      * xbroadcast *
@@ -128,18 +127,9 @@ namespace xt
         {
             static inline R run(const A& r)
             {
-                return R(r.cbegin(), r.cend());
+                return R(std::begin(r), std::end(r));
             }
         };
-
-        template <class R, class T>
-        struct shape_forwarder<R, std::initializer_list<T>>
-        {
-            static inline R run(std::initializer_list<T> s)
-            {
-                return R(s);
-            }
-        };        
 
         template <class R>
         struct shape_forwarder<R, R>
@@ -177,11 +167,10 @@ namespace xt
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
 
-    template <class E>
-    inline auto broadcast(E&& e, std::initializer_list<std::size_t> s)
+    template <class E, class I, std::size_t L>
+    inline auto broadcast(E&& e, const I(&s)[L])
     {
-        // TODO: In the case of an initializer_list, use an array instead of a vector.
-        using broadcast_type = xbroadcast<get_xexpression_type<E>, std::vector<std::size_t>, false>;
+        using broadcast_type = xbroadcast<get_xexpression_type<E>, std::array<std::size_t, L>, false>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }


### PR DESCRIPTION
Notes on this change:

 - `std::cbegin` is missing in `gcc 4.9`, so using `std::begin`
 - This triggers the clang bug which we have discussed.
 - I added clang 3.8 to the test suite to show that this work with clang 3.8 onward.

![matrix](https://cloud.githubusercontent.com/assets/2397974/21286449/4c220a86-c454-11e6-9324-6ffd02745eff.png)