### PR TITLE
Enable xiterator to be initialized with a pointer-type shape

### DIFF
--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -125,6 +125,7 @@ namespace xt
         using shape_type = S;
 
         xiterator(It it, const shape_type& shape);
+        xiterator(It it, const size_type* shape, size_type dimension);
 
         self_type& operator++();
         self_type operator++(int);
@@ -286,6 +287,13 @@ namespace xt
     inline xiterator<It, S>::xiterator(It it, const shape_type& shape)
         : m_it(it), m_shape(shape),
           m_index(make_shape<shape_type>(shape.size(), size_type(0)))
+    {
+    }
+
+    template <class It, class S>
+    inline xiterator<It, S>::xiterator(It it, const size_type* shape, size_type dimension)
+        : m_it(it), m_shape(shape, shape + dimension),
+          m_index(make_shape<shape_type>(dimension, size_type(0)))
     {
     }
 


### PR DESCRIPTION
This is for more efficient iterator pairs in `xtensor-python`.

Still not great since we are copying things in the stored shape of the xiterator.