### PR TITLE
Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Appveyor](https://ci.appveyor.com/api/projects/status/quf1hllkedr0rxbk?svg=true)](https://ci.appveyor.com/project/QuantStack/xtensor)
 [![Documentation Status](http://readthedocs.org/projects/xtensor/badge/?version=latest)](https://xtensor.readthedocs.io/en/latest/?badge=latest)
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/QuantStack/xtensor/notebooks/notebooks/xtensor.ipynb)
+[![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Multi-dimensional arrays with broadcasting and lazy computing.
 

--- a/docs/source/api/container_index.rst
+++ b/docs/source/api/container_index.rst
@@ -16,3 +16,4 @@ Containers and views
    xtensor_adaptor
    xview
    xbroadcast
+   xindexview

--- a/docs/source/api/xindexview.rst
+++ b/docs/source/api/xindexview.rst
@@ -1,0 +1,18 @@
+.. Copyright (c) 2016, Johan Mabille and Sylvain Corlay
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+xindexview
+==========
+
+.. doxygenclass:: xt::xindexview
+   :project: xtensor
+   :members:
+
+.. doxygenfunction:: xt::index_view(E&, I&&)
+   :project: xtensor
+
+.. doxygenfunction:: xt::filter
+   :project: xtensor

--- a/docs/source/api/xview.rst
+++ b/docs/source/api/xview.rst
@@ -11,7 +11,7 @@ xview
    :project: xtensor
    :members:
 
-.. doxygenfunction:: xt::make_xview
+.. doxygenfunction:: xt::view
    :project: xtensor
 
 .. doxygenfunction:: xt::range(T, T)

--- a/docs/source/view.rst
+++ b/docs/source/view.rst
@@ -67,10 +67,45 @@ you are actually also altering the underlying expression.
     v1(0, 0) = 1;
     // => a(1, 0, 1) = 1
 
+Index views
+-----------
+
+Index views are one-dimensional views of an ``xexpression``, containing the elements whose positions are specified by a list
+of indices. Like for sliced views, the elements of the underlying ``xexpression`` are not copied. Index views should be built
+with the ``index_view`` helper function.
+
+.. code::
+
+    #include "xtensor/xarray.hpp"
+    #include "xtensor/xindexview.hpp"
+
+    xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
+    auto b = xt::index_view(a, {{0,0}, {1, 0}, {0, 1}});
+    // => b = { 1, 4, 5 }
+    b += 100;
+    // => a = {{101, 5, 3}, {104, 105, 6}}
+
+Filter views
+------------
+
+Filters are one-dimensional views holding elements of an ``xexpression`` that verify a given condition. Like for other views,
+the elements of the underlying ``xexpression`` are not copied. Filters should be built with the ``filter`` helper function.
+
+.. code::
+
+    #include "xtensor/xarray.hpp"
+    #include "xtensor/xindexview.hpp"
+
+    xt::xarray<double> a = {{1, 5, 3}, {4, 5, 6}};
+    auto v = xt::filter(a, a >= 5);
+    // => v = { 5, 5, 6 }
+    v += 100;
+    // => a = {{1, 105, 3}, {4, 105, 106}}
+
 Broadcasting views
 ------------------
 
-The second type of view provided by `xtensor` is *broadcasting view*. Such a view broadcast an expression to the specified
+The last type of view provided by `xtensor` is *broadcasting view*. Such a view broadcast an expression to the specified
 shape. As long as the view is not assigned to an array, no memory allocation or copy occurs. Broadcasting views should be
 built with the ``broadcast`` helper function.
 

--- a/docs/source/view.rst
+++ b/docs/source/view.rst
@@ -15,7 +15,7 @@ Sliced views
 
 Sliced views consist of the combination of the ``xexpression`` to adapt, and a list of ``slice`` s that specify how
 the shape must be adapted. Sliced views are implemented by the ``xview`` class. Objects of this type should not be
-instantiated directly, but though the ``make_xview`` helper function.
+instantiated directly, but though the ``view`` helper function.
 
 Slices can be specified in the following ways:
 
@@ -35,19 +35,19 @@ Slices can be specified in the following ways:
     xt::xarray<int> a(shape);
     
     // View with same number of dimensions
-    auto v1 = xt::make_xview(a, xt::range(1, 3), xt:all(), xt::range(1, 3));
+    auto v1 = xt::view(a, xt::range(1, 3), xt:all(), xt::range(1, 3));
     // => v1.shape() = { 2, 2, 2 }
     // => v1(0, 0, 0) = a(1, 0, 1)
     // => v1(1, 1, 1) = a(2, 1, 2)
 
     // View reducing the number of dimensions
-    auto v2 = xt::make_xview(a, 1, xt::all(), xt::range(0, 4, 2));
+    auto v2 = xt::view(a, 1, xt::all(), xt::range(0, 4, 2));
     // => v1.shape() = { 2, 2 }
     // => v1(0, 0) = a(1, 0, 0)
     // => v1(1, 1) = a(1, 1, 2)
 
     // View increasing the number of dimensions
-    auto v3 = xt::make_xview(a, xt::all(), xt::all(), xt::newaxis(), xt::all());
+    auto v3 = xt::view(a, xt::all(), xt::all(), xt::newaxis(), xt::all());
     // => v1.shape() = { 3, 2, 1, 4 }
     // => v1(0, 0, 0, 0) = a(0, 0, 0)
 
@@ -63,7 +63,7 @@ you are actually also altering the underlying expression.
     std::vector<size_t> shape = {3, 2, 4};
     xt::xarray<int> a(shape, 0);
 
-    auto v1 = xt::make_xview(a, 1, xt::all(), xt::range(1, 3));
+    auto v1 = xt::view(a, 1, xt::all(), xt::range(1, 3));
     v1(0, 0) = 1;
     // => a(1, 0, 1) = 1
 

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -61,6 +61,8 @@ namespace xt
      *
      * @tparam CT the closure type of the \ref xexpression to broadcast
      * @tparam X the type of the specified shape.
+     *
+     * @sa broadcast
      */
     template <class CT, class X>
     class xbroadcast : public xexpression<xbroadcast<CT, X>>

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -42,12 +42,16 @@ namespace xt
      * @class xindexview
      * @brief View into xexpression from vector of indices.
      *
-     * Th xindexview class implements a flat (1D) view into a multidimensional
+     * The xindexview class implements a flat (1D) view into a multidimensional
      * xexpression yielding the values at the indices of the index array.
+     * xindexview is not meant to be used directly, but only with the \ref index_view
+     * and \ref filter helper functions.
      *
-     * @tparam E the xexpression type underlying this view.
+     * @tparam E the xexpression type underlying this view
      * @tparam S the shape type of the view
      * @tparam I the index array type of the view
+     *
+     * @sa index_view, filter
      */
     template <class E, class S, class I>
     class xindexview : public xview_semantic<xindexview<E, S, I>>
@@ -229,7 +233,7 @@ namespace xt
      */
     //@{
     /**
-     * Constructs an xindexview, selecting the indices specified by \ref indices.
+     * Constructs an xindexview, selecting the indices specified by \a indices.
      * The resulting xexpression has a 1D shape with a length of n for n indices.
      * 
      * @param e the underlying xepxression for this view
@@ -335,7 +339,7 @@ namespace xt
     /**
      * Returns a reference to the element at the specified position in the xindexview.
      * @param first iterator starting the sequence of indices
-     * @param second iterator ending the sequence of indices
+     * @param last iterator ending the sequence of indices
      * The number of indices in the squence should be equal to or greater 1.
      */
     template <class E, class S, class I>
@@ -684,9 +688,9 @@ namespace xt
     }
 
     /**
-     * @brief create an indexview from a container of indices.
+     * @brief creates an indexview from a container of indices.
      *        
-     * Returns a 1D view with the elements at \ref indices selected.
+     * Returns a 1D view with the elements at \a indices selected.
      *
      * @param e the underlying xexpression
      * @param indices the indices to select
@@ -705,14 +709,6 @@ namespace xt
         return xindexview<E, std::array<std::size_t, 1>, I>(e, std::forward<I>(indices));
     }
 
-    /**
-     * @brief create an indexview from a initializer list or a static array of indices.
-     *        
-     * Returns a 1D view with the elements at \ref indices selected.
-     *
-     * @param e the underlying xexpression
-     * @param indices the indices to select
-     */
     template <class E, std::size_t L>
     auto inline index_view(E& e, const xindex(&indices)[L]) noexcept
     {
@@ -720,13 +716,13 @@ namespace xt
     }
 
     /**
-     * @brief create a view into \ref e filtered by \ref condition.
+     * @brief creates a view into \a e filtered by \a condition.
      *        
-     * Returns a 1D view with the elements selected where \ref condition evaluates to \em true.
-     * This is equivalent to \verbatim{index_view(e, where(condition));}
+     * Returns a 1D view with the elements selected where \a condition evaluates to \em true.
+     * This is equivalent to \verbatim{index_view(e, where(condition));}\endverbatim
      * 
      * @param e the underlying xexpression
-     * @param condition xexpression with shape of \ref e which selects indices
+     * @param condition xexpression with shape of \a e which selects indices
      *
      * \code{.cpp}
      * xarray<double> a = {{1,5,3}, {4,5,6}};

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -693,14 +693,14 @@ namespace xt
      * 
      * \code{.cpp}
      * xarray<double> a = {{1,5,3}, {4,5,6}};
-     * b = make_xindexview(a, {{0, 0}, {1, 0}, {1, 1}});
+     * b = index_view(a, {{0, 0}, {1, 0}, {1, 1}});
      * std::cout << b << std::endl; // {1, 4, 5}
      * b += 100;
      * std::cout << a << std::endl; // {{101, 5, 3}, {104, 105, 6}}
      * \endcode
      */
     template <class E, class I = std::vector<xindex>>
-    auto inline make_xindexview(E& e, I&& indices) noexcept
+    auto inline index_view(E& e, I&& indices) noexcept
     {
         return xindexview<E, std::array<std::size_t, 1>, I>(e, std::forward<I>(indices));
     }
@@ -714,7 +714,7 @@ namespace xt
      * @param indices the indices to select
      */
     template <class E, std::size_t L>
-    auto inline make_xindexview(E& e, const xindex(&indices)[L]) noexcept
+    auto inline index_view(E& e, const xindex(&indices)[L]) noexcept
     {
         return xindexview<E, std::array<std::size_t, 1>, std::array<xindex, L>>(e, to_array(indices));
     }
@@ -723,19 +723,19 @@ namespace xt
      * @brief create a view into \ref e filtered by \ref condition.
      *        
      * Returns a 1D view with the elements selected where \ref condition evaluates to \em true.
-     * This is equivalent to \verbatim{make_xindexview(e, where(condition));}
+     * This is equivalent to \verbatim{index_view(e, where(condition));}
      * 
      * @param e the underlying xexpression
      * @param condition xexpression with shape of \ref e which selects indices
      *
      * \code{.cpp}
      * xarray<double> a = {{1,5,3}, {4,5,6}};
-     * b = make_xfilter(a, a >= 5);
+     * b = filter(a, a >= 5);
      * std::cout << b << std::endl; // {5, 5, 6}
      * \endcode
      */
     template <class E, class O>
-    auto inline make_xfilter(E& e, O&& condition) noexcept
+    auto inline filter(E& e, O&& condition) noexcept
     {
         auto indices = where(std::forward<O>(condition));
         return xindexview<E, std::vector<std::size_t>, decltype(indices)>(e, std::move(indices));

--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -45,7 +45,7 @@ namespace xt
                     out << '{';
                     for (;i != e.shape()[0] - 1; ++i)
                     {
-                        xout<I - 1>::output(out, make_xview(e, i), blanks + 1) << ',';
+                        xout<I - 1>::output(out, view(e, i), blanks + 1) << ',';
                         if (I == 1 || e.dimension() == 1)
                         {
                              out << ' ';
@@ -55,7 +55,7 @@ namespace xt
                              out << std::endl << indents;
                         }
                     }
-                    xout<I - 1>::output(out, make_xview(e, i), blanks + 1) << '}';
+                    xout<I - 1>::output(out, view(e, i), blanks + 1) << '}';
                 }
                 return out;
             }

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -396,11 +396,11 @@ namespace xt
     }
 
     /**
-     * @function nonzero(const T& arr)
+     * @ingroup logical_operators
      * @brief return vector of indices where T is not zero
      * 
      * @param arr input array
-     * @return vector of \ref index_types where arr is not equal to zero
+     * @return vector of \a index_types where arr is not equal to zero
      */
     template <class T>
     inline auto nonzero(const T& arr)
@@ -442,12 +442,12 @@ namespace xt
     }
 
     /**
-     * @function where(const T& condition)
+     * @ingroup logical_operators
      * @brief return vector of indices where condition is true
-     *        (equivalent to \ref nonzero(conditition))
+     *        (equivalent to \a nonzero(condition))
      * 
      * @param condition input array
-     * @return vector of \ref index_types where arr is not equal to zero
+     * @return vector of \a index_types where condition is not equal to zero
      */
     template <class T>
     inline auto where(const T& condition)

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -80,10 +80,10 @@ namespace xt
 
     /**
      * Returns a slice representing an interval, to
-     * be used as an argument of make_xview function.
+     * be used as an argument of view function.
      * @param min the first index of the interval
      * @param max the last index of the interval
-     * @sa make_xview
+     * @sa view
      */
     template <class T>
     inline auto range(T min, T max) noexcept
@@ -120,11 +120,11 @@ namespace xt
 
     /**
      * Returns a slice representing an interval, to
-     * be used as an argument of make_xview function.
+     * be used as an argument of view function.
      * @param min the first index of the interval
      * @param max the last index of the interval
      * @param step the space between two indices
-     * @sa make_xview
+     * @sa view
      */
     template <class T>
     inline auto range(T min, T max, T step) noexcept
@@ -163,8 +163,8 @@ namespace xt
 
     /**
      * Returns a slice representing a full dimension,
-     * to be used as an argument of make_xview function.
-     * @sa make_xview
+     * to be used as an argument of view function.
+     * @sa view
      */
     inline auto all() noexcept
     {
@@ -197,8 +197,8 @@ namespace xt
 
     /**
     * Returns a slice representing a new axis of length one,
-    * to be used as an argument of make_xview function.
-    * @sa make_xview
+    * to be used as an argument of view function.
+    * @sa view
     */
     inline auto newaxis() noexcept
     {

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -48,7 +48,8 @@ namespace xt
      *
      * The xview class implements a multidimensional view with tensor
      * semantic. It is used to adapt the shape of an xexpression without
-     * changing it.
+     * changing it. xview is not meant to be used directly, but
+     * only with the \ref view helper functions.
      *
      * @tparam E the expression type to adapt
      * @tparam S the slices type describing the shape adaptation

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -53,7 +53,7 @@ namespace xt
      * @tparam E the expression type to adapt
      * @tparam S the slices type describing the shape adaptation
      *
-     * @sa make_xview, range, all, newaxis
+     * @sa view, range, all, newaxis
      */
     template <class E, class... S>
     class xview : public xview_semantic<xview<E, S...>>
@@ -195,7 +195,7 @@ namespace xt
     };
 
     template <class E, class... S>
-    xview<E, get_slice_type<E, S>...> make_xview(E& e, S&&... slices);
+    xview<E, get_slice_type<E, S>...> view(E& e, S&&... slices);
 
     /*****************************
      * xview_stepper declaration *
@@ -298,10 +298,10 @@ namespace xt
     /**
      * Constructs a view on the specified xexpression.
      * Users should not call directly this constructor but
-     * use the make_xview function instead.
+     * use the view function instead.
      * @param e the xexpression to adapt
      * @param slices the slices list describing the view
-     * @sa make_xview
+     * @sa view
      */
     template <class E, class... S>
     template <class... SL>
@@ -574,7 +574,7 @@ namespace xt
      * @sa range, all, newaxis
      */
     template <class E, class... S>
-    inline xview<E, get_slice_type<E, S>...> make_xview(E& e, S&&... slices)
+    inline xview<E, get_slice_type<E, S>...> view(E& e, S&&... slices)
     {
         return detail::make_view_impl(e, std::make_index_sequence<sizeof...(S)>(), std::forward<S>(slices)...);
     }

--- a/notebooks/xtensor.ipynb
+++ b/notebooks/xtensor.ipynb
@@ -167,7 +167,7 @@
     "xt::xarray<double> arr2\n",
     "  {5.0, 6.0, 7.0};\n",
     "\n",
-    "std::cout << xt::make_xview(arr1, 1) + arr2;;"
+    "std::cout << xt::view(arr1, 1) + arr2;;"
    ]
   },
   {

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -22,7 +22,7 @@ namespace xt
     {
         xarray<double> e = xt::random::rand<double>({3, 3});
         xarray<double> e_copy = e;
-        auto v = make_xindexview(e, {{1, 1}, {1, 2}, {2, 2}});
+        auto v = index_view(e, {{1, 1}, {1, 2}, {2, 2}});
 
         using shape_type = typename decltype(v)::shape_type;
         EXPECT_EQ(shape_type{3}, v.shape());
@@ -55,7 +55,7 @@ namespace xt
     TEST(xindexview, boolean)
     {
         xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
-        auto v = make_xfilter(e, e > 0);
+        auto v = filter(e, e > 0);
         EXPECT_EQ(1, v(0));
 
         v += 2;
@@ -67,7 +67,7 @@ namespace xt
         EXPECT_EQ(6, e(2, 2));
 
         xarray<double> e2 = random::rand<double>({3, 3, 3, 3});
-        auto v2 = make_xfilter(e2, e2 > 0.5);
+        auto v2 = filter(e2, e2 > 0.5);
         v2 *= 0;
         EXPECT_TRUE(!any(e2 > 0.5));
     }
@@ -76,7 +76,7 @@ namespace xt
     {
         xarray<double> e = xt::random::rand<double>({3, 3});
         auto fn = e * 3 - 120;
-        auto v = make_xindexview(fn, {{1, 1}, {1, 2}, {2, 2}});
+        auto v = index_view(fn, {{1, 1}, {1, 2}, {2, 2}});
         EXPECT_EQ(fn(1, 1), v(0));
         EXPECT_EQ(fn(1, 2), v[{1}]);
 
@@ -94,8 +94,8 @@ namespace xt
     TEST(xindexview, view_on_view)
     {
         xarray<double> e = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
-        auto v = make_xfilter(e, e > 0);
-        auto v_on_v = make_xview(v, 1);
+        auto v = filter(e, e > 0);
+        auto v_on_v = view(v, 1);
         v_on_v(0) = 10;
         EXPECT_EQ(10, e(1, 1));
     }

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -45,8 +45,8 @@ namespace xt
                          {5, 6, 7, 8},
                          {9, 10, 11, 12}};
 
-        auto v_1 = make_xview(e, 1, xt::all());
-        auto v_2 = make_xview(e, xt::all(), 1);
+        auto v_1 = view(e, 1, xt::all());
+        auto v_2 = view(e, xt::all(), 1);
 
         std::stringstream out_1;
         out_1 << v_1;

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -24,38 +24,38 @@ namespace xt
         std::vector<double> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, 1, range(1, 4));
+        auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
         EXPECT_EQ(a(1, 2), view1(1));
         EXPECT_EQ(1, view1.dimension());
 
-        auto view0 = make_xview(a, 0, range(0, 3));
+        auto view0 = view(a, 0, range(0, 3));
         EXPECT_EQ(a(0, 0), view0(0));
         EXPECT_EQ(a(0, 1), view0(1));
         EXPECT_EQ(1, view0.dimension());
         EXPECT_EQ(3, view0.shape()[0]);
 
-        auto view2 = make_xview(a, range(0, 2), 2);
+        auto view2 = view(a, range(0, 2), 2);
         EXPECT_EQ(a(0, 2), view2(0));
         EXPECT_EQ(a(1, 2), view2(1));
         EXPECT_EQ(1, view2.dimension());
         EXPECT_EQ(2, view2.shape()[0]);
 
-        auto view4 = make_xview(a, 1);
+        auto view4 = view(a, 1);
         EXPECT_EQ(1, view4.dimension());
         EXPECT_EQ(4, view4.shape()[0]);
 
-        auto view5 = make_xview(view4, 1);
+        auto view5 = view(view4, 1);
         EXPECT_EQ(0, view5.dimension());
         EXPECT_EQ(0, view5.shape().size());
 
-        auto view6 = make_xview(a, 1, all());
+        auto view6 = view(a, 1, all());
         EXPECT_EQ(a(1, 0), view6(0));
         EXPECT_EQ(a(1, 1), view6(1));
         EXPECT_EQ(a(1, 2), view6(2));
         EXPECT_EQ(a(1, 3), view6(3));
 
-        auto view7 = make_xview(a, all(), 2);
+        auto view7 = view(a, all(), 2);
         EXPECT_EQ(a(0, 2), view7(0));
         EXPECT_EQ(a(1, 2), view7(1));
         EXPECT_EQ(a(2, 2), view7(2));
@@ -83,7 +83,7 @@ namespace xt
         xarray<double> a(shape);
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, 1);
+        auto view1 = view(a, 1);
         EXPECT_EQ(2, view1.dimension());
         EXPECT_EQ(a(1, 0, 0), view1(0, 0));
         EXPECT_EQ(a(1, 0, 1), view1(0, 1));
@@ -124,7 +124,7 @@ namespace xt
                                   13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, range(0, 2), 1, range(1, 4));
+        auto view1 = view(a, range(0, 2), 1, range(1, 4));
         auto iter = view1.begin();
         auto iter_end = view1.end();
 
@@ -142,7 +142,7 @@ namespace xt
         ++iter;
         EXPECT_EQ(iter, iter_end);
 
-        auto view2 = make_xview(view1, range(0, 2), range(1, 3));
+        auto view2 = view(view1, range(0, 2), range(1, 3));
         auto iter2 = view2.begin();
         auto iter_end2 = view2.end();
 
@@ -169,7 +169,7 @@ namespace xt
         std::vector<int> data2 = { 1, 2, 3 };
         std::copy(data2.cbegin(), data2.cend(), b.storage_begin());
 
-        auto func = make_xview(a, 1, range(1, 4)) + b;
+        auto func = view(a, 1, range(1, 4)) + b;
         auto iter = func.begin();
         auto iter_end = func.end();
 
@@ -188,7 +188,7 @@ namespace xt
         std::vector<int> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, 1, range(1, 4));
+        auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
         EXPECT_EQ(a(1, 2), view1(1));
         EXPECT_EQ(1, view1.dimension());
@@ -213,7 +213,7 @@ namespace xt
     {
         xtensor<double, 1> arr1{ {2} };
         std::fill(arr1.begin(), arr1.end(), 6);
-        auto view = xt::make_xview(arr1, 0);
+        auto view = xt::view(arr1, 0);
         auto iter = view.begin();
         auto iter_end = view.end();
         ++iter;
@@ -225,7 +225,7 @@ namespace xt
         const xtensor<double, 3> arr{ {1, 2, 3}, 2.5 };
         xtensor<double, 2> arr2{ {2, 3}, 0.0 };
         xtensor<double, 2> ref{ {2, 3}, 2.5 };
-        arr2 = xt::make_xview(arr, 0);
+        arr2 = xt::view(arr, 0);
         EXPECT_EQ(ref, arr2);
     }
 
@@ -248,7 +248,7 @@ namespace xt
         std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, all(), newaxis(), all());
+        auto view1 = view(a, all(), newaxis(), all());
         EXPECT_EQ(a(1, 1), view1(1, 0, 1));
         EXPECT_EQ(a(1, 2), view1(1, 0, 2));
         EXPECT_EQ(3, view1.dimension());
@@ -256,7 +256,7 @@ namespace xt
         EXPECT_EQ(1, view1.shape()[1]);
         EXPECT_EQ(4, view1.shape()[2]);
 
-        auto view2 = make_xview(a, all(), all(), newaxis());
+        auto view2 = view(a, all(), all(), newaxis());
         EXPECT_EQ(a(1, 1), view2(1, 1, 0));
         EXPECT_EQ(a(1, 2), view2(1, 2, 0));
         EXPECT_EQ(3, view2.dimension());
@@ -264,22 +264,22 @@ namespace xt
         EXPECT_EQ(4, view2.shape()[1]);
         EXPECT_EQ(1, view2.shape()[2]);
 
-        auto view3 = make_xview(a, 1, newaxis(), all());
+        auto view3 = view(a, 1, newaxis(), all());
         EXPECT_EQ(a(1, 1), view3(0, 1));
         EXPECT_EQ(a(1, 2), view3(0, 2));
         EXPECT_EQ(2, view3.dimension());
 
-        auto view4 = make_xview(a, 1, all(), newaxis());
+        auto view4 = view(a, 1, all(), newaxis());
         EXPECT_EQ(a(1, 1), view4(1, 0));
         EXPECT_EQ(a(1, 2), view4(2, 0));
         EXPECT_EQ(2, view4.dimension());
 
-        auto view5 = make_xview(view1, 1);
+        auto view5 = view(view1, 1);
         EXPECT_EQ(a(1, 1), view5(0, 1));
         EXPECT_EQ(a(1, 2), view5(0, 2));
         EXPECT_EQ(2, view5.dimension());
 
-        auto view6 = make_xview(view2, 1);
+        auto view6 = view(view2, 1);
         EXPECT_EQ(a(1, 1), view6(1, 0));
         EXPECT_EQ(a(1, 2), view6(2, 0));
         EXPECT_EQ(2, view6.dimension());
@@ -298,7 +298,7 @@ namespace xt
         std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         std::copy(data.cbegin(), data.cend(), a.storage_begin());
 
-        auto view1 = make_xview(a, all(), all(), newaxis());
+        auto view1 = view(a, all(), all(), newaxis());
         auto iter1 = view1.begin();
         auto iter1_end = view1.end();
 
@@ -328,7 +328,7 @@ namespace xt
         ++iter1;
         EXPECT_EQ(iter1_end, iter1);
 
-        auto view2 = make_xview(a, all(), newaxis(), all());
+        auto view2 = view(a, all(), newaxis(), all());
         auto iter2 = view2.begin();
         auto iter2_end = view2.end();
 
@@ -371,8 +371,8 @@ namespace xt
         data_end += 4;
         std::copy(data.cbegin(), data_end, b.storage_begin());
 
-        auto view = make_xview(b, newaxis(), all());
-        xarray<double> res = a + view;
+        auto v = view(b, newaxis(), all());
+        xarray<double> res = a + v;
 
         std::vector<double> data2{ 2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16 };
         xarray<double> expected(shape);

--- a/test/test_xview_semantic.cpp
+++ b/test/test_xview_semantic.cpp
@@ -58,13 +58,13 @@ namespace xt
     TEST(xview_semantic, a_plus_b)
     {
         view_op_tester<std::plus<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major + row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa + viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -72,8 +72,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major + column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa + viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -81,8 +81,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major + central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa + viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -90,8 +90,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major + unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa + viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -100,13 +100,13 @@ namespace xt
     TEST(xview_semantic, a_minus_b)
     {
         view_op_tester<std::minus<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major - row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa - viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -114,8 +114,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major - column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa - viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -123,8 +123,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major - central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa - viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -132,8 +132,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major - unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa - viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -142,13 +142,13 @@ namespace xt
     TEST(xview_semantic, a_times_b)
     {
         view_op_tester<std::multiplies<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major * row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa * viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -156,8 +156,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major * column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa * viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -165,8 +165,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major * central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa * viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -174,8 +174,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major * unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa * viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -184,13 +184,13 @@ namespace xt
     TEST(xview_semantic, a_divdide_by_b)
     {
         view_op_tester<std::divides<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major / row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa / viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -198,8 +198,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major / column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa / viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -207,8 +207,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major / central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa / viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -216,8 +216,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major / unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb = viewa / viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -226,13 +226,13 @@ namespace xt
     TEST(xview_semantic, a_plus_equal_b)
     {
         view_op_tester<std::plus<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major += row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb += viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -240,8 +240,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major += column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb += viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -249,8 +249,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major += central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb += viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -258,8 +258,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major += unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb += viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -268,13 +268,13 @@ namespace xt
     TEST(xview_semantic, a_minus_equal_b)
     {
         view_op_tester<std::minus<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major -= row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb -= viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -282,8 +282,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major -= column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb -= viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -291,8 +291,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major -= central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb -= viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -300,8 +300,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major -= unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb -= viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -310,13 +310,13 @@ namespace xt
     TEST(xview_semantic, a_times_equal_b)
     {
         view_op_tester<std::multiplies<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major *= row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb *= viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -324,8 +324,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major *= column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb *= viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -333,8 +333,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major *= central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb *= viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -342,8 +342,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major *= unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb *= viewua;
             EXPECT_EQ(t.vres_ru, b);
         }
@@ -352,13 +352,13 @@ namespace xt
     TEST(xview_semantic, a_divide_by_equal_b)
     {
         view_op_tester<std::divides<>> t;
-        auto viewa = make_xview(t.a, t.x_slice, t.y_slice, t.z_slice);
+        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major /= row_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewra = make_xview(t.ra, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewra = view(t.ra, t.x_slice, t.y_slice, t.z_slice);
             viewb /= viewra;
             EXPECT_EQ(t.vres_rr, b);
         }
@@ -366,8 +366,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major /= column_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewca = make_xview(t.ca, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewca = view(t.ca, t.x_slice, t.y_slice, t.z_slice);
             viewb /= viewca;
             EXPECT_EQ(t.vres_rc, b);
         }
@@ -375,8 +375,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major /= central_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewcta = make_xview(t.cta, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewcta = view(t.cta, t.x_slice, t.y_slice, t.z_slice);
             viewb /= viewcta;
             EXPECT_EQ(t.vres_rct, b);
         }
@@ -384,8 +384,8 @@ namespace xt
         {
             SCOPED_TRACE("row_major /= unit_major");
             xarray<int> b = t.a;
-            auto viewb = make_xview(b, t.x_slice, t.y_slice, t.z_slice);
-            auto viewua = make_xview(t.ua, t.x_slice, t.y_slice, t.z_slice);
+            auto viewb = view(b, t.x_slice, t.y_slice, t.z_slice);
+            auto viewua = view(t.ua, t.x_slice, t.y_slice, t.z_slice);
             viewb /= viewua;
             EXPECT_EQ(t.vres_ru, b);
         }


### PR DESCRIPTION
Renamed the following functions:

- make_view => view
- make_xindexview => index_view
- make_xfilter => filter

That's may look less C++, but it's simpler.

Also added the documentation of xindexview that I accidentally dropped from the documentation PR.
@wolfv I added short descriptions of index views and filter views in the narrative documentation (that I accidentally forgot to add in the documentation PR), do not hesitate to submit PRs if you think it can be improved.