### PR TITLE
Eye function

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -135,32 +135,36 @@ namespace xt
             }
         };
 
-        template <class T, template <class> class K, class F = K<T>>
+        template <class F>
         struct fn_impl
         {
-            using value_type = T;
+            using value_type = typename F::value_type;
             using size_type = std::size_t;
 
-            inline T operator()() const
+            fn_impl(F&& f) : m_ft(f)
+            {
+            }
+
+            inline value_type operator()() const
             {
                 // special case when called without args (happens when printing)
-                return T();
+                return value_type();
             }
 
             template <class... Args>
-            inline T operator()(Args... args) const
+            inline value_type operator()(Args... args) const
             {
                 size_type idx [sizeof...(Args)] = {static_cast<size_type>(args)...};
                 return access_impl(std::begin(idx), std::end(idx));
             }
 
-            inline T operator[](const xindex& idx) const
+            inline value_type operator[](const xindex& idx) const
             {
                 return access_impl(idx.begin(), idx.end());
             }
 
             template <class It>
-            inline T element(It first, It last) const
+            inline value_type element(It first, It last) const
             {
                 return access_impl(first, last);
             }
@@ -168,7 +172,7 @@ namespace xt
         private:
             F m_ft;
             template <class It>
-            inline T access_impl(const It& begin, const It& end) const
+            inline value_type access_impl(const It& begin, const It& end) const
             {
                 return m_ft(begin, end);
             }
@@ -177,6 +181,12 @@ namespace xt
         template <class T>
         struct eye_fn
         {
+            using value_type = T;
+
+            eye_fn(int k) : m_k(k)
+            {
+            }
+
             template <class It>
             inline T operator()(const It& /*begin*/, const It& end) const
             {
@@ -186,21 +196,41 @@ namespace xt
                 auto end_2 = end;
                 end_1 -= 1;
                 end_2 -= 2;
-                return *(end_1) == *(end_2) ? T(1) : T(0);
+                return *(end_1) == *(end_2) + m_k ? T(1) : T(0);
             }
+
+        private:
+            int m_k;
         };
     }
 
+    /**
+     * @function eye(const std::vector<std::size_t>& shape, int k = 0)
+     * @brief generate array with ones on the diagonal
+     *
+     * @param shape shape of the resulting expression
+     * @param k index of the diagonal. 0 (default) refers to the main diagonal,
+     *          a positive value refers to an upper diagonal, and a negative
+     *          value to a lower diagonal.
+     *
+     * @tparam T value_type of xexpression
+     *
+     * @return xgenerator that generates the values on access
+     */
     template <class T = bool>
-    inline auto eye(const std::vector<size_t>& shape)
+    inline auto eye(const std::vector<std::size_t>& shape, int k = 0)
     {
-        return detail::make_xgenerator(detail::fn_impl<T, detail::eye_fn>(), shape);
+        return detail::make_xgenerator(detail::fn_impl<detail::eye_fn<T>>(detail::eye_fn<T>(k)), shape);
     }
 
+    /**
+     * @function eye(std::size_t n, int k = 0)
+     * @brief like eye with a shape of n x n
+     */
     template <class T = bool>
-    inline auto eye(std::size_t n)
+    inline auto eye(std::size_t n, int k = 0)
     {
-        return eye<T>({n, n});
+        return eye<T>({n, n}, k);
     }
 
     /**

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -135,7 +135,7 @@ namespace xt
             }
         };
 
-        template <class T, template<class, class> class F>
+        template <class T, template <class> class K, class F = K<T>>
         struct fn_impl
         {
             using value_type = T;
@@ -166,19 +166,27 @@ namespace xt
             }
 
         private:
+            F m_ft;
             template <class It>
             inline T access_impl(const It& begin, const It& end) const
             {
-                return F<T, It>()(begin, end);
+                return m_ft(begin, end);
             }
         };
 
-        template <class T, class It>
+        template <class T>
         struct eye_fn
         {
+            template <class It>
             inline T operator()(const It& /*begin*/, const It& end) const
             {
-                return *(end - 1) == *(end - 2) ? T(1) : T(0);
+                // workaround windows compile error by using temporary 
+                // iterators and operator-=
+                auto end_1 = end;
+                auto end_2 = end;
+                end_1 -= 1;
+                end_2 -= 2;
+                return *(end_1) == *(end_2) ? T(1) : T(0);
             }
         };
     }

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -133,6 +133,57 @@ namespace xt
                 return m_start;
             }
         };
+
+        template <class T, class F>
+        struct fn_impl
+        {
+            using value_type = T;
+            using size_type = std::size_t;
+
+            fn_impl(F& fn) : m_fn(fn)
+            {
+            }
+
+            template <class... Args>
+            inline T operator()(Args... args) const
+            {
+                xindex idx({static_cast<size_type>(args)...});
+                return access_impl(idx.begin(), idx.end());
+            }
+
+            inline T operator[](const xindex& idx) const
+            {
+                return access_impl(idx.begin(), idx.end());
+            }
+
+            template <class It>
+            inline T element(It first, It last) const
+            {
+                return access_impl(first, last);
+            }
+
+        private:
+            std::function<T(xindex::iterator&, xindex::iterator&)> m_fn;
+
+            template <class It>
+            inline T access_impl(It&& begin, It&& end) const
+            {
+                return m_fn(begin, end);
+            }
+        };
+    }
+
+    template <class T = bool>
+    inline auto eye(const std::vector<size_t>& shape)
+    {
+        auto fn = [](xindex::iterator& /*begin*/, xindex::iterator& end) { return *(end - 1) == *(end - 2) ? 1 : 0; };
+        return detail::make_xgenerator(detail::fn_impl<T, decltype(fn)>(fn), shape);
+    }
+
+    template <class T = bool>
+    inline auto eye(std::size_t n)
+    {
+        return eye<T>({n, n});
     }
 
     /**

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -176,13 +176,12 @@ namespace xt
         template <class T, class It>
         struct eye_fn
         {
-            T operator()(const It& /*begin*/, const It& end)
+            inline T operator()(const It& /*begin*/, const It& end) const
             {
-                return *(end - 1) == *(end - 2) ? 1 : 0;
+                return *(end - 1) == *(end - 2) ? T(1) : T(0);
             }
         };
     }
-
 
     template <class T = bool>
     inline auto eye(const std::vector<size_t>& shape)

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -144,4 +144,22 @@ namespace xt
         ASSERT_EQ(m_assigned(3), 1000);
     }
 
+    TEST(xbuilder, eye)
+    {
+        auto e = eye(5);
+        ASSERT_EQ(2, e.dimension());
+        shape_t expected_shape = {5, 5};
+        ASSERT_EQ(expected_shape, e.shape());
+
+        ASSERT_EQ(1, e(1, 1));
+        xindex idx({1, 0});
+        ASSERT_EQ(0, e[idx]);
+
+        xarray<bool> m_assigned = e;
+        ASSERT_EQ(1, m_assigned(2, 2));
+        ASSERT_EQ(0, m_assigned(4, 2));
+
+        xt::xindex idx2({2, 2});
+        ASSERT_EQ(1, e.element(idx2.begin(), idx2.end()));
+    }
 }


### PR DESCRIPTION
Hi,

I've implemented the eye function through xgenerator. This time I tried to use a generic std::function that works on iterators. 

However, I faced a difficulty when using the static array + std::begin/end() combination @SylvainCorlay demonstrated in the last PR. I didn't find any way to keep the std::function as a function template. 

Do you have ideas / is it necessary?

I think if this works well, the fn_impl could get some nice helper-wrapper to initialize a xgenerator from a lambda function, or the mechanism could be integrated directly into xgenerator. 