### PR TITLE
Implement <, >, <=, >=, equals_to, clip, and fix bug in boolean ops

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -198,6 +198,36 @@ namespace xt
         using functor_type = detail::mf_type<E1, E2>;
         return detail::make_xfunction((functor_type)std::fdim, e1, e2);
     }
+    
+    namespace detail
+    {
+        // this function will be part of std with C++17
+        template <class T>
+        constexpr T clamp(const T v, const T lo, const T hi)
+        {
+            return v < lo ? lo : hi < v ? hi : v;
+        }
+    }
+
+    /**
+     * @ingroup basic_functions
+     * @brief Clip values between hi and lo
+     * 
+     * Returns an \ref xfunction for the element-wise clipped 
+     * values between hi- and lo
+     * @param e1 an \ref xexpression or a scalar
+     * @param hi a scalar
+     * @param lo a scalar
+     *
+     * @return a \ref xfunction
+     */
+    template <class E1, class E2, class E3>
+    inline auto clip(const E1& e1, const E2& hi, const E3& lo) noexcept
+        -> detail::get_xfunction_free_type<E1, E2, E3>
+    {
+        using functor_type = detail::mf_type<E1, E2, E3>;
+        return detail::make_xfunction((functor_type)detail::clamp, e1, hi, lo);
+    }
 
     /*************************
      * exponential functions *

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -23,41 +23,30 @@ namespace xt
      * helpers *
      ***********/
 
-    template <class T>
-    struct identity
-    {
-        using result_type = T;
-
-        constexpr T operator()(const T& t) const noexcept
-        {
-            return +t;
-        }
-    };
-
-    template <class T>
-    struct conditional_ternary
-    {
-        using result_type = T;
-
-        constexpr result_type operator()(const T& t1, const T& t2, const T& t3) const noexcept
-        {
-            return t1 ? t2 : t3;
-        }
-    };
-
-    template <class T>
-    struct conditional
-    {
-        using result_type = bool;
-
-        constexpr result_type operator()(const T t1, const T t2) const noexcept
-        {
-            return t1 < t2;
-        }
-    };
-
     namespace detail
     {
+        template <class T>
+        struct identity
+        {
+            using result_type = T;
+
+            constexpr T operator()(const T& t) const noexcept
+            {
+                return +t;
+            }
+        };
+
+        template <class T>
+        struct conditional_ternary
+        {
+            using result_type = T;
+
+            constexpr result_type operator()(const T& t1, const T& t2, const T& t3) const noexcept
+            {
+                return t1 ? t2 : t3;
+            }
+        };
+
         template <template <class...> class F, class... E>
         inline auto make_xfunction(const E&... e) noexcept
         {
@@ -81,7 +70,7 @@ namespace xt
     template <class E>
     inline auto operator+(const xexpression<E>& e) noexcept
     {
-        return detail::make_xfunction<identity>(e.derived_cast());
+        return detail::make_xfunction<detail::identity>(e.derived_cast());
     }
 
     template <class E>
@@ -176,9 +165,9 @@ namespace xt
 
     template <class E1, class E2, class E3>
     inline auto where(const E1& e1, const E2& e2, const E3& e3) noexcept
-        -> detail::get_xfunction_type<conditional_ternary, E1, E2, E3>
+        -> detail::get_xfunction_type<detail::conditional_ternary, E1, E2, E3>
     {
-         return detail::make_xfunction<conditional_ternary>(e1, e2, e3);
+         return detail::make_xfunction<detail::conditional_ternary>(e1, e2, e3);
     }
 
     template <class E1>

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -121,6 +121,15 @@ namespace xt
         EXPECT_EQ(fdim(sa, b)(0, 0), std::fdim(sa, b(0, 0)));
     }
 
+    TEST(xmath, clip)
+    {
+        shape_type shape = {3, 2};
+        xarray<double> a = {1,2,3,4,5,6};
+        xarray<double> res = {2, 2, 3, 4, 4, 4};
+
+        xarray<double> clipped = clip(a, 2.0, 4.0);
+        EXPECT_EQ(res, clipped);
+    }
 
     /***************************
      * Exponential functions

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -89,5 +89,98 @@ namespace xt
         double sa = 4.6;
         EXPECT_EQ((sa / b)(0, 0), sa / b(0, 0));
     }
+
+    TEST(operation, less)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {1, 1, 1, 0, 0};
+        xarray<bool> b = a < 4; 
+        EXPECT_EQ(expected, b);
+    }
+
+    TEST(operation, less_equal)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {1, 1, 1, 1, 0};
+        xarray<bool> b = a <= 4; 
+        EXPECT_EQ(expected, b);
+    }
+
+    TEST(operation, greater)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {0, 0, 0, 0, 1};
+        xarray<bool> b = a > 4;
+        EXPECT_EQ(expected, b);
+    }
+
+    TEST(operation, greater_equal)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {0, 0, 0, 1, 1};
+        xarray<bool> b = a >= 4; 
+        EXPECT_EQ(expected, b);
+    }
+
+    TEST(operation, negate)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {1, 1, 1, 0, 0};
+        xarray<bool> b = !(a >= 4);
+        EXPECT_EQ(expected, b);
+    }
+
+    TEST(operation, equal_to)
+    {
+        xarray<double> a = {1, 2, 3, 4, 5};
+        xarray<bool> expected = {0, 0, 0, 1, 0};
+        xarray<bool> b = equal_to(a, 4);
+        EXPECT_EQ(expected, b);
+
+        xarray<double> other = {1, 2, 3, 0, 0};
+        xarray<bool> b_2 = equal_to(a, other);
+        xarray<bool> expected_2 = {1, 1, 1, 0, 0};
+        EXPECT_EQ(expected_2, b_2);
+    }
+
+    TEST(operation, logical_and)
+    {
+        xarray<bool> a = {0, 0, 0, 1, 0};
+        xarray<bool> expected = {0, 0, 0, 0, 0};
+        xarray<bool> b = a && 0;
+        xarray<bool> c = a && a;
+        EXPECT_EQ(expected, b);
+        EXPECT_EQ(c, a);
+    }
+
+    TEST(operation, logical_or)
+    {
+        xarray<bool> a = {0, 0, 0, 1, 0};
+        xarray<bool> other = {0, 0, 0, 0, 0};
+        xarray<bool> b = a || other;
+        xarray<bool> c = a || 0;
+        xarray<bool> d = a || 1;
+        EXPECT_EQ(b, a);
+        EXPECT_EQ(c, a);
+
+        xarray<bool>expected = {1, 1, 1, 1, 1};
+        EXPECT_EQ(expected, d);
+    }
+
+    TEST(operation, any)
+    {
+        xarray<int> a = {0, 0, 3};
+        EXPECT_EQ(true, any(a));
+        xarray<int> b = {{0, 0, 0}, {0, 0, 0}};
+        EXPECT_EQ(false, any(b));
+    }
+
+    TEST(operation, all)
+    {
+        xarray<int> a = {1, 1, 3};
+        EXPECT_EQ(true, all(a));
+        xarray<int> b = {{0, 2, 1}, {2, 1, 0}};
+        EXPECT_EQ(false, all(b));
+    }
 }
 


### PR DESCRIPTION
This PR implements a bunch of boolean ops, and adds tests. Also for logical_or/and/not.

I fixed a bug in which the return type wasn't correctly determined in get_xfunction_type.

Also, identity and conditional_ternary structs are moved to the `detail` namespace. This way, `xt::identity` could be an overload for `xt::eye` as in numpy.