### PR TITLE
WIP: separate `index_type` from `shape_type` in xassign and xiterator

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -53,6 +53,7 @@ namespace xt
         using lhs_iterator = typename E1::stepper;
         using rhs_iterator = typename E2::const_stepper;
         using shape_type = typename E1::shape_type;
+        using index_type = get_index_type<shape_type>;
         using size_type = typename lhs_iterator::size_type;
 
         data_assigner(E1& e1, const E2 & e2);
@@ -72,7 +73,7 @@ namespace xt
         rhs_iterator m_rhs;
         rhs_iterator m_rhs_end;
 
-        shape_type m_index;
+        index_type m_index;
     };
 
     /***********************************
@@ -173,7 +174,7 @@ namespace xt
     inline data_assigner<E1, E2>::data_assigner(E1& e1, const E2& e2)
         : m_e1(e1), m_lhs(e1.stepper_begin(e1.shape())),
           m_rhs(e2.stepper_begin(e1.shape())), m_rhs_end(e2.stepper_end(e1.shape())),
-          m_index(make_sequence<typename E1::shape_type>(e1.shape().size(), size_type(0)))
+          m_index(make_sequence<index_type>(e1.shape().size(), size_type(0)))
     {
     }
 

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -48,7 +48,25 @@ namespace xt
 
     template <class C>
     using get_storage_iterator = typename detail::get_storage_iterator_impl<C>::type;
+ 
+    namespace detail
+    {
+        template <class ST>
+        struct index_type_impl
+        {
+            using type = std::vector<typename ST::value_type>;
+        };
 
+        template <class V, std::size_t L>
+        struct index_type_impl<std::array<V, L>>
+        {
+            using type = std::array<V, L>;
+        };
+    }
+
+    template <class C>
+    using get_index_type = typename detail::index_type_impl<C>::type;
+ 
     template <class C>
     class xstepper
     {
@@ -92,9 +110,9 @@ namespace xt
     bool operator!=(const xstepper<C>& lhs,
                     const xstepper<C>& rhs);
 
-    template <class S, class ST>
+    template <class S, class IT, class ST>
     void increment_stepper(S& stepper,
-                           ST& index,
+                           IT& index,
                            const ST& shape);
 
     /*************
@@ -118,6 +136,7 @@ namespace xt
         using iterator_category = std::forward_iterator_tag;
 
         using shape_type = S;
+        using index_type = get_index_type<shape_type>;
 
         xiterator(It it, const shape_type& shape);
 
@@ -132,7 +151,7 @@ namespace xt
 
         subiterator_type m_it;
         shape_type m_shape;
-        shape_type m_index;
+        index_type m_index;
     };
 
     template <class It, class S>
@@ -246,9 +265,9 @@ namespace xt
         return !(lhs.equal(rhs));
     }
 
-    template <class S, class ST>
+    template <class S, class IT, class ST>
     void increment_stepper(S& stepper,
-                           ST& index,
+                           IT& index,
                            const ST& shape)
     {
         using size_type = typename S::size_type;
@@ -280,7 +299,7 @@ namespace xt
     template <class It, class S>
     inline xiterator<It, S>::xiterator(It it, const shape_type& shape)
         : m_it(it), m_shape(shape),
-          m_index(make_sequence<shape_type>(shape.size(), size_type(0)))
+          m_index(make_sequence<index_type>(shape.size(), size_type(0)))
     {
     }
 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -18,6 +18,7 @@
 
 #include "xarray.hpp"
 #include "xslice.hpp"
+#include "xiterator.hpp"
 
 namespace xt
 {
@@ -185,6 +186,8 @@ namespace xt
         disable_xslice<T, size_type> sliced_access(const T& squeeze, Args...) const;
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = get_index_type<shape_type>;
+
         void assign_temporary_impl(temporary_type& tmp);
 
         friend class xview_semantic<xview<E, S...>>;
@@ -412,7 +415,7 @@ namespace xt
     template <class It>
     inline auto xview<E, S...>::element(It first, It last) -> reference
     {
-        auto index = make_sequence<typename E::shape_type>(m_e.dimension(), 0);
+        auto index = make_sequence<base_index_type>(m_e.dimension(), 0);
         auto func1 = [&first](const auto& s)
         {
             return get_slice_value(s, first);


### PR DESCRIPTION
There is one outstanding instance `make_sequence` that should be converted in xview (for the index of the underlying expression for `operator[]`). Although it should probably not be called `index_type`.