### PR TITLE
`promote_shape` on xview

### DIFF
--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -76,7 +76,6 @@ namespace xt
         using difference_type = typename E::difference_type;
         
         using shape_type = promote_shape_t<typename E::shape_type, X>;
-        using strides_type = promote_strides_t<typename E::strides_type, X>;
         using closure_type = const self_type;
 
         using const_stepper = typename E::const_stepper;

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -110,7 +110,6 @@ namespace xt
         using difference_type = detail::common_difference_type<E...>;
 
         using shape_type = promote_shape_t<typename E::shape_type...>;
-        using strides_type = promote_strides_t<typename E::strides_type...>;
         using closure_type = const self_type;
 
         using const_stepper = xfunction_stepper<F, R, E...>;

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -45,7 +45,6 @@ namespace xt
 
         using self_type = xscalar<T>;
         using shape_type = std::array<size_type, 0>;
-        using strides_type = std::array<size_type, 0>;
 
         using closure_type = const self_type;
         using const_stepper = xscalar_stepper<T>;
@@ -57,8 +56,6 @@ namespace xt
         size_type dimension() const noexcept;
 
         shape_type shape() const noexcept;
-        strides_type strides() const noexcept;
-        strides_type backstrides() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const noexcept;
@@ -197,18 +194,6 @@ namespace xt
 
     template <class T>
     inline auto xscalar<T>::shape() const noexcept -> shape_type
-    {
-        return {};
-    }
-
-    template <class T>
-    inline auto xscalar<T>::strides() const noexcept -> strides_type
-    {
-        return {};
-    }
-
-    template <class T>
-    inline auto xscalar<T>::backstrides() const noexcept -> strides_type
     {
         return {};
     }


### PR DESCRIPTION
 - removed strides_type and related methods in expressions where they don't make sense.
 - use underlying expression's `shape_type` in `xview`