### PR TITLE
xgenerator

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -14,6 +14,7 @@
 #define XBUILDER_HPP
 
 #include <utility>
+#include <cmath>
 
 #include "xfunction.hpp"
 #include "xbroadcast.hpp"
@@ -152,7 +153,7 @@ namespace xt
     template <class T>
     inline auto arange(T start, T stop, T step = 1) noexcept
     {
-        std::size_t shape = (stop - start) / step;
+        std::size_t shape = static_cast<std::size_t>(std::ceil((stop - start) / step));
         return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {shape});
     }
 

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -123,13 +123,13 @@ namespace xt
 
             inline T operator[](const xindex& idx) const
             {
-                return m_start + m_step * idx[0];
+                return T(m_start + m_step * idx[0]);
             }
 
             template <class It>
             inline T element(It first, It /*last*/) const
             {
-                return m_start + m_step * (*first);
+                return T(m_start + m_step * (*first));
             }
 
         private:
@@ -150,6 +150,18 @@ namespace xt
         };
     }
 
+    /**
+     * @function arange(T start, T stop, T step = 1)
+     * @brief generate numbers evenly spaced within given half-open interval [start, stop).
+     *
+     * @param start start of the interval
+     * @param stop stop of the interval
+     * @param step stepsize
+     *
+     * @tparam T value_type of xexpression
+     *
+     * @return xgenerator that generates the values on access
+     */
     template <class T>
     inline auto arange(T start, T stop, T step = 1) noexcept
     {
@@ -157,12 +169,36 @@ namespace xt
         return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {shape});
     }
 
+    /**
+     * @function arange(T stop)
+     * @brief generate numbers evenly spaced within given half-open interval [0, stop)
+     *        with a step size of 1.
+     *
+     * @param stop stop of the interval
+     *
+     * @tparam T value_type of xexpression
+     *
+     * @return xgenerator that generates the values on access
+     */
     template <class T>
     inline auto arange(T stop) noexcept
     {
         return arange<T>(T(0), stop, T(1));
     }
 
+    /**
+     * @function linspace
+     * @brief generate @a num_samples evenly spaced numbers over given interval
+     *
+     * @param start start of interval
+     * @param stop stop of interval
+     * @param num_samples number of samples (defaults to 50)
+     * @param endpoint if true, include endpoint (defaults to true)
+     *
+     * @tparam T value_type of xexpression
+     *
+     * @return xgenerator that generates the values on access
+     */
     template <class T>
     inline auto linspace(T start, T stop, std::size_t num_samples = 50, bool endpoint = true) noexcept
     {
@@ -170,6 +206,20 @@ namespace xt
         return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {num_samples});
     }
 
+    /**
+     * @function logspace
+     * @brief generate @num_samples numbers evenly spaced on a log scale over given interval
+     *
+     * @param start start of interval (pow(base, start) is the first value).
+     * @param stop stop of interval (pow(base, stop) is the final value, except if endpoint = false)
+     * @param num_samples number of samples (defaults to 50)
+     * @param base the base of the log space.
+     * @param endpoint if true, include endpoint (defaults to true)
+     *
+     * @tparam T value_type of xexpression
+     *
+     * @return xgenerator that generates the values on access
+     */
     template <class T>
     inline auto logspace(T start, T stop, std::size_t num_samples, T base = 10, bool endpoint = true) noexcept
     {

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -17,6 +17,7 @@
 
 #include "xfunction.hpp"
 #include "xbroadcast.hpp"
+#include "xgenerator.hpp"
 
 #ifdef X_OLD_CLANG
     #include <initializer_list>
@@ -86,6 +87,93 @@ namespace xt
     }
 #endif
 
+    namespace detail
+    {
+
+        template <class Functor, class I>
+        inline auto make_xgenerator(Functor&& f, std::initializer_list<I> shape) noexcept
+        {
+            using type = xgenerator<Functor, typename Functor::value_type>;
+            return type(std::forward<Functor>(f), std::vector<std::size_t>(shape));
+        }
+        
+        template <class Functor, class S>
+        inline auto make_xgenerator(Functor&& f, const S& shape) noexcept
+        {
+            using type = xgenerator<Functor, typename Functor::value_type>;
+            return type(std::forward<Functor>(f), shape);
+        }
+
+        template <class T>
+        struct arange_impl
+        {
+            using value_type = T;
+
+            arange_impl(T start, T stop, T step) :
+                m_start(start), m_stop(stop), m_step(step)
+            {
+            }
+
+            template <class... Args>
+            inline T operator()(Args... args) const
+            {
+                return access_impl(args...);
+            }
+
+            inline T operator[](const xindex& idx) const
+            {
+                return m_start + m_step * idx[0];
+            }
+
+            template <class It>
+            inline T element(It first, It /*last*/) const
+            {
+                return m_start + m_step * (*first);
+            }
+
+        private:
+            value_type m_start;
+            value_type m_stop;
+            value_type m_step;
+
+            template <class T1, class... Args>
+            inline T access_impl(T1 t, Args... /*args*/) const
+            {
+                return m_start + m_step * t;
+            }
+
+            inline T access_impl() const
+            {
+                return m_start;
+            }
+        };
+    }
+
+    template <class T>
+    inline auto arange(T start, T stop, T step = 1) noexcept
+    {
+        std::size_t shape = (stop - start) / step;
+        return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {shape});
+    }
+
+    template <class T>
+    inline auto arange(T stop) noexcept
+    {
+        return arange<T>(T(0), stop, T(1));
+    }
+
+    template <class T>
+    inline auto linspace(T start, T stop, std::size_t num_samples = 50, bool endpoint = true) noexcept
+    {
+        T step = (stop - start) / T(num_samples - (endpoint ? 1 : 0));
+        return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {num_samples});
+    }
+
+    template <class T>
+    inline auto logspace(T start, T stop, std::size_t num_samples, T base = 10, bool endpoint = true) noexcept
+    {
+        return pow(base, linspace(start, stop, num_samples, endpoint));
+    }
+
 }
 #endif
-

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -93,14 +93,14 @@ namespace xt
         template <class Functor, class I>
         inline auto make_xgenerator(Functor&& f, std::initializer_list<I> shape) noexcept
         {
-            using type = xgenerator<Functor, typename Functor::value_type>;
+            using type = xgenerator<Functor, typename Functor::value_type, std::vector<std::size_t>>;
             return type(std::forward<Functor>(f), std::vector<std::size_t>(shape));
         }
         
         template <class Functor, class S>
         inline auto make_xgenerator(Functor&& f, const S& shape) noexcept
         {
-            using type = xgenerator<Functor, typename Functor::value_type>;
+            using type = xgenerator<Functor, typename Functor::value_type, std::vector<std::size_t>>;
             return type(std::forward<Functor>(f), shape);
         }
 

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -1,0 +1,494 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef xgenerator_HPP
+#define xgenerator_HPP
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <tuple>
+#include <algorithm>
+
+#include "xexpression.hpp"
+#include "xiterator.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    template <class F, class R>
+    class xgenerator_stepper;
+
+    /**************
+     * xgenerator *
+     **************/
+
+    /**
+     * @class xgenerator
+     * @brief Multidimensional function operating on indices.
+     *
+     * Th xgenerator class implements a multidimensional function
+     * operating on the supplied indices.
+     *
+     * @tparam F the function type
+     * @tparam R the return type of the function
+     */
+    template <class F, class R>
+    class xgenerator : public xexpression<xgenerator<F, R>>
+    {
+
+    public:
+
+        using self_type = xgenerator<F, R>;
+        using functor_type = typename std::remove_reference<F>::type;
+
+        using value_type = R;
+        using reference = value_type;
+        using const_reference = value_type;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+
+        using shape_type = std::vector<size_type>;
+        using strides_type = std::vector<size_type>;
+        using closure_type = const self_type;
+
+        using const_stepper = xgenerator_stepper<F, R>;
+        using const_iterator = xiterator<const_stepper, shape_type>;
+        using const_storage_iterator = const_iterator;
+
+        template <class Func, class S>
+        xgenerator(Func&& f, const S& shape) noexcept;
+
+        size_type dimension() const noexcept;
+        shape_type shape() const;
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+        const_reference operator[](const xindex& index) const;
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        template <class S>
+        bool broadcast_shape(S& shape) const;
+
+        template <class S>
+        bool is_trivial_broadcast(const S& /*strides*/) const noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        template <class S>
+        xiterator<const_stepper, S> xbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> xend(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxbegin(const S& shape) const noexcept;
+        template <class S>
+        xiterator<const_stepper, S> cxend(const S& shape) const noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+
+        template <class S>
+        const_stepper stepper_end(const S& shape) const noexcept;
+
+        const_storage_iterator storage_begin() const noexcept;
+        const_storage_iterator storage_end() const noexcept;
+
+        const_storage_iterator storage_cbegin() const noexcept;
+        const_storage_iterator storage_cend() const noexcept;
+
+    private:
+
+        template <class Func, std::size_t... I>
+        const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
+
+        functor_type m_f;
+        shape_type m_shape;
+        friend class xgenerator_stepper<F, R>;
+    };
+
+    /***************************
+     * xgenerator_stepper *
+     ***************************/
+
+    template <class F, class R>
+    class xgenerator_stepper
+    {
+
+    public:
+
+        using self_type = xgenerator_stepper<F, R>;
+        using functor_type = typename std::remove_reference<F>::type;
+        using xfunction_type = xgenerator<F, R>;
+
+        using value_type = typename xfunction_type::value_type;
+        using reference = typename xfunction_type::value_type;
+        using pointer = typename xfunction_type::const_pointer;
+        using size_type = typename xfunction_type::size_type;
+        using difference_type = typename xfunction_type::difference_type;
+        using iterator_category = std::input_iterator_tag;
+
+        using shape_type = typename xfunction_type::shape_type;
+
+        xgenerator_stepper(const xfunction_type* func, const shape_type& shape) noexcept;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+
+        void to_end();
+
+        reference operator*() const;
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+        const xfunction_type* p_f;
+        shape_type m_shape;
+        shape_type m_index;
+    };
+
+    template <class F, class R>
+    bool operator==(const xgenerator_stepper<F, R>& it1,
+                    const xgenerator_stepper<F, R>& it2);
+
+    template <class F, class R>
+    bool operator!=(const xgenerator_stepper<F, R>& it1,
+                    const xgenerator_stepper<F, R>& it2);
+
+    /**********************************
+     * xgenerator implementation *
+     **********************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xgenerator applying the specified function to the given
+     * arguments.
+     * @param f the function to apply
+     * @param e the \ref xexpression arguments
+     */
+    template <class F, class R>
+    template <class Func, class S>
+    inline xgenerator<F, R>::xgenerator(Func&& f, const S& shape) noexcept
+        : m_f(std::forward<Func>(f)), m_shape(shape)
+    {
+    }
+    //@}
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the number of dimensions of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the xgenerator.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::shape() const -> shape_type
+    {
+        return m_shape;
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    /**
+     * Returns the evaluated element at the specified position in the function.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the function.
+     */
+    template <class F, class R>
+    template <class... Args>
+    inline auto xgenerator<F, R>::operator()(Args... args) const -> const_reference
+    {
+        return m_f(args...);
+    }
+
+    template <class F, class R>
+    inline auto xgenerator<F, R>::operator[](const xindex& index) const -> const_reference
+    {
+        return m_f[index];
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the function.
+     * @param first iterator starting the sequence of indices
+     * @param second iterator starting the sequence of indices
+     * The number of indices in the squence should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class F, class R>
+    template <class It>
+    inline auto xgenerator<F, R>::element(It first, It last) const -> const_reference
+    {
+        return m_f.element(first, last);
+    }
+    //@}
+    
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R>
+    template <class S>
+    inline bool xgenerator<F, R>::broadcast_shape(S& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class F, class R>
+    template <class S>
+    inline bool xgenerator<F, R>::is_trivial_broadcast(const S& /*strides*/) const noexcept
+    {
+        return false;
+    }
+    //@}
+
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::begin() const noexcept -> const_iterator
+    {
+        return xbegin(m_shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::end() const noexcept -> const_iterator
+    {
+        return xend(m_shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::cbegin() const noexcept -> const_iterator
+    {
+        return begin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::cend() const noexcept -> const_iterator
+    {
+        return end();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the function. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for braodcasting
+     */
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::xbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        return xiterator<const_stepper, S>(stepper_begin(shape), shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * function. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     */
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::xend(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        return xiterator<const_stepper, S>(stepper_end(shape), shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the function. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for braodcasting
+     */
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::cxbegin(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        return xbegin(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * function. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     */
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::cxend(const S& shape) const noexcept -> xiterator<const_stepper, S>
+    {
+        return xend(shape);
+    }
+    //@}
+
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        return xgenerator_stepper<F, R>(this, shape);
+    }
+
+    template <class F, class R>
+    template <class S>
+    inline auto xgenerator<F, R>::stepper_end(const S& shape) const noexcept -> const_stepper
+    {
+        auto stepper = xgenerator_stepper<F, R>(this, shape);
+        stepper.to_end();
+        return stepper;
+    }
+
+    /**
+     * @name Storage iterators
+     */
+    /**
+     * Returns an iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::storage_begin() const noexcept -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::storage_end() const noexcept -> const_storage_iterator
+    {
+        return cend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::storage_cbegin() const noexcept -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R>
+    inline auto xgenerator<F, R>::storage_cend() const noexcept -> const_storage_iterator
+    {
+        return cend();
+    }
+    //@}
+
+    /******************************************
+     * xgenerator_stepper implementation *
+     ******************************************/
+
+    template <class F, class R>
+    inline xgenerator_stepper<F, R>::xgenerator_stepper(const xfunction_type* func, const shape_type& shape) noexcept
+        : p_f(func), m_shape(shape), m_index(make_sequence<shape_type>(shape.size(), size_type(0)))
+    {
+    }
+
+    template <class F, class R>
+    inline void xgenerator_stepper<F, R>::step(size_type dim, size_type n)
+    {
+        m_index[dim] += n;
+    }
+
+    template <class F, class R>
+    inline void xgenerator_stepper<F, R>::step_back(size_type dim, size_type n)
+    {
+        m_index[dim] -= 1;
+    }
+
+    template <class F, class R>
+    inline void xgenerator_stepper<F, R>::reset(size_type dim)
+    {
+        m_index[dim] = 0;
+    }
+
+    template <class F, class R>
+    inline void xgenerator_stepper<F, R>::to_end()
+    {
+        m_index = m_shape;
+    }
+
+    template <class F, class R>
+    inline bool xgenerator_stepper<F, R>::equal(const self_type& rhs) const
+    {
+        return p_f == rhs.p_f && std::equal(m_index.begin(), m_index.end(), rhs.m_index.begin());
+    }
+
+    template <class F, class R>
+    inline auto xgenerator_stepper<F, R>::operator*() const -> reference
+    {
+        return (*p_f)[m_index];
+    }
+
+    template <class F, class R>
+    inline bool operator==(const xgenerator_stepper<F, R>& it1,
+                           const xgenerator_stepper<F, R>& it2)
+    {
+        return it1.equal(it2);
+    }
+
+    template <class F, class R>
+    inline bool operator!=(const xgenerator_stepper<F, R>& it1,
+                           const xgenerator_stepper<F, R>& it2)
+    {
+        return !(it1.equal(it2));
+    }
+}
+
+#endif

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -44,14 +44,14 @@ namespace xt
 
     TEST(xbuilder, arange_min_max)
     {
-        auto ls = arange<uint>(10, 20);
+        auto ls = arange<unsigned int>(10u, 20u);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {10};
         ASSERT_EQ(ls.shape(), expected_shape);
         ASSERT_EQ(ls[{0}], 10);
         ASSERT_EQ(ls(9), 19);
         ASSERT_EQ(ls(2), 12);
-        xarray<uint> m_assigned = ls;
+        xarray<unsigned int> m_assigned = ls;
         ASSERT_EQ(m_assigned.dimension(), 1);
         ASSERT_EQ(m_assigned.shape()[0], 10);
         ASSERT_EQ(m_assigned[{0}], 10);
@@ -61,21 +61,21 @@ namespace xt
 
     TEST(xbuilder, arange_min_max_step)
     {
-        auto ls = arange<float>(10, 20, 0.5);
+        auto ls = arange<float>(10, 20, 0.5f);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {20};
         ASSERT_EQ(ls.shape(), expected_shape);
         ASSERT_EQ(ls[{0}], 10);
         ASSERT_EQ(ls(10), 15);
-        ASSERT_EQ(ls(3), 11.5);
+        ASSERT_EQ(ls(3), 11.5f);
         xarray<float> m_assigned = ls;
         ASSERT_EQ(m_assigned.dimension(), 1);
         ASSERT_EQ(m_assigned.shape()[0], 20);
         ASSERT_EQ(m_assigned[{0}], 10);
         ASSERT_EQ(m_assigned(10), 15);
-        ASSERT_EQ(m_assigned(3), 11.5);
+        ASSERT_EQ(m_assigned(3), 11.5f);
 
-        auto l3 = arange<float>(0, 1, 0.3);
+        auto l3 = arange<float>(0, 1, 0.3f);
         shape_t expected_shape_2 = {4};
         ASSERT_EQ(l3.shape(), expected_shape_2);
         ASSERT_EQ(l3[{0}], 0);
@@ -84,12 +84,12 @@ namespace xt
 
     TEST(xbuilder, linspace)
     {
-        auto ls = linspace<float>(20, 50);
+        auto ls = linspace<float>(20.f, 50.f);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {50};
         ASSERT_EQ(ls.shape(), expected_shape);
-        ASSERT_EQ(ls[{0}], 20);
-        ASSERT_EQ(ls(49), 50);
+        ASSERT_EQ(ls[{0}], 20.f);
+        ASSERT_EQ(ls(49), 50.f);
 
         float at_3 = 20 + 3 * (50.f - 20.f) / (50.f - 1.f);
         ASSERT_EQ(ls(3), at_3);
@@ -104,16 +104,16 @@ namespace xt
 
     TEST(xbuilder, linspace_n_samples_endpoint)
     {
-        auto ls = linspace<float>(20, 50, 100, false);
+        auto ls = linspace<float>(20.f, 50.f, 100.f, false);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {100};
         ASSERT_EQ(ls.shape(), expected_shape);
-        ASSERT_EQ(ls[{0}], 20);
+        ASSERT_EQ(ls[{0}], 20.f);
 
-        float at_end = 49.7;
+        float at_end = 49.7f;
         ASSERT_EQ(ls(99), at_end);
 
-        float at_3 = 20.9;
+        float at_3 = 20.9f;
         ASSERT_EQ(ls(3), at_3);
 
         xarray<float> m_assigned = ls;
@@ -126,7 +126,7 @@ namespace xt
 
     TEST(xbuilder, logspace)
     {
-        auto ls = logspace<double>(2, 3, 4);
+        auto ls = logspace<double>(2., 3., 4.);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {4};
         ASSERT_EQ(ls.shape(), expected_shape);

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -126,7 +126,7 @@ namespace xt
         ASSERT_EQ(ls.shape(), expected_shape);
         ASSERT_EQ(ls[{0}], 100);
 
-        double at_1 = std::pow<double>(10.0, (2.0 + 1.0/3.0));
+        double at_1 = std::pow(10.0, (2.0 + 1.0/3.0));
         ASSERT_EQ(ls(1), at_1);
 
         ASSERT_EQ(ls(3), 1000);

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -104,7 +104,7 @@ namespace xt
 
     TEST(xbuilder, linspace_n_samples_endpoint)
     {
-        auto ls = linspace<float>(20.f, 50.f, 100.f, false);
+        auto ls = linspace<float>(20.f, 50.f, 100, false);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {100};
         ASSERT_EQ(ls.shape(), expected_shape);
@@ -126,7 +126,7 @@ namespace xt
 
     TEST(xbuilder, logspace)
     {
-        auto ls = logspace<double>(2., 3., 4.);
+        auto ls = logspace<double>(2., 3., 4);
         ASSERT_EQ(ls.dimension(), 1);
         shape_t expected_shape = {4};
         ASSERT_EQ(ls.shape(), expected_shape);

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -13,6 +13,7 @@
 namespace xt
 {
     using std::size_t;
+    using shape_t = std::vector<std::size_t>;
 
     TEST(xbuilder, ones)
     {
@@ -22,4 +23,119 @@ namespace xt
         xarray<double> m_assigned = m;
         ASSERT_EQ(1.0, m_assigned(0, 1));
     }
+
+    TEST(xbuilder, arange_simple)
+    {
+        auto ls = arange<double>(50);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {50};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 0);
+        auto ls_49 = ls(49);
+        ASSERT_EQ(49, ls_49);
+        ASSERT_EQ(ls(29), 29);
+        xarray<double> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 50);
+        ASSERT_EQ(m_assigned[{0}], 0);
+        ASSERT_EQ(m_assigned[{49}], 49);
+        ASSERT_EQ(m_assigned[{29}], 29);
+    }
+
+    TEST(xbuilder, arange_min_max)
+    {
+        auto ls = arange<uint>(10, 20);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {10};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 10);
+        ASSERT_EQ(ls(9), 19);
+        ASSERT_EQ(ls(2), 12);
+        xarray<uint> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 10);
+        ASSERT_EQ(m_assigned[{0}], 10);
+        ASSERT_EQ(m_assigned[{9}], 19);
+        ASSERT_EQ(m_assigned[{2}], 12);
+    }
+
+    TEST(xbuilder, arange_min_max_step)
+    {
+        auto ls = arange<float>(10, 20, 0.5);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {20};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 10);
+        ASSERT_EQ(ls(10), 15);
+        ASSERT_EQ(ls(3), 11.5);
+        xarray<float> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 20);
+        ASSERT_EQ(m_assigned[{0}], 10);
+        ASSERT_EQ(m_assigned(10), 15);
+        ASSERT_EQ(m_assigned(3), 11.5);
+    }
+
+    TEST(xbuilder, linspace)
+    {
+        auto ls = linspace<float>(20, 50);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {50};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 20);
+        ASSERT_EQ(ls(49), 50);
+
+        float at_3 = 20 + 3 * (50.f - 20.f) / (50.f - 1.f);
+        ASSERT_EQ(ls(3), at_3);
+
+        xarray<float> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 50);
+        ASSERT_EQ(m_assigned[{0}], 20);
+        ASSERT_EQ(m_assigned(49), 50);
+        ASSERT_EQ(m_assigned(3), at_3);
+    }
+
+    TEST(xbuilder, linspace_n_samples_endpoint)
+    {
+        auto ls = linspace<float>(20, 50, 100, false);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {100};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 20);
+
+        float at_end = 49.7;
+        ASSERT_EQ(ls(99), at_end);
+
+        float at_3 = 20.9;
+        ASSERT_EQ(ls(3), at_3);
+
+        xarray<float> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 100);
+        ASSERT_EQ(m_assigned[{0}], 20);
+        ASSERT_EQ(m_assigned(99), at_end);
+        ASSERT_EQ(m_assigned(3), at_3);
+    }
+
+    TEST(xbuilder, logspace)
+    {
+        auto ls = logspace<double>(2, 3, 4);
+        ASSERT_EQ(ls.dimension(), 1);
+        shape_t expected_shape = {4};
+        ASSERT_EQ(ls.shape(), expected_shape);
+        ASSERT_EQ(ls[{0}], 100);
+
+        double at_1 = std::pow<double>(10.0, (2.0 + 1.0/3.0));
+        ASSERT_EQ(ls(1), at_1);
+
+        ASSERT_EQ(ls(3), 1000);
+        xarray<double> m_assigned = ls;
+        ASSERT_EQ(m_assigned.dimension(), 1);
+        ASSERT_EQ(m_assigned.shape()[0], 4);
+        ASSERT_EQ(m_assigned[{0}], 100);
+        ASSERT_EQ(m_assigned(1), at_1);
+        ASSERT_EQ(m_assigned(3), 1000);
+    }
+
 }

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -74,6 +74,12 @@ namespace xt
         ASSERT_EQ(m_assigned[{0}], 10);
         ASSERT_EQ(m_assigned(10), 15);
         ASSERT_EQ(m_assigned(3), 11.5);
+
+        auto l3 = arange<float>(0, 1, 0.3);
+        shape_t expected_shape_2 = {4};
+        ASSERT_EQ(l3.shape(), expected_shape_2);
+        ASSERT_EQ(l3[{0}], 0);
+        ASSERT_EQ(3.f * 0.3f, l3[{3}]);
     }
 
     TEST(xbuilder, linspace)


### PR DESCRIPTION
As discussed, renamed xindex_function to xgenerator. 

Removed all functions except for `arange`, `linspace` and `logspace`.

