### PR TITLE
xindexview function for advanced indexing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xexpression.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xfunction.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xgenerator.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xindexview.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xio.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xiterator.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmath.hpp

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -111,9 +111,6 @@ namespace xt
 
     private:
 
-        template <class Func, std::size_t... I>
-        const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
-
         functor_type m_f;
         shape_type m_shape;
         friend class xgenerator_stepper<F, R, S>;

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -1,0 +1,726 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XINDEXVIEW_HPP
+#define XINDEXVIEW_HPP
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <tuple>
+#include <algorithm>
+
+#include "xexpression.hpp"
+#include "xiterator.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    template <bool is_const, class T, class S>
+    class xindexview_stepper;
+
+    template <class T, class S>
+    class xindexview;
+
+    template <class T, class S>
+    struct xcontainer_inner_types<xindexview<T, S>>
+    {
+        using temporary_type = xarray<typename T::value_type>;
+    };
+
+    /**************
+     * xindexview *
+     **************/
+
+    /**
+     * @class xindexview
+     * @brief Multidimensional function operating on indices.
+     *
+     * Th xindexview class implements a multidimensional function,
+     * generating a value from the supplied indices.
+     *
+     * @tparam T the function type
+     * @tparam R the return type of the function
+     * @tparam S the shape type of the generator
+     */
+    template <class T, class S>
+    class xindexview : public xview_semantic<xindexview<T, S>>
+    {
+
+    public:
+
+        using self_type = xindexview<T, S>;
+        using expression_type = T;
+        using semantic_base = xview_semantic<self_type>;
+
+        using indices_type = std::vector<xindex>;
+
+        using value_type = typename T::value_type;
+        using reference = typename T::reference;
+        using const_reference = typename T::const_reference;
+        using pointer = typename T::pointer;
+        using const_pointer = typename T::const_pointer;
+        using size_type = typename T::size_type;
+        using difference_type = typename T::difference_type;
+
+        using shape_type = S;
+        using strides_type = S;
+        using closure_type = const self_type;
+
+        using stepper = xindexview_stepper<false, T, shape_type>;
+        using iterator = xiterator<stepper, shape_type>;
+        using storage_iterator = iterator;
+
+        using const_stepper = xindexview_stepper<true, T, shape_type>;
+        using const_iterator = xiterator<const_stepper, shape_type>;
+        using const_storage_iterator = const_iterator;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = get_index_type<shape_type>;
+
+        xindexview(T& f, const indices_type&& indices) noexcept;
+
+        template <class OE>
+        self_type& operator=(const xexpression<OE>& e);
+
+        size_type dimension() const noexcept;
+        const shape_type& shape() const;
+
+        template <class... Args>
+        reference operator()(std::size_t idx, Args... args);
+        reference operator()();
+        reference operator[](const xindex& index);
+
+        template <class It>
+        reference element(const It& first, const It& last);
+
+        template <class... Args>
+        const_reference operator()(std::size_t idx, Args... args) const;
+        const_reference operator()() const;
+        const_reference operator[](const xindex& index) const;
+
+        template <class It>
+        const_reference element(const It& first, const It& last) const;
+
+        template <class O>
+        bool broadcast_shape(O& shape) const;
+
+        template <class O>
+        bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator begin() const;
+        const_iterator end() const;
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
+        template <class ST>
+        xiterator<stepper, ST> xbegin(const ST& shape);
+        template <class ST>
+        xiterator<stepper, ST> xend(const ST& shape);
+
+        template <class ST>
+        xiterator<const_stepper, ST> xbegin(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> xend(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> cxbegin(const ST& shape) const;
+        template <class ST>
+        xiterator<const_stepper, ST> cxend(const ST& shape) const;
+
+        template <class ST>
+        stepper stepper_begin(const ST& shape);
+        template <class ST>
+        stepper stepper_end(const ST& shape);
+
+        template <class ST>
+        const_stepper stepper_begin(const ST& shape) const;
+        template <class ST>
+        const_stepper stepper_end(const ST& shape) const;
+
+        storage_iterator storage_begin();
+        storage_iterator storage_end();
+
+        const_storage_iterator storage_begin() const;
+        const_storage_iterator storage_end() const;
+
+        const_storage_iterator storage_cbegin() const;
+        const_storage_iterator storage_cend() const;
+
+    private:
+
+        T& m_e;
+        indices_type m_indices;
+        shape_type m_shape;
+        
+        void assign_temporary_impl(temporary_type& tmp);
+
+        friend class xview_semantic<xindexview<T, S>>;
+    };
+
+    /***************************
+     * xindexview_stepper      *
+     ***************************/
+
+    template <bool is_const, class T, class S>
+    class xindexview_stepper
+    {
+
+    public:
+
+        using view_type = std::conditional_t<is_const,
+                                             const xindexview<T, S>,
+                                             xindexview<T, S>>;
+
+        using self_type = xindexview_stepper<is_const, T, S>;
+
+        using value_type = typename view_type::value_type;
+
+        using reference = std::conditional_t<is_const,
+                                             typename view_type::const_reference,
+                                             typename view_type::reference>;
+
+        using pointer = typename view_type::pointer;
+        using size_type = typename view_type::size_type;
+        using difference_type = typename view_type::difference_type;
+        using iterator_category = std::input_iterator_tag;
+
+        using shape_type = typename view_type::shape_type;
+        using index_type = get_index_type<shape_type>;
+
+        xindexview_stepper(view_type* func, const shape_type& shape) noexcept;
+
+        reference operator*() const;
+
+        void step(size_type dim, size_type n = 1);
+        void step_back(size_type dim, size_type n = 1);
+        void reset(size_type dim);
+
+        void to_end();
+
+        bool equal(const self_type& rhs) const;
+
+    private:
+        view_type* p_view;
+        shape_type m_shape;
+        index_type m_index;
+    };
+
+    template <bool is_const, class T, class S>
+    bool operator==(const xindexview_stepper<is_const, T, S>& it1,
+                    const xindexview_stepper<is_const, T, S>& it2);
+
+    template <bool is_const, class T, class S>
+    bool operator!=(const xindexview_stepper<is_const, T, S>& it1,
+                    const xindexview_stepper<is_const, T, S>& it2);
+
+    /*****************************
+     * xindexview implementation *
+     *****************************/
+
+    /**
+     * @name Constructor
+     */
+    //@{
+    /**
+     * Constructs an xindexview applying the specified function over the 
+     * given shape.
+     * @param f the function to apply
+     * @param shape the shape of the xindexview
+     */
+    template <class T, class S>
+    inline xindexview<T, S>::xindexview(T& e, const indices_type&& indices) noexcept
+        : m_e(e), m_indices(indices), m_shape({indices.size()})
+    {
+    }
+    //@}
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class T, class S>
+    template <class OE>
+    inline auto xindexview<T, S>::operator=(const xexpression<OE>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+    
+    template <class T, class S>
+    inline void xindexview<T, S>::assign_temporary_impl(temporary_type& tmp)
+    {
+        std::copy(tmp.storage_cbegin(), tmp.storage_cend(), begin());
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the number of dimensions of the function.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::dimension() const noexcept -> size_type
+    {
+        return m_shape.size();
+    }
+
+    /**
+     * Returns the shape of the xindexview.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::shape() const -> const shape_type&
+    {
+        return m_shape;
+    }
+    //@}
+
+    /**
+     * @name Data
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::operator()() const -> const_reference
+    {
+        return m_e();
+    }
+
+    template <class T, class S>
+    inline auto xindexview<T, S>::operator()() -> reference
+    {
+        return m_e();
+    }
+
+    template <class T, class S>
+    template <class... Args>
+    inline auto xindexview<T, S>::operator()(std::size_t idx, Args... args) -> reference
+    {
+        return m_e[m_indices[idx]];
+    }
+
+    /**
+     * Returns the evaluated element at the specified position in the function.
+     * @param args a list of indices specifying the position in the function. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the function.
+     */
+    template <class T, class S>
+    template <class... Args>
+    inline auto xindexview<T, S>::operator()(std::size_t idx, Args... args) const -> const_reference
+    {
+        return m_e[m_indices[idx]];
+    }
+
+    template <class T, class S>
+    inline auto xindexview<T, S>::operator[](const xindex& index) -> reference
+    {
+        return m_e[m_indices[index[0]]];
+    }
+
+    template <class T, class S>
+    inline auto xindexview<T, S>::operator[](const xindex& index) const -> const_reference
+    {
+        return m_e[m_indices[index[0]]];
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the function.
+     * @param first iterator starting the sequence of indices
+     * @param second iterator starting the sequence of indices
+     * The number of indices in the squence should be equal or greater
+     * than the number of dimensions of the container.
+     */
+    template <class T, class S>
+    template <class It>
+    inline auto xindexview<T, S>::element(const It& first, const It& /*last*/) -> reference
+    {
+        return m_e[m_indices[(*first)]];
+    }
+
+    template <class T, class S>
+    template <class It>
+    inline auto xindexview<T, S>::element(const It& first, const It& /*last*/) const -> const_reference
+    {
+        return m_e[m_indices[(*first)]];
+    }
+    //@}
+    
+    /**
+     * @name Broadcasting
+     */
+    //@{
+    /**
+     * Broadcast the shape of the function to the specified parameter.
+     * @param shape the result shape
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class T, class S>
+    template <class O>
+    inline bool xindexview<T, S>::broadcast_shape(O& shape) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
+
+    /**
+     * Compares the specified strides with those of the container to see whether
+     * the broadcasting is trivial.
+     * @return a boolean indicating whether the broadcasting is trivial
+     */
+    template <class T, class S>
+    template <class O>
+    inline bool xindexview<T, S>::is_trivial_broadcast(const O& /*strides*/) const noexcept
+    {
+        return false;
+    }
+    //@}
+
+    /****************
+     * iterator api *
+     ****************/
+
+    /**
+     * @name Iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::begin() -> iterator
+    {
+        return xbegin(shape());
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::end() -> iterator
+    {
+        return xend(shape());
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::begin() const -> const_iterator
+    {
+        return xbegin(shape());
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::end() const -> const_iterator
+    {
+        return xend(shape());
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::cbegin() const -> const_iterator
+    {
+        return begin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::cend() const -> const_iterator
+    {
+        return end();
+    }
+
+    /**
+     * Returns an iterator to the first element of the view. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for braodcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::xbegin(const ST& shape) -> xiterator<stepper, ST>
+    {
+        return xiterator<stepper, ST>(stepper_begin(shape), shape);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * view. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::xend(const ST& shape) -> xiterator<stepper, ST>
+    {
+        return xiterator<stepper, ST>(stepper_end(shape), shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the view. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for braodcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::xbegin(const ST& shape) const -> xiterator<const_stepper, ST>
+    {
+        return xiterator<const_stepper, ST>(stepper_begin(shape), shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * view. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::xend(const ST& shape) const -> xiterator<const_stepper, ST>
+    {
+        return xiterator<const_stepper, ST>(stepper_end(shape), shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the view. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for braodcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::cxbegin(const ST& shape) const -> xiterator<const_stepper, ST>
+    {
+        return xbegin(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * container. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     */
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::cxend(const ST& shape) const -> xiterator<const_stepper, ST>
+    {
+        return xend(shape);
+    }
+    //@}
+
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::stepper_begin(const ST& shape) -> stepper
+    {
+        return stepper(this, shape);
+    }
+
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::stepper_end(const ST& shape) -> stepper
+    {
+        auto s = stepper(this, shape);
+        s.to_end();
+        return s;
+    }
+
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::stepper_begin(const ST& shape) const -> const_stepper
+    {
+        return const_stepper(this, shape);
+    }
+
+    template <class T, class S>
+    template <class ST>
+    inline auto xindexview<T, S>::stepper_end(const ST& shape) const -> const_stepper
+    {
+        auto s = const_stepper(this, shape);
+        s.to_end();
+        return s;
+    }
+
+    /************************
+     * storage_iterator api *
+     ************************/
+
+    /**
+     * @name Storage iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the buffer containing
+     * the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_begin() -> storage_iterator
+    {
+        return begin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of
+     * the buffer containing the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_end() -> storage_iterator
+    {
+        return end();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_begin() const -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_end() const -> const_storage_iterator
+    {
+        return cend();
+    }
+    //@}
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_cbegin() const -> const_storage_iterator
+    {
+        return cbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the view.
+     */
+    template <class T, class S>
+    inline auto xindexview<T, S>::storage_cend() const -> const_storage_iterator
+    {
+        return cend();
+    }
+    //@}
+
+    /*************************************
+     * xindexview_stepper implementation *
+     *************************************/
+
+    template <bool is_const, class T, class S>
+    inline xindexview_stepper<is_const, T, S>::xindexview_stepper(view_type* view, const shape_type& shape) noexcept
+        : p_view(view), m_shape(shape), m_index(make_sequence<index_type>(shape.size(), size_type(0)))
+    {
+    }
+
+    template <bool is_const, class T, class S>
+    inline void xindexview_stepper<is_const, T, S>::step(size_type dim, size_type n)
+    {
+        m_index[dim] += n;
+    }
+
+    template <bool is_const, class T, class S>
+    inline void xindexview_stepper<is_const, T, S>::step_back(size_type dim, size_type n)
+    {
+        m_index[dim] -= 1;
+    }
+
+    template <bool is_const, class T, class S>
+    inline void xindexview_stepper<is_const, T, S>::reset(size_type dim)
+    {
+        m_index[dim] = 0;
+    }
+
+    template <bool is_const, class T, class S>
+    inline void xindexview_stepper<is_const, T, S>::to_end()
+    {
+        m_index = m_shape;
+    }
+
+    template <bool is_const, class T, class S>
+    inline bool xindexview_stepper<is_const, T, S>::equal(const self_type& rhs) const
+    {
+        return p_view == rhs.p_view && std::equal(m_index.begin(), m_index.end(), rhs.m_index.begin());
+    }
+
+    template <bool is_const, class T, class S>
+    inline auto xindexview_stepper<is_const, T, S>::operator*() const -> reference
+    {
+        return (*p_view)[m_index];
+    }
+
+    template <bool is_const, class T, class S>
+    inline bool operator==(const xindexview_stepper<is_const, T, S>& it1,
+                           const xindexview_stepper<is_const, T, S>& it2)
+    {
+        return it1.equal(it2);
+    }
+
+    template <bool is_const, class T, class S>
+    inline bool operator!=(const xindexview_stepper<is_const, T, S>& it1,
+                           const xindexview_stepper<is_const, T, S>& it2)
+    {
+        return !(it1.equal(it2));
+    }
+
+    template <class T>
+    auto inline make_xindexview(T& arr, const std::vector<xindex>&& indices)
+    {
+        return xt::xindexview<T, std::vector<std::size_t>>(arr, std::move(indices));
+    }
+
+    template <class T, class O>
+    auto inline make_xboolview(T& arr, const O& bool_arr)
+    {
+        std::vector<xindex> indices;
+
+        auto shape = arr.shape();
+        xindex idx = xindex(arr.dimension());
+
+        auto next_idx = [&shape](xindex& idx) {
+            for (int i = shape.size() - 1; i >= 0; i--)
+                if (idx[i] >= shape[i] - 1)
+                    idx[i] = 0;
+                else
+                    return idx[i]++;
+        };
+
+        std::size_t total_size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>());
+        for (std::size_t i = 0; i < total_size; i++) {
+            if (bool_arr[idx])
+                indices.push_back(idx);
+            next_idx(idx);
+        }
+
+        return xt::xindexview<T, std::vector<std::size_t>>(arr, std::move(indices));
+    }
+
+}
+
+#endif

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -40,12 +40,12 @@ namespace xt
 
     /**
      * @class xindexview
-     * @brief View from vector of indices.
+     * @brief View into xexpression from vector of indices.
      *
-     * Th xindexview class implements a flat view into a multidimensional
-     * array yielding the values at the indices of the index array.
+     * Th xindexview class implements a flat (1D) view into a multidimensional
+     * xexpression yielding the values at the indices of the index array.
      *
-     * @tparam T the function type
+     * @tparam E the xexpression type underlying this view.
      * @tparam S the shape type of the view
      * @tparam I the index array type of the view
      */

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -19,34 +19,35 @@
 namespace xt
 {
 
-    /***********
-     * helpers *
-     ***********/
-
-    template <class T>
-    struct identity
-    {
-        using result_type = T;
-
-        constexpr T operator()(const T& t) const noexcept
-        {
-            return +t;
-        }
-    };
-
-    template <class T>
-    struct conditional_ternary
-    {
-        using result_type = T;
-
-        constexpr result_type operator()(const T& t1, const T& t2, const T& t3) const noexcept
-        {
-            return t1 ? t2 : t3;
-        }
-    };
-
     namespace detail
     {
+
+        /***********
+         * helpers *
+         ***********/
+
+        template <class T>
+        struct identity
+        {
+            using result_type = T;
+
+            constexpr T operator()(const T& t) const noexcept
+            {
+                return +t;
+            }
+        };
+
+        template <class T>
+        struct conditional_ternary
+        {
+            using result_type = T;
+
+            constexpr result_type operator()(const T& t1, const T& t2, const T& t3) const noexcept
+            {
+                return t1 ? t2 : t3;
+            }
+        };
+
         template <template <class...> class F, class... E>
         inline auto make_xfunction(E&&... e) noexcept
         {
@@ -69,9 +70,9 @@ namespace xt
 
     template <class E>
     inline auto operator+(E&& e) noexcept
-        -> detail::get_xfunction_type<identity, E>
+        -> detail::get_xfunction_type<detail::identity, E>
     {
-        return detail::make_xfunction<identity>(std::forward<E>(e));
+        return detail::make_xfunction<detail::identity>(std::forward<E>(e));
     }
 
     template <class E>
@@ -204,14 +205,14 @@ namespace xt
     template <class E>
     inline bool any(E&& e)
     {
-        return std::any_of(e.storage_begin(), e.storage_end(), 
+        return std::any_of(e.storage_cbegin(), e.storage_cend(), 
                            [](const typename std::decay<E>::type::value_type& el) { return el; });
     }
 
     template <class E>
     inline bool all(E&& e)
     {
-        return std::all_of(e.storage_begin(), e.storage_end(),
+        return std::all_of(e.storage_cbegin(), e.storage_cend(),
                            [](const typename std::decay<E>::type::value_type& el) { return el; });
     }
 }

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -492,6 +492,25 @@ namespace xt
         template<typename T>
         struct is_complex<std::complex<T>> : public std::true_type {};
     }
+
+    /**************************
+    * to_array implementation *
+    ***************************/
+
+    namespace detail
+    {
+        template <class T, std::size_t N, std::size_t... I>
+        constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&a)[N], std::index_sequence<I...>)
+        {
+            return { {a[I]...} };
+        }
+    }
+
+    template <class T, std::size_t N>
+    constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N])
+    {
+        return detail::to_array_impl(a, std::make_index_sequence<N>{});
+    }
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,8 +72,8 @@ set(XTENSOR_TESTS
     test_xbuilder.cpp
     test_xcontainer_semantic.cpp
     test_xfunction.cpp
-    test_xiterator.cpp
     test_xindexview.cpp
+    test_xiterator.cpp
     test_xio.cpp
     test_xmath.cpp
     test_xnoalias.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(XTENSOR_TESTS
     test_xcontainer_semantic.cpp
     test_xfunction.cpp
     test_xiterator.cpp
+    test_xindexview.cpp
     test_xio.cpp
     test_xmath.cpp
     test_xnoalias.cpp

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -23,6 +23,10 @@ namespace xt
         xarray<double> e = xt::random::rand<double>({3, 3});
         xarray<double> e_copy = e;
         auto v = make_xindexview(e, {{1, 1}, {1, 2}, {2, 2}});
+
+        using shape_type = typename decltype(v)::shape_type;
+        EXPECT_EQ(shape_type{3}, v.shape());
+        
         EXPECT_EQ(e(1, 1), v(0));
         EXPECT_EQ(e(1, 2), v[{1}]);
 
@@ -51,7 +55,7 @@ namespace xt
     TEST(xindexview, boolean)
     {
         xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
-        auto v = make_xboolview(e, e > 0);
+        auto v = make_xfilter(e, e > 0);
         EXPECT_EQ(1, v(0));
 
         v += 2;
@@ -63,7 +67,7 @@ namespace xt
         EXPECT_EQ(6, e(2, 2));
 
         xarray<double> e2 = random::rand<double>({3, 3, 3, 3});
-        auto v2 = make_xboolview(e2, e2 > 0.5);
+        auto v2 = make_xfilter(e2, e2 > 0.5);
         v2 *= 0;
         EXPECT_TRUE(!any(e2 > 0.5));
     }
@@ -85,5 +89,14 @@ namespace xt
         EXPECT_EQ(fn(1, 2), *(++it));
         EXPECT_EQ(fn(2, 2), *(++it));
         EXPECT_EQ(++it, v.end());
+    }
+
+    TEST(xindexview, view_on_view)
+    {
+        xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+        auto v = make_xfilter(e, e > 0);
+        auto v_on_v = make_xview(v, 1);
+        v_on_v(0) = 10;
+        EXPECT_EQ(10, e(1, 1));
     }
 }

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -1,0 +1,66 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xrandom.hpp"
+#include "xtensor/xindexview.hpp"
+#include "xtensor/xbroadcast.hpp"
+#include "xtensor/xview.hpp"
+#include "test_common.hpp"
+
+namespace xt
+{
+    using std::size_t;
+
+    TEST(xindexview, indices)
+    {
+        xarray<double> e = xt::random::rand<double>({3, 3});
+        xarray<double> e_copy = e;
+        auto v = make_xindexview(e, {{1, 1}, {1, 2}, {2, 2}});
+        EXPECT_EQ(e(1, 1), v(0));
+        EXPECT_EQ(e(1, 2), v[{1}]);
+
+        std::vector<size_t> idx = {2};
+        EXPECT_EQ(e(2, 2), v.element(idx.begin(), idx.end()));
+
+        v += 3;
+        auto expected = e_copy(1, 1) + 3;
+        EXPECT_EQ(expected, e(1, 1));
+
+        auto t = v + 3;
+        EXPECT_EQ((e_copy(1, 1) + 6), t(0));
+        EXPECT_EQ((e(1, 1) + 3), t(0));
+
+        xarray<double> as = {3, 3, 3};
+        v = as;
+        EXPECT_TRUE(all(equal_to(v, as)));
+        EXPECT_EQ(3, e(2, 2));
+    }
+
+    TEST(xindexview, boolean)
+    {
+        xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+        auto v = make_xboolview(e, e > 0);
+        EXPECT_EQ(1, v(0));
+
+        v += 2;
+        EXPECT_EQ(3, e(1, 1));
+        EXPECT_EQ(3, v(1));
+
+        v += xarray<double>{1, 2, 3};
+        EXPECT_EQ(5, e(1, 1));
+        EXPECT_EQ(6, e(2, 2));
+
+        xarray<double> e2 = random::rand<double>({3, 3, 3, 3});
+        auto v2 = make_xboolview(e2, e2 > 0.5);
+        v2 *= 0;
+        EXPECT_TRUE(!any(e2 > 0.5));
+    }
+
+}

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -37,9 +37,14 @@ namespace xt
         EXPECT_EQ((e_copy(1, 1) + 6), t(0));
         EXPECT_EQ((e(1, 1) + 3), t(0));
 
+        v = broadcast(123, v.shape());
+        EXPECT_EQ(123, e(1, 1));
+        EXPECT_EQ(123, e(1, 2));
+        EXPECT_EQ(123, e(2, 2));
+
         xarray<double> as = {3, 3, 3};
         v = as;
-        EXPECT_TRUE(all(equal_to(v, as)));
+        EXPECT_TRUE(all(equal(v, as)));
         EXPECT_EQ(3, e(2, 2));
     }
 
@@ -63,4 +68,22 @@ namespace xt
         EXPECT_TRUE(!any(e2 > 0.5));
     }
 
+    TEST(xindexview, indices_on_function)
+    {
+        xarray<double> e = xt::random::rand<double>({3, 3});
+        auto fn = e * 3 - 120;
+        auto v = make_xindexview(fn, {{1, 1}, {1, 2}, {2, 2}});
+        EXPECT_EQ(fn(1, 1), v(0));
+        EXPECT_EQ(fn(1, 2), v[{1}]);
+
+        std::vector<size_t> idx = {2};
+        EXPECT_EQ(fn(2, 2), v.element(idx.begin(), idx.end()));
+
+        auto it = v.begin();
+        EXPECT_EQ(fn(1, 1), *it);
+
+        EXPECT_EQ(fn(1, 2), *(++it));
+        EXPECT_EQ(fn(2, 2), *(++it));
+        EXPECT_EQ(++it, v.end());
+    }
 }

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -195,5 +195,36 @@ namespace xt
         xarray<int> b = {{0, 2, 1}, {2, 1, 0}};
         EXPECT_EQ(false, all(b));
     }
+
+    TEST(operation, nonzero)
+    {
+        xarray<int> a = {1, 0, 3};
+        std::vector<xindex> expected = {{0}, {2}};
+        EXPECT_EQ(expected, nonzero(a));
+
+        xarray<int> b = {{0, 2, 1}, {2, 1, 0}};
+        std::vector<xindex> expected_b = {{0, 1}, {0, 2}, {1, 0}, {1, 1}};
+        EXPECT_EQ(expected_b, nonzero(b));
+
+        auto c = equal(b, 0);
+        std::vector<xindex> expected_c = {{0, 0}, {1, 2}};
+        EXPECT_EQ(expected_c, nonzero(c));
+
+        shape_type s = {3, 3, 3};
+        xarray<bool> d(s);
+        std::fill(d.begin(), d.end(), true);
+
+        auto d_nz = nonzero(d);
+        EXPECT_EQ(3 * 3 * 3, d_nz.size());
+        xindex last_idx = {2, 2, 2};
+        EXPECT_EQ(last_idx, d_nz.back());
+    }
+
+    TEST(operation, where_only_condition)
+    {
+        xarray<int> a = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+        std::vector<xindex> expected = {{0, 0}, {1, 1}, {2, 2}};
+        EXPECT_EQ(expected, where(a));
+    }
 }
 


### PR DESCRIPTION
I hope this doesn't come across as spam :) but I have attempted an implementation for an "index view". ie. one can provide a list of indices and those will be selected into a linear view.
Essentially, it allows for numpys advanced indexing like so:

```
	xt::xarray<double> rn = xt::random::rand<double>({3, 3}, 0, 1);

	auto v = xt::make_xindexview(rn, {{1,1}, {2,2}});
	auto v2 = xt::make_boolview(rn, (rn > 0.2));
	std::cout << v << std::endl;
	std::cout << v2 << std::endl;
	v += 2.0;

	v2 += 15;
	std::cout << rn << std::endl;

```

With corresponding output:

```
{{0.135477, 0.835009, 0.968868},
 {0.221034, 0.308167, 0.547221},
 {0.188382, 0.992881, 0.996461}}

{0.308167, 0.996461}

{0.835009, 0.968868, 0.221034, 0.308167, 0.547221, 0.992881, 0.996461}

{{0.135477, 15.835, 15.9689},
 {15.221, 17.3082, 15.5472},
 {0.188382, 15.9929, 17.9965}}
```

Let me know what you think.
