### PR TITLE
WIP Cleanup meta functions

### DIFF
--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -195,7 +195,7 @@ namespace xt
     template <class E, class S>
     inline auto broadcast(E&& e, const S& s) noexcept
     {
-        using broadcast_type = xbroadcast<xclosure<E>, S>;
+        using broadcast_type = xbroadcast<const_xclosure<E>, S>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
@@ -204,7 +204,7 @@ namespace xt
     template <class E, class I>
     inline auto broadcast(E&& e, std::initializer_list<I> s) noexcept
     {
-        using broadcast_type = xbroadcast<xclosure<E>, std::vector<std::size_t>>;
+        using broadcast_type = xbroadcast<const_xclosure<E>, std::vector<std::size_t>>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
@@ -212,7 +212,7 @@ namespace xt
     template <class E, class I, std::size_t L>
     inline auto broadcast(E&& e, const I(&s)[L]) noexcept
     {
-        using broadcast_type = xbroadcast<xclosure<E>, std::array<std::size_t, L>>;
+        using broadcast_type = xbroadcast<const_xclosure<E>, std::array<std::size_t, L>>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -71,7 +71,7 @@ namespace xt
     public:
 
         using self_type = xbroadcast<CT, X>;
-        using xexpression_type = typename std::decay<typename CT::type>::type;
+        using xexpression_type = std::decay_t<typename CT::type>;
 
         using value_type = typename xexpression_type::value_type;
         using reference = typename xexpression_type::reference;

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -71,7 +71,7 @@ namespace xt
     public:
 
         using self_type = xbroadcast<CT, X>;
-        using xexpression_type = std::decay_t<typename CT::type>;
+        using xexpression_type = std::decay_t<CT>;
 
         using value_type = typename xexpression_type::value_type;
         using reference = typename xexpression_type::reference;
@@ -88,7 +88,7 @@ namespace xt
         using const_storage_iterator = const_iterator;
 
         template <class S>
-        xbroadcast(typename CT::type e, S s) noexcept;
+        xbroadcast(CT e, S s) noexcept;
 
         size_type dimension() const noexcept;
         const shape_type & shape() const noexcept;
@@ -133,7 +133,7 @@ namespace xt
 
     private:
 
-        typename CT::type m_e;
+        CT m_e;
         shape_type m_shape;
     };
 
@@ -195,7 +195,7 @@ namespace xt
     template <class E, class S>
     inline auto broadcast(E&& e, const S& s) noexcept
     {
-        using broadcast_type = xbroadcast<const_xclosure<E>, S>;
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, S>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
@@ -204,7 +204,7 @@ namespace xt
     template <class E, class I>
     inline auto broadcast(E&& e, std::initializer_list<I> s) noexcept
     {
-        using broadcast_type = xbroadcast<const_xclosure<E>, std::vector<std::size_t>>;
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, std::vector<std::size_t>>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
@@ -212,7 +212,7 @@ namespace xt
     template <class E, class I, std::size_t L>
     inline auto broadcast(E&& e, const I(&s)[L]) noexcept
     {
-        using broadcast_type = xbroadcast<const_xclosure<E>, std::array<std::size_t, L>>;
+        using broadcast_type = xbroadcast<const_xclosure_t<E>, std::array<std::size_t, L>>;
         using shape_type = typename broadcast_type::shape_type;
         return broadcast_type(std::forward<E>(e), detail::forward_shape<shape_type>(s));
     }
@@ -235,7 +235,7 @@ namespace xt
      */
     template <class CT, class X>
     template <class S>
-    inline xbroadcast<CT, X>::xbroadcast(typename CT::type e, S s) noexcept
+    inline xbroadcast<CT, X>::xbroadcast(CT e, S s) noexcept
         : m_e(e), m_shape(std::move(s))
     {
         xt::broadcast_shape(e.shape(), m_shape);

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -163,6 +163,9 @@ namespace xt
         using type = xscalar<detail::closure_t<E>>;
     };
 
+    template <class E>
+    using xclosure_t = typename xclosure<E>::type;
+
     template <class E, class EN = void>
     struct const_xclosure
     {
@@ -174,7 +177,10 @@ namespace xt
     {
         using type = xscalar<detail::const_closure_t<E>>;
     };
-    
+ 
+    template <class E>
+    using const_xclosure_t = typename const_xclosure<E>::type;
+
     /***************
      * xvalue_type *
      ***************/

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -131,8 +131,8 @@ namespace xt
         struct const_closure
         {
             using type = typename std::conditional<std::is_lvalue_reference<S>::value,
-                                                   const typename std::decay<S>::type&,
-                                                   typename std::decay<S>::type>::type;
+                                                   const std::decay_t<S>&,
+                                                   std::decay_t<S>>::type;
         };
     }
 
@@ -143,7 +143,7 @@ namespace xt
     };
 
     template <class E>
-    struct xclosure<E, disable_xexpression<typename std::decay<E>::type>>
+    struct xclosure<E, disable_xexpression<std::decay_t<E>>>
     {
         using type = xscalar<typename detail::const_closure<E>::type>;
     };

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -128,24 +128,51 @@ namespace xt
     namespace detail
     {
         template <class S>
+        struct closure
+        {
+            using type = typename std::conditional<std::is_lvalue_reference<S>::value,
+                                                   std::conditional_t<std::is_const<S>::value,
+                                                                      const std::decay_t<S>&, std::decay_t<S>&>,
+                                                   std::decay_t<S>>::type;
+        };
+
+        template <class S>
+        using closure_t = typename closure<S>::type;
+
+        template <class S>
         struct const_closure
         {
             using type = typename std::conditional<std::is_lvalue_reference<S>::value,
                                                    const std::decay_t<S>&,
                                                    std::decay_t<S>>::type;
         };
+        
+        template <class S>
+        using const_closure_t = typename const_closure<S>::type;
     }
 
     template <class E, class EN = void>
     struct xclosure
     {
-        using type = typename detail::const_closure<E>::type;
+        using type = detail::closure_t<E>;
     };
 
     template <class E>
     struct xclosure<E, disable_xexpression<std::decay_t<E>>>
     {
-        using type = xscalar<typename detail::const_closure<E>::type>;
+        using type = xscalar<detail::closure_t<E>>;
+    };
+
+    template <class E, class EN = void>
+    struct const_xclosure
+    {
+        using type = detail::const_closure_t<E>;
+    };
+
+    template <class E>
+    struct const_xclosure<E, disable_xexpression<std::decay_t<E>>>
+    {
+        using type = xscalar<detail::const_closure_t<E>>;
     };
     
     /***************

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -107,17 +107,17 @@ namespace xt
         using const_reference = value_type;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using size_type = detail::common_size_type<std::decay_t<typename CT::type>...>;
-        using difference_type = detail::common_difference_type<std::decay_t<typename CT::type>...>;
+        using size_type = detail::common_size_type<std::decay_t<CT>...>;
+        using difference_type = detail::common_difference_type<std::decay_t<CT>...>;
 
-        using shape_type = promote_shape_t<typename std::decay_t<typename CT::type>::shape_type...>;
+        using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
 
         using const_stepper = xfunction_stepper<F, R, CT...>;
         using const_iterator = xiterator<const_stepper, shape_type>;
         using const_storage_iterator = xf_storage_iterator<F, R, CT...>;
 
         template <class Func>
-        xfunction(Func&& f, typename CT::type... e) noexcept;
+        xfunction(Func&& f, CT... e) noexcept;
 
         size_type dimension() const noexcept;
         const shape_type& shape() const;
@@ -176,7 +176,7 @@ namespace xt
         template <class Func, std::size_t... I>
         const_storage_iterator build_storage_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
 
-        std::tuple<typename CT::type...> m_e;
+        std::tuple<CT...> m_e;
         functor_type m_f;
         shape_type m_shape;
 
@@ -220,7 +220,7 @@ namespace xt
         reference deref_impl(std::index_sequence<I...>) const;
 
         const xfunction_type* p_f;
-        std::tuple<typename std::decay_t<typename CT::type>::const_storage_iterator...> m_it;
+        std::tuple<typename std::decay_t<CT>::const_storage_iterator...> m_it;
 
     };
 
@@ -274,7 +274,7 @@ namespace xt
         reference deref_impl(std::index_sequence<I...>) const;
 
         const xfunction_type* p_f;
-        std::tuple<typename std::decay_t<typename CT::type>::const_stepper...> m_it;
+        std::tuple<typename std::decay_t<CT>::const_stepper...> m_it;
     };
 
     template <class F, class R, class... CT>
@@ -301,7 +301,7 @@ namespace xt
      */
     template <class F, class R, class... CT>
     template <class Func>
-    inline xfunction<F, R, CT...>::xfunction(Func&& f, typename CT::type... e) noexcept
+    inline xfunction<F, R, CT...>::xfunction(Func&& f, CT... e) noexcept
         : m_e(e...), m_f(std::forward<Func>(f)), m_shape(make_sequence<shape_type>(dimension(), size_type(1)))
     {
         broadcast_shape(m_shape);

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -107,10 +107,10 @@ namespace xt
         using const_reference = value_type;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using size_type = detail::common_size_type<typename std::decay<typename CT::type>::type...>;
-        using difference_type = detail::common_difference_type<typename std::decay<typename CT::type>::type...>;
+        using size_type = detail::common_size_type<std::decay_t<typename CT::type>...>;
+        using difference_type = detail::common_difference_type<std::decay_t<typename CT::type>...>;
 
-        using shape_type = promote_shape_t<typename std::decay<typename CT::type>::type::shape_type...>;
+        using shape_type = promote_shape_t<typename std::decay_t<typename CT::type>::shape_type...>;
 
         using const_stepper = xfunction_stepper<F, R, CT...>;
         using const_iterator = xiterator<const_stepper, shape_type>;
@@ -220,7 +220,7 @@ namespace xt
         reference deref_impl(std::index_sequence<I...>) const;
 
         const xfunction_type* p_f;
-        std::tuple<typename std::decay<typename CT::type>::type::const_storage_iterator...> m_it;
+        std::tuple<typename std::decay_t<typename CT::type>::const_storage_iterator...> m_it;
 
     };
 
@@ -274,7 +274,7 @@ namespace xt
         reference deref_impl(std::index_sequence<I...>) const;
 
         const xfunction_type* p_f;
-        std::tuple<typename std::decay<typename CT::type>::type::const_stepper...> m_it;
+        std::tuple<typename std::decay_t<typename CT::type>::const_stepper...> m_it;
     };
 
     template <class F, class R, class... CT>

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -35,12 +35,12 @@ namespace xt
         }
 
         template <class... E>
-        using mf_type = common_value_type<typename std::decay<E>::type...> (*) (xvalue_type_t<typename std::decay<E>::type>...);
+        using mf_type = common_value_type<std::decay_t<E>...> (*) (xvalue_type_t<std::decay_t<E>>...);
 
         template <class... E>
-        using get_xfunction_free_type = std::enable_if_t<has_xexpression<typename std::decay<E>::type...>::value,
+        using get_xfunction_free_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
                                                          xfunction<mf_type<E...>,
-                                                                   common_value_type<typename std::decay<E>::type...>,
+                                                                   common_value_type<std::decay_t<E>...>,
                                                                    xclosure<E>...>>;
     }
 

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -30,7 +30,7 @@ namespace xt
         template <class R, class... Args, class... E>
         inline auto make_xfunction(R (*f) (Args...), E&&... e) noexcept
         {
-            using type = xfunction<R (*) (Args...), R, const_xclosure<E>...>;
+            using type = xfunction<R (*) (Args...), R, const_xclosure_t<E>...>;
             return type(f, std::forward<E>(e)...);
         }
 
@@ -41,7 +41,7 @@ namespace xt
         using get_xfunction_free_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
                                                          xfunction<mf_type<E...>,
                                                                    common_value_type<std::decay_t<E>...>,
-                                                                   const_xclosure<E>...>>;
+                                                                   const_xclosure_t<E>...>>;
     }
 
     /*******************

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -30,7 +30,7 @@ namespace xt
         template <class R, class... Args, class... E>
         inline auto make_xfunction(R (*f) (Args...), E&&... e) noexcept
         {
-            using type = xfunction<R (*) (Args...), R, xclosure<E>...>;
+            using type = xfunction<R (*) (Args...), R, const_xclosure<E>...>;
             return type(f, std::forward<E>(e)...);
         }
 
@@ -41,7 +41,7 @@ namespace xt
         using get_xfunction_free_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
                                                          xfunction<mf_type<E...>,
                                                                    common_value_type<std::decay_t<E>...>,
-                                                                   xclosure<E>...>>;
+                                                                   const_xclosure<E>...>>;
     }
 
     /*******************

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -53,7 +53,7 @@ namespace xt
         {
             using functor_type = F<common_value_type<std::decay_t<E>...>>;
             using result_type = typename functor_type::result_type;
-            using type = xfunction<functor_type, result_type, const_xclosure<E>...>;
+            using type = xfunction<functor_type, result_type, const_xclosure_t<E>...>;
             return type(functor_type(), std::forward<E>(e)...);
         }
 
@@ -61,7 +61,7 @@ namespace xt
         using get_xfunction_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
                                                     xfunction<F<common_value_type<std::decay_t<E>...>>,
                                                               typename F<common_value_type<std::decay_t<E>...>>::result_type,
-                                                              const_xclosure<E>...>>;
+                                                              const_xclosure_t<E>...>>;
     }
 
     /*************

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -53,7 +53,7 @@ namespace xt
         {
             using functor_type = F<common_value_type<std::decay_t<E>...>>;
             using result_type = typename functor_type::result_type;
-            using type = xfunction<functor_type, result_type, xclosure<E>...>;
+            using type = xfunction<functor_type, result_type, const_xclosure<E>...>;
             return type(functor_type(), std::forward<E>(e)...);
         }
 
@@ -61,7 +61,7 @@ namespace xt
         using get_xfunction_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
                                                     xfunction<F<common_value_type<std::decay_t<E>...>>,
                                                               typename F<common_value_type<std::decay_t<E>...>>::result_type,
-                                                              xclosure<E>...>>;
+                                                              const_xclosure<E>...>>;
     }
 
     /*************

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -51,16 +51,16 @@ namespace xt
         template <template <class...> class F, class... E>
         inline auto make_xfunction(E&&... e) noexcept
         {
-            using functor_type = F<common_value_type<typename std::decay<E>::type...>>;
+            using functor_type = F<common_value_type<std::decay_t<E>...>>;
             using result_type = typename functor_type::result_type;
             using type = xfunction<functor_type, result_type, xclosure<E>...>;
             return type(functor_type(), std::forward<E>(e)...);
         }
 
         template <template <class...> class F, class... E>
-        using get_xfunction_type = std::enable_if_t<has_xexpression<typename std::decay<E>::type...>::value,
-                                                    xfunction<F<common_value_type<typename std::decay<E>::type...>>,
-                                                              typename F<common_value_type<typename std::decay<E>::type...>>::result_type,
+        using get_xfunction_type = std::enable_if_t<has_xexpression<std::decay_t<E>...>::value,
+                                                    xfunction<F<common_value_type<std::decay_t<E>...>>,
+                                                              typename F<common_value_type<std::decay_t<E>...>>::result_type,
                                                               xclosure<E>...>>;
     }
 
@@ -469,7 +469,7 @@ namespace xt
     inline bool any(E&& e)
     {
         return std::any_of(e.storage_cbegin(), e.storage_cend(), 
-                           [](const typename std::decay<E>::type::value_type& el) { return el; });
+                           [](const typename std::decay_t<E>::value_type& el) { return el; });
     }
 
     /**
@@ -485,7 +485,7 @@ namespace xt
     inline bool all(E&& e)
     {
         return std::all_of(e.storage_cbegin(), e.storage_cend(),
-                           [](const typename std::decay<E>::type::value_type& el) { return el; });
+                           [](const typename std::decay_t<E>::value_type& el) { return el; });
     }
 }
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -36,7 +36,7 @@ namespace xt
 
     public:
 
-        using value_type = typename std::decay<CT>::type;
+        using value_type = std::decay_t<CT>;
         using reference = value_type&;
         using const_reference = const value_type&;
         using pointer = value_type*;

--- a/include/xtensor/xvectorize.hpp
+++ b/include/xtensor/xvectorize.hpp
@@ -30,7 +30,7 @@ namespace xt
         // Yes, really. std::enable_if<true> as a workaround to MSVC madness.
         // (buggy error C2210 when mixing parameter packs and template aliases)
         template <class... E>
-        using xfunction_type = std::enable_if_t<true, xfunction<F, R, xclosure<E>...>>;
+        using xfunction_type = std::enable_if_t<true, xfunction<F, R, xclosure_t<E>...>>;
 
         template <class Func>
         explicit xvectorizer(Func&& f);


### PR DESCRIPTION
To support the editing `xviews` on `xscalar`, we need to have non-const accessors on xscalar, in the case of a non-const closure type.