### PR TITLE
iterator performance

### DIFF
--- a/docs/source/expression.rst
+++ b/docs/source/expression.rst
@@ -147,12 +147,12 @@ Element access
 Iterators
 ~~~~~~~~~
 
-- ``begin()`` and ``end()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the expression. The order of the iteration is ``row-major``
+- ``xbegin()`` and ``xend()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the expression. The order of the iteration is ``row-major``
   in that the index of the last dimension is incremented first. This iterator pair permits to use algorithms of the STL with ``xexpression`` as if they were simple containers.
-- ``xbegin()`` and ``xend()`` are similar but take a *broadcasting shape* as an argument. Elements are iterated upon in a row-major way, but certain dimensions are repeated to match the
-  provided shape as per the rules described above. For an expression ``e``, ``e.xbegin(e.shape())`` and ``e.begin()`` are equivalent.
-- ``storage_begin()`` and ``storage_end()`` return iterators on the buffer containing the elements of the ``xexpression`` when it is an in-memory container. Otherwise, it is similar
-  to ``begin()`` and ``end()``. For in-memory containers, the iteration is done directly on the buffer and may be faster than the one provided by ``begin()`` / ``end()`` .
+- ``xbegin(shape)`` and ``xend(shape)`` are similar but take a *broadcasting shape* as an argument. Elements are iterated upon in a row-major way, but certain dimensions are
+  repeated to match the provided shape as per the rules described above. For an expression ``e``, ``e.xbegin(e.shape())`` and ``e.begin()`` are equivalent.
+- ``begin()`` and ``end()`` return iterators on the buffer containing the elements of the ``xexpression`` when it is an in-memory container. Otherwise, they are similar
+  to ``xbegin()`` and ``xend()``. For in-memory containers, the iteration is done directly on the buffer and may be faster than the one provided by ``xbegin()`` / ``xend()`` .
 
 .. _NumPy: http://www.numpy.org
 .. _libdynd: http://libdynd.org

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -103,7 +103,7 @@ namespace xt
         bool trivial_broadcast = trivial && detail::is_trivial_broadcast(de1, de2);
         if(trivial_broadcast)
         {
-            std::copy(de2.storage_cbegin(), de2.storage_cend(), de1.storage_begin());
+            std::copy(de2.cbegin(), de2.cend(), de1.begin());
         }
         else
         {
@@ -161,7 +161,7 @@ namespace xt
     inline void scalar_computed_assign(xexpression<E1>& e1, const E2& e2, F&& f)
     {
         E1& d = e1.derived_cast();
-        std::transform(d.storage_cbegin(), d.storage_cend(), d.storage_begin(),
+        std::transform(d.cbegin(), d.cend(), d.begin(),
                 [e2, &f](const auto& v) { return f(v, e2); });
     }
 

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -77,11 +77,11 @@ namespace xt
         using const_stepper = typename xexpression_type::const_stepper;
         using stepper = const_stepper;
 
-        using const_iterator = xiterator<const_stepper, shape_type>;
-        using iterator = const_iterator;
+        using const_broadcast_iterator = xiterator<const_stepper, shape_type*>;
+        using broadcast_iterator = const_broadcast_iterator;
 
-        using const_storage_iterator = const_iterator;
-        using storage_iterator = const_storage_iterator;
+        using const_iterator = const_broadcast_iterator;
+        using iterator = const_iterator;
 
         template <class S>
         xbroadcast(CT e, S&& s) noexcept;
@@ -107,6 +107,11 @@ namespace xt
         const_iterator cbegin() const noexcept;
         const_iterator cend() const noexcept;
 
+        const_broadcast_iterator xbegin() const noexcept;
+        const_broadcast_iterator xend() const noexcept;
+        const_broadcast_iterator cxbegin() const noexcept;
+        const_broadcast_iterator cxend() const noexcept;
+
         template <class S>
         xiterator<const_stepper, S> xbegin(const S& shape) const noexcept;
         template <class S>
@@ -120,12 +125,6 @@ namespace xt
         const_stepper stepper_begin(const S& shape) const noexcept;
         template <class S>
         const_stepper stepper_end(const S& shape) const noexcept;
-
-        const_storage_iterator storage_begin() const noexcept;
-        const_storage_iterator storage_end() const noexcept;
-
-        const_storage_iterator storage_cbegin() const noexcept;
-        const_storage_iterator storage_cend() const noexcept;
 
     private:
 
@@ -300,14 +299,58 @@ namespace xt
     /**
      * @name Iterators
      */
+    /**
+     * Returns an iterator to the first element of the buffer
+     * containing the elements of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::begin() const noexcept -> const_iterator
+    {
+        return cxbegin();
+    }
+
+    /**
+     * Returns an iterator to the element following the last
+     * element of the buffer containing the elements of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::end() const noexcept -> const_iterator
+    {
+        return cxend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::cbegin() const noexcept -> const_iterator
+    {
+        return cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::cend() const noexcept -> const_iterator
+    {
+        return cxend();
+    }
+    //@}
+
+    /**
+     * @name Broadcast iterators
+     */
     //@{
     /**
      * Returns a constant iterator to the first element of the expression.
      */
     template <class CT, class X>
-    inline auto xbroadcast<CT, X>::begin() const noexcept -> const_iterator
+    inline auto xbroadcast<CT, X>::xbegin() const noexcept -> const_broadcast_iterator
     {
-        return cxbegin(shape());
+        return const_broadcast_iterator(stepper_begin(m_shape), &m_shape);
     }
 
     /**
@@ -315,18 +358,18 @@ namespace xt
      * of the expression.
      */
     template <class CT, class X>
-    inline auto xbroadcast<CT, X>::end() const noexcept -> const_iterator
+    inline auto xbroadcast<CT, X>::xend() const noexcept -> const_broadcast_iterator
     {
-        return cxend(shape());
+        return const_broadcast_iterator(stepper_end(m_shape), &m_shape);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
      */
     template <class CT, class X>
-    inline auto xbroadcast<CT, X>::cbegin() const noexcept -> const_iterator
+    inline auto xbroadcast<CT, X>::cxbegin() const noexcept -> const_broadcast_iterator
     {
-        return cxbegin(shape());
+        return xbegin();
     }
 
     /**
@@ -334,9 +377,9 @@ namespace xt
      * of the expression.
      */
     template <class CT, class X>
-    inline auto xbroadcast<CT, X>::cend() const noexcept -> const_iterator
+    inline auto xbroadcast<CT, X>::cxend() const noexcept -> const_broadcast_iterator
     {
-        return cxend(shape());
+        return xend();
     }
 
     /**
@@ -407,50 +450,6 @@ namespace xt
         // Could check if (broadcastable(shape, m_shape)
         return m_e.stepper_end(shape);
     }
-
-    /**
-     * @name Storage iterators
-     */
-    /**
-     * Returns an iterator to the first element of the buffer
-     * containing the elements of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::storage_begin() const noexcept -> const_storage_iterator
-    {
-        return cbegin();
-    }
-
-    /**
-     * Returns an iterator to the element following the last
-     * element of the buffer containing the elements of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::storage_end() const noexcept -> const_storage_iterator
-    {
-        return cend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the buffer
-     * containing the elements of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::storage_cbegin() const noexcept -> const_storage_iterator
-    {
-        return cbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::storage_cend() const noexcept -> const_storage_iterator
-    {
-        return cend();
-    }
-    //@}
 
 }
 

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -63,11 +63,11 @@ namespace xt
         using const_stepper = xgenerator_stepper<F, R, S>;
         using stepper = const_stepper;
 
-        using const_iterator = xiterator<const_stepper, shape_type>;
-        using iterator = const_iterator;
+        using const_broadcast_iterator = xiterator<const_stepper, shape_type*>;
+        using broadcast_iterator = const_broadcast_iterator;
 
-        using const_storage_iterator = const_iterator;
-        using storage_iterator = const_storage_iterator;
+        using const_iterator = const_broadcast_iterator;
+        using iterator = const_iterator;
 
         template <class Func>
         xgenerator(Func&& f, const S& shape) noexcept;
@@ -93,6 +93,11 @@ namespace xt
         const_iterator cbegin() const noexcept;
         const_iterator cend() const noexcept;
 
+        const_broadcast_iterator xbegin() const noexcept;
+        const_broadcast_iterator xend() const noexcept;
+        const_broadcast_iterator cxbegin() const noexcept;
+        const_broadcast_iterator cxend() const noexcept;
+
         template <class O>
         xiterator<const_stepper, O> xbegin(const O& shape) const noexcept;
         template <class O>
@@ -104,15 +109,8 @@ namespace xt
 
         template <class O>
         const_stepper stepper_begin(const O& shape) const noexcept;
-
         template <class O>
         const_stepper stepper_end(const O& shape) const noexcept;
-
-        const_storage_iterator storage_begin() const noexcept;
-        const_storage_iterator storage_end() const noexcept;
-
-        const_storage_iterator storage_cbegin() const noexcept;
-        const_storage_iterator storage_cend() const noexcept;
 
     private:
 
@@ -121,9 +119,9 @@ namespace xt
         friend class xgenerator_stepper<F, R, S>;
     };
 
-    /***************************
+    /**********************
      * xgenerator_stepper *
-     ***************************/
+     **********************/
 
     template <class F, class R, class S>
     class xgenerator_stepper
@@ -173,9 +171,9 @@ namespace xt
     bool operator!=(const xgenerator_stepper<F, R, S>& it1,
                     const xgenerator_stepper<F, R, S>& it2);
 
-    /**********************************
+    /*****************************
      * xgenerator implementation *
-     **********************************/
+     *****************************/
 
     /**
      * @name Constructor
@@ -287,14 +285,58 @@ namespace xt
     /**
      * @name Iterators
      */
+    /**
+     * Returns an iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::begin() const noexcept -> const_iterator
+    {
+        return cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::end() const noexcept -> const_iterator
+    {
+        return cxend();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the buffer
+     * containing the elements of the function.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::cbegin() const noexcept -> const_iterator
+    {
+        return cxbegin();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last
+     * element of the buffer containing the elements of the function.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::cend() const noexcept -> const_iterator
+    {
+        return cxend();
+    }
+    //@}
+
+    /**
+     * @name Broadcast iterators
+     */
     //@{
     /**
      * Returns a constant iterator to the first element of the function.
      */
     template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::begin() const noexcept -> const_iterator
+    inline auto xgenerator<F, R, S>::xbegin() const noexcept -> const_broadcast_iterator
     {
-        return xbegin(m_shape);
+        return const_broadcast_iterator(stepper_begin(m_shape), &m_shape);
     }
 
     /**
@@ -302,18 +344,18 @@ namespace xt
      * of the function.
      */
     template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::end() const noexcept -> const_iterator
+    inline auto xgenerator<F, R, S>::xend() const noexcept -> const_broadcast_iterator
     {
-        return xend(m_shape);
+        return const_broadcast_iterator(stepper_end(m_shape), &m_shape);
     }
 
     /**
      * Returns a constant iterator to the first element of the function.
      */
     template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::cbegin() const noexcept -> const_iterator
+    inline auto xgenerator<F, R, S>::cxbegin() const noexcept -> const_broadcast_iterator
     {
-        return begin();
+        return xbegin();
     }
 
     /**
@@ -321,9 +363,9 @@ namespace xt
      * of the function.
      */
     template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::cend() const noexcept -> const_iterator
+    inline auto xgenerator<F, R, S>::cxend() const noexcept -> const_broadcast_iterator
     {
-        return end();
+        return xend();
     }
 
     /**
@@ -390,50 +432,6 @@ namespace xt
         size_type offset = shape.size() - dimension();
         return xgenerator_stepper<F, R, S>(this, offset, true);
     }
-
-    /**
-     * @name Storage iterators
-     */
-    /**
-     * Returns an iterator to the first element of the buffer
-     * containing the elements of the function.
-     */
-    template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::storage_begin() const noexcept -> const_storage_iterator
-    {
-        return cbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the function.
-     */
-    template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::storage_end() const noexcept -> const_storage_iterator
-    {
-        return cend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the buffer
-     * containing the elements of the function.
-     */
-    template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::storage_cbegin() const noexcept -> const_storage_iterator
-    {
-        return cbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the function.
-     */
-    template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::storage_cend() const noexcept -> const_storage_iterator
-    {
-        return cend();
-    }
-    //@}
 
     /******************************************
      * xgenerator_stepper implementation *

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -315,9 +315,9 @@ namespace xt
         const E1& de1 = e1.derived_cast();
         const E2& de2 = e2.derived_cast();
         bool res = de1.shape() == de2.shape();
-        auto iter1 = de1.begin();
-        auto iter2 = de2.begin();
-        auto iter_end = de1.end();
+        auto iter1 = de1.xbegin();
+        auto iter2 = de2.xbegin();
+        auto iter_end = de1.xend();
         while (res && iter1 != iter_end)
         {
             res = (*iter1++ == *iter2++);
@@ -468,7 +468,7 @@ namespace xt
     template <class E>
     inline bool any(E&& e)
     {
-        return std::any_of(e.storage_cbegin(), e.storage_cend(), 
+        return std::any_of(e.cbegin(), e.cend(), 
                            [](const typename std::decay_t<E>::value_type& el) { return el; });
     }
 
@@ -484,7 +484,7 @@ namespace xt
     template <class E>
     inline bool all(E&& e)
     {
-        return std::all_of(e.storage_cbegin(), e.storage_cend(),
+        return std::all_of(e.cbegin(), e.cend(),
                            [](const typename std::decay_t<E>::value_type& el) { return el; });
     }
 }

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -50,11 +50,11 @@ namespace xt
         using stepper = xscalar_stepper<false, CT>;;
         using const_stepper = xscalar_stepper<true, CT>;
 
-        using iterator = xscalar_iterator<false, CT>;
-        using const_iterator = xscalar_iterator<true, CT>;
+        using broadcast_iterator = xscalar_iterator<false, CT>;
+        using const_broadcast_iterator = xscalar_iterator<true, CT>;
 
-        using storage_iterator = iterator;
-        using const_storage_iterator = const_iterator;
+        using iterator = broadcast_iterator;
+        using const_iterator = const_broadcast_iterator;
 
         xscalar(CT value) noexcept;
 
@@ -88,20 +88,28 @@ namespace xt
         const_iterator end() const noexcept;
         const_iterator cbegin() const noexcept;
         const_iterator cend() const noexcept;
+
+        broadcast_iterator xbegin() noexcept;
+        broadcast_iterator xend() noexcept;
+
+        const_broadcast_iterator xbegin() const noexcept;
+        const_broadcast_iterator xend() const noexcept;
+        const_broadcast_iterator cxbegin() const noexcept;
+        const_broadcast_iterator cxend() const noexcept;
         
         template <class S>
-        iterator xbegin(const S& shape) noexcept;
+        broadcast_iterator xbegin(const S& shape) noexcept;
         template <class S>
-        iterator xend(const S& shape) noexcept;
+        broadcast_iterator xend(const S& shape) noexcept;
 
         template <class S>
-        const_iterator xbegin(const S& shape) const noexcept;
+        const_broadcast_iterator xbegin(const S& shape) const noexcept;
         template <class S>
-        const_iterator xend(const S& shape) const noexcept;
+        const_broadcast_iterator xend(const S& shape) const noexcept;
         template <class S>
-        const_iterator cxbegin(const S& shape) const noexcept;
+        const_broadcast_iterator cxbegin(const S& shape) const noexcept;
         template <class S>
-        const_iterator cxend(const S& shape) const noexcept;
+        const_broadcast_iterator cxend(const S& shape) const noexcept;
 
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
@@ -112,15 +120,6 @@ namespace xt
         const_stepper stepper_begin(const S& shape) const noexcept;
         template <class S>
         const_stepper stepper_end(const S& shape) const noexcept;
-
-        storage_iterator storage_begin() noexcept;
-        storage_iterator storage_end() noexcept;
-
-        const_storage_iterator storage_begin() const noexcept;
-        const_storage_iterator storage_end() const noexcept;
-
-        const_storage_iterator storage_cbegin() const noexcept;
-        const_storage_iterator storage_cend() const noexcept;
 
     private:
 
@@ -338,45 +337,81 @@ namespace xt
     }
 
     template <class CT>
-    template <class S>
-    inline auto xscalar<CT>::xbegin(const S&) noexcept -> iterator
+    inline auto xscalar<CT>::xbegin() noexcept -> broadcast_iterator
     {
-        return iterator(this);
+        return broadcast_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::xend() noexcept -> broadcast_iterator
+    {
+        return broadcast_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::xbegin() const noexcept -> const_broadcast_iterator
+    {
+        return const_broadcast_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::xend() const noexcept -> const_broadcast_iterator
+    {
+        return const_broadcast_iterator(this);
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::cxbegin() const noexcept -> const_broadcast_iterator
+    {
+        return xbegin();
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::cxend() const noexcept -> const_broadcast_iterator
+    {
+        return xend();
     }
 
     template <class CT>
     template <class S>
-    inline auto xscalar<CT>::xend(const S&) noexcept -> iterator
+    inline auto xscalar<CT>::xbegin(const S&) noexcept -> broadcast_iterator
     {
-        return iterator(this);
+        return broadcast_iterator(this);
     }
 
     template <class CT>
     template <class S>
-    inline auto xscalar<CT>::xbegin(const S&) const noexcept -> const_iterator
+    inline auto xscalar<CT>::xend(const S&) noexcept -> broadcast_iterator
     {
-        return const_iterator(this);
+        return broadcast_iterator(this);
     }
 
     template <class CT>
     template <class S>
-    inline auto xscalar<CT>::xend(const S&) const noexcept -> const_iterator
+    inline auto xscalar<CT>::xbegin(const S&) const noexcept -> const_broadcast_iterator
     {
-        return const_iterator(this);
+        return const_broadcast_iterator(this);
     }
 
     template <class CT>
     template <class S>
-    inline auto xscalar<CT>::cxbegin(const S&) const noexcept -> const_iterator
+    inline auto xscalar<CT>::xend(const S&) const noexcept -> const_broadcast_iterator
     {
-        return const_iterator(this);
+        return const_broadcast_iterator(this);
     }
 
     template <class CT>
     template <class S>
-    inline auto xscalar<CT>::cxend(const S&) const noexcept -> const_iterator
+    inline auto xscalar<CT>::cxbegin(const S&) const noexcept -> const_broadcast_iterator
     {
-        return const_iterator(this);
+        return const_broadcast_iterator(this);
+    }
+
+    template <class CT>
+    template <class S>
+    inline auto xscalar<CT>::cxend(const S&) const noexcept -> const_broadcast_iterator
+    {
+        return const_broadcast_iterator(this);
     }
 
     template <class CT>
@@ -405,42 +440,6 @@ namespace xt
     inline auto xscalar<CT>::stepper_end(const S&) const noexcept -> const_stepper
     {
         return const_stepper(this + 1);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_begin() noexcept -> storage_iterator
-    {
-        return storage_iterator(this);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_end() noexcept -> storage_iterator
-    {
-        return storage_iterator(this);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_begin() const noexcept -> const_storage_iterator
-    {
-        return const_storage_iterator(this);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_end() const noexcept -> const_storage_iterator
-    {
-        return const_storage_iterator(this);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_cbegin() const noexcept -> const_storage_iterator
-    {
-        return const_storage_iterator(this);
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::storage_cend() const noexcept -> const_storage_iterator
-    {
-        return const_storage_iterator(this);
     }
 
     template <class T>

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -550,7 +550,7 @@ namespace xt
     inline auto xview_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
     {
         D& d = this->derived_cast();
-        std::transform(d.begin(), d.end(), d.begin(),
+        std::transform(d.xbegin(), d.xend(), d.xbegin(),
                 [e, &f](const auto& v) { return f(v, e); });
         return this->derived_cast();
     }

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -430,42 +430,42 @@ namespace xt
     }
 
     template <class V, class C = std::vector<std::size_t>>
-    void test_storage_iterator(V& vec)
+    void test_iterator(V& vec)
     {
         {
             SCOPED_TRACE("row_major storage iterator");
             row_major_result<C> rm;
             vec.reshape(rm.m_shape, layout::row_major);
-            std::copy(rm.data().cbegin(), rm.data().cend(), vec.storage_begin());
+            std::copy(rm.data().cbegin(), rm.data().cend(), vec.begin());
             EXPECT_EQ(rm.data(), vec.data());
-            EXPECT_EQ(vec.storage_end(), vec.data().end());
+            EXPECT_EQ(vec.end(), vec.data().end());
         }
 
         {
             SCOPED_TRACE("column_major storage iterator");
             column_major_result<C> cm;
             vec.reshape(cm.m_shape, layout::column_major);
-            std::copy(cm.data().cbegin(), cm.data().cend(), vec.storage_begin());
+            std::copy(cm.data().cbegin(), cm.data().cend(), vec.begin());
             EXPECT_EQ(cm.data(), vec.data());
-            EXPECT_EQ(vec.storage_end(), vec.data().end());
+            EXPECT_EQ(vec.end(), vec.data().end());
         }
 
         {
             SCOPED_TRACE("central_major storage iterator");
             central_major_result<C> cem;
             vec.reshape(cem.m_shape, cem.m_strides);
-            std::copy(cem.data().cbegin(), cem.data().cend(), vec.storage_begin());
+            std::copy(cem.data().cbegin(), cem.data().cend(), vec.begin());
             EXPECT_EQ(cem.data(), vec.data());
-            EXPECT_EQ(vec.storage_end(), vec.data().end());
+            EXPECT_EQ(vec.end(), vec.data().end());
         }
 
         {
             SCOPED_TRACE("unit_shape storage iterator");
             unit_shape_result<C> usr;
             vec.reshape(usr.m_shape, layout::row_major);
-            std::copy(usr.data().cbegin(), usr.data().cend(), vec.storage_begin());
+            std::copy(usr.data().cbegin(), usr.data().cend(), vec.begin());
             EXPECT_EQ(usr.data(), vec.data());
-            EXPECT_EQ(vec.storage_end(), vec.data().end());
+            EXPECT_EQ(vec.end(), vec.data().end());
         }
     }
 }

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -151,10 +151,10 @@ namespace xt
         test_broadcast2(a);
     }
 
-    TEST(xarray, storage_iterator)
+    TEST(xarray, iterator)
     {
         xarray<int> a;
-        test_storage_iterator(a);
+        test_iterator(a);
     }
 
     TEST(xarray, initializer_list)

--- a/test/test_xarray_adaptor.cpp
+++ b/test/test_xarray_adaptor.cpp
@@ -125,11 +125,11 @@ namespace xt
         test_broadcast2(a);
     }
 
-    TEST(xarray_adaptor, storage_iterator)
+    TEST(xarray_adaptor, iterator)
     {
         vec_type v;
         adaptor_type a(v);
-        test_storage_iterator(a);
+        test_iterator(a);
     }
 }
 

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -29,7 +29,7 @@ namespace xt
         ASSERT_EQ(4.0, m1_broadcast2(0, 1, 0));
         ASSERT_EQ(5.0, m1_broadcast2(0, 1, 1));
 
-        double f = *(m1_broadcast.begin());
+        double f = *(m1_broadcast.xbegin());
         xarray<double> m1_assigned = m1_broadcast;
         ASSERT_EQ(5.0, m1_assigned(0, 1, 1));
     }

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -27,11 +27,11 @@ namespace xt
     {
         row_major_result<> rm;
         m_a.reshape(rm.shape(), rm.strides());
-        std::copy(rm.data().cbegin(), rm.data().cend(), m_a.storage_begin());
+        std::copy(rm.data().cbegin(), rm.data().cend(), m_a.begin());
 
         unit_shape_result<> us;
         m_b.reshape(us.shape(), us.strides());
-        std::copy(us.data().cbegin(), us.data().cend(), m_b.storage_begin());
+        std::copy(us.data().cbegin(), us.data().cend(), m_b.begin());
 
         using shape_type = layout_result<>::shape_type;
         shape_type sh = { 4, 3, 2, 4};
@@ -143,8 +143,8 @@ namespace xt
     void test_xfunction_iterator(const xarray<int>& a, const xarray<int>& b)
     {
         auto func = (a + b);
-        auto iter = func.begin();
-        auto itera = a.begin();
+        auto iter = func.xbegin();
+        auto itera = a.xbegin();
         auto iterb = b.xbegin(a.shape());
         auto nb_iter = a.shape().back() * 2 + 1;
         for(size_t i = 0; i < nb_iter; ++i)
@@ -177,8 +177,8 @@ namespace xt
     void test_xfunction_iterator_end(const xarray<int>& a, const xarray<int>& b)
     {
         auto func = (a + b);
-        auto iter = func.begin();
-        auto iter_end = func.end();
+        auto iter = func.xbegin();
+        auto iter_end = func.xend();
         auto size = a.size();
         for(size_t i = 0; i < size; ++i)
         {

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -83,12 +83,12 @@ namespace xt
         std::vector<size_t> idx = {2};
         EXPECT_EQ(fn(2, 2), v.element(idx.begin(), idx.end()));
 
-        auto it = v.begin();
+        auto it = v.xbegin();
         EXPECT_EQ(fn(1, 1), *it);
 
         EXPECT_EQ(fn(1, 2), *(++it));
         EXPECT_EQ(fn(2, 2), *(++it));
-        EXPECT_EQ(++it, v.end());
+        EXPECT_EQ(++it, v.xend());
     }
 
     TEST(xindexview, view_on_view)

--- a/test/test_xiterator.cpp
+++ b/test/test_xiterator.cpp
@@ -25,8 +25,8 @@ namespace xt
         size_type nb_inc = shape.back() * shape[shape.size() - 2] + 1;
         int expected = a(1, 0, 1);
         
-        auto iter = a.begin();
-        auto iter2 = a.begin();
+        auto iter = a.xbegin();
+        auto iter2 = a.xbegin();
         for(size_type i = 0; i < nb_inc; ++i)
         {
             ++iter;
@@ -115,8 +115,8 @@ namespace xt
         xarray_adaptor<typename R::vector_type> a(data, result.shape(), result.strides());
 
         size_type size = a.size();
-        auto iter = a.begin();
-        auto last = a.end();
+        auto iter = a.xbegin();
+        auto last = a.xend();
         for(size_type i = 0; i < size; ++i)
         {
             ++iter;

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -212,7 +212,7 @@ namespace xt
 
         shape_type s = {3, 3, 3};
         xarray<bool> d(s);
-        std::fill(d.begin(), d.end(), true);
+        std::fill(d.xbegin(), d.xend(), true);
 
         auto d_nz = nonzero(d);
         EXPECT_EQ(3 * 3 * 3, d_nz.size());

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -39,7 +39,7 @@ namespace xt
     TEST(xscalar, iterator)
     {
         xscalar<int> x(2);
-        auto iter = x.begin();
+        auto iter = x.xbegin();
         *iter = 4;
         EXPECT_EQ(4, x());
     }

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -151,10 +151,10 @@ namespace xt
         test_broadcast(a);
     }
 
-    TEST(xtensor, storage_iterator)
+    TEST(xtensor, iterator)
     {
         xtensor<int, 3> a;
-        test_storage_iterator<xtensor<int, 3>, container_type>(a);
+        test_iterator<xtensor<int, 3>, container_type>(a);
     }
 
     TEST(xtensor, zerod)

--- a/test/test_xtensor_adaptor.cpp
+++ b/test/test_xtensor_adaptor.cpp
@@ -125,10 +125,10 @@ namespace xt
         test_broadcast(a);
     }
 
-    TEST(xtensor_adaptor, storage_iterator)
+    TEST(xtensor_adaptor, iterator)
     {
         vec_type v;
         adaptor_type a(v);
-        test_storage_iterator<adaptor_type, container_type>(a);
+        test_iterator<adaptor_type, container_type>(a);
     }
 }

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -45,7 +45,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
@@ -104,7 +104,7 @@ namespace xt
             211, 212
         };
         xarray<double> a(shape);
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, 1);
         EXPECT_EQ(2, view1.dimension());
@@ -155,11 +155,11 @@ namespace xt
         xarray<double> a(shape);
         std::vector<double> data {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                                   13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, range(0, 2), 1, range(1, 4));
-        auto iter = view1.begin();
-        auto iter_end = view1.end();
+        auto iter = view1.xbegin();
+        auto iter_end = view1.xend();
 
         EXPECT_EQ(6, *iter);
         ++iter;
@@ -176,8 +176,8 @@ namespace xt
         EXPECT_EQ(iter, iter_end);
 
         auto view2 = view(view1, range(0, 2), range(1, 3));
-        auto iter2 = view2.begin();
-        auto iter_end2 = view2.end();
+        auto iter2 = view2.xbegin();
+        auto iter_end2 = view2.xend();
 
         EXPECT_EQ(7, *iter2);
         ++iter2;
@@ -195,16 +195,16 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<int> a(shape);
         std::vector<int> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         view_shape_type shape2 = { 4 };
         xarray<int> b(shape2);
         std::vector<int> data2 = { 1, 2, 3, 4 };
-        std::copy(data2.cbegin(), data2.cend(), b.storage_begin());
+        std::copy(data2.cbegin(), data2.cend(), b.begin());
 
         auto v = view(a + b, 1, range(1, 4));
-        auto iter = v.begin();
-        auto iter_end = v.end();
+        auto iter = v.xbegin();
+        auto iter_end = v.xend();
 
         EXPECT_EQ(8, *iter);
         ++iter;
@@ -219,15 +219,15 @@ namespace xt
     {
         xtensor<int, 2> a({ 3, 4 });
         std::vector<int> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
         EXPECT_EQ(a(1, 2), view1(1));
         EXPECT_EQ(1, view1.dimension());
 
-        auto iter = view1.begin();
-        auto iter_end = view1.end();
+        auto iter = view1.xbegin();
+        auto iter_end = view1.xend();
 
         EXPECT_EQ(6, *iter);
         ++iter;
@@ -245,10 +245,10 @@ namespace xt
     TEST(xview, trivial_iterating)
     {
         xtensor<double, 1> arr1{ {2} };
-        std::fill(arr1.begin(), arr1.end(), 6);
+        std::fill(arr1.xbegin(), arr1.xend(), 6);
         auto view = xt::view(arr1, 0);
-        auto iter = view.begin();
-        auto iter_end = view.end();
+        auto iter = view.xbegin();
+        auto iter_end = view.xend();
         ++iter;
         EXPECT_EQ(iter, iter_end);
     }
@@ -279,7 +279,7 @@ namespace xt
         view_shape_type shape = { 3, 4 };
         xarray<double> a(shape);
         std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, all(), newaxis(), all());
         EXPECT_EQ(a(1, 1), view1(1, 0, 1));
@@ -329,11 +329,11 @@ namespace xt
         view_shape_type shape = { 3, 4 };
         xarray<double> a(shape);
         std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         auto view1 = view(a, all(), all(), newaxis());
-        auto iter1 = view1.begin();
-        auto iter1_end = view1.end();
+        auto iter1 = view1.xbegin();
+        auto iter1_end = view1.xend();
 
         EXPECT_EQ(a(0, 0), *iter1);
         ++iter1;
@@ -362,8 +362,8 @@ namespace xt
         EXPECT_EQ(iter1_end, iter1);
 
         auto view2 = view(a, all(), newaxis(), all());
-        auto iter2 = view2.begin();
-        auto iter2_end = view2.end();
+        auto iter2 = view2.xbegin();
+        auto iter2_end = view2.xend();
 
         EXPECT_EQ(a(0, 0), *iter2);
         ++iter2;
@@ -397,19 +397,19 @@ namespace xt
         view_shape_type shape = { 3, 4 };
         xarray<double> a(shape);
         std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-        std::copy(data.cbegin(), data.cend(), a.storage_begin());
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
         xarray<double> b(view_shape_type(1, 4));
         auto data_end = data.cbegin();
         data_end += 4;
-        std::copy(data.cbegin(), data_end, b.storage_begin());
+        std::copy(data.cbegin(), data_end, b.begin());
 
         auto v = view(b, newaxis(), all());
         xarray<double> res = a + v;
 
         std::vector<double> data2{ 2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16 };
         xarray<double> expected(shape);
-        std::copy(data2.cbegin(), data2.cend(), expected.storage_begin());
+        std::copy(data2.cbegin(), data2.cend(), expected.begin());
 
         EXPECT_EQ(expected, res);
     }


### PR DESCRIPTION
Fixes #135.

Improved ``xiterator`` perofrmance by avoiding the copy of the shape when it is possible.

@nbecker you might be interested in this, although it doesn't fix *all* the performances issues.

You can now use the range for loop syntax and achieve the same performance than with the ``storage_begin``/``storage_end`` methods (which have been renamed in ``begin``/``end``).