### PR TITLE
Move semantic with xreducer axes

### DIFF
--- a/docs/source/numpy.rst
+++ b/docs/source/numpy.rst
@@ -225,6 +225,23 @@ argument.
   ``imag(a)`` is the same as that of ``a``.
 - If ``a`` has real values, ``imag(a)`` returns ``zeros(a.shape())``.
 
+Reducers
+--------
+
+Reducers accumulate values of tensor expressions along specified axes. When not specified, values
+are accumulated along all the axes of the expression. Like in the rest of xtensor, return values
+of e.g. ``sum`` and ``prod`` don't hold any values and are computed upon access or assigmnent.
+
+In the case of xtensor, the list of axes must be increasingly sorted.
+
++-----------------------------------------------+-----------------------------------------------+
+|            Python 3 - numpy                   |                C++ 14 - xtensor               |
++===============================================+===============================================+
+| ``np.sum(a, axis=[0, 1])``                    | ``xt::sum(a, {0, 1})``                        |
++-----------------------------------------------+-----------------------------------------------+
+| ``np.prod(a, axis=1)``                        | ``xt::prod(a, {1})``                          |
++-----------------------------------------------+-----------------------------------------------+
+
 Mathematical functions
 ----------------------
 

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -441,7 +441,7 @@ namespace xt
     template <class... Types>
     inline auto xtuple(Types&&... args)
     {
-        return std::tuple<detail::const_closure_t<Types>...>(std::forward<Types>(args)...);
+        return std::tuple<const_closure_t<Types>...>(std::forward<Types>(args)...);
     }
 
     /**

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -128,13 +128,13 @@ namespace xt
     template <class E, class EN = void>
     struct xclosure
     {
-        using type = detail::closure_t<E>;
+        using type = closure_t<E>;
     };
 
     template <class E>
     struct xclosure<E, disable_xexpression<std::decay_t<E>>>
     {
-        using type = xscalar<detail::closure_t<E>>;
+        using type = xscalar<closure_t<E>>;
     };
 
     template <class E>
@@ -143,13 +143,13 @@ namespace xt
     template <class E, class EN = void>
     struct const_xclosure
     {
-        using type = detail::const_closure_t<E>;
+        using type = const_closure_t<E>;
     };
 
     template <class E>
     struct const_xclosure<E, disable_xexpression<std::decay_t<E>>>
     {
-        using type = xscalar<detail::const_closure_t<E>>;
+        using type = xscalar<const_closure_t<E>>;
     };
  
     template <class E>

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -819,10 +819,10 @@ namespace xt
      * @return an \ref xreducer
      */
     template <class E, class X>
-    inline auto sum(E&& e, const X& axes) noexcept
+    inline auto sum(E&& e, X&& axes) noexcept
     {
         using functor_type = std::plus<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
     }
 
 #ifdef X_OLD_CLANG
@@ -852,10 +852,10 @@ namespace xt
      * @return an \ref xreducer
      */
     template <class E, class X>
-    inline auto prod(E&& e, const X& axes) noexcept
+    inline auto prod(E&& e, X&& axes) noexcept
     {
         using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
     }
 
 #ifdef X_OLD_CLANG

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -10,6 +10,16 @@
 #define XREDUCER_HPP
 
 #include <algorithm>
+#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
+#include <iterator>
+#include <stdexcept>
+#ifdef X_OLD_CLANG
+#include <vector>
+#endif
+
 #include "xexpression.hpp"
 #include "xiterator.hpp"
 #include "xutils.hpp"
@@ -22,7 +32,7 @@ namespace xt
      **********/
 
     template <class F, class E, class X>
-    auto reduce(F&& f, E&& e, const X& axes) noexcept;
+    auto reduce(F&& f, E&& e, X&& axes) noexcept;
 
 #ifdef X_OLD_CLANG
     template <class F, class E, class I>
@@ -60,6 +70,7 @@ namespace xt
         using const_iterator = const_broadcast_iterator;
         using iterator = const_iterator;
     };
+
     /**
      * @class xreducer
      * @brief Reducing function operating over specified axes.
@@ -84,7 +95,7 @@ namespace xt
         using self_type = xreducer<F, CT, X>;
         using functor_type = typename std::remove_reference<F>::type;
         using xexpression_type = std::decay_t<CT>;
-        using axis_storage = X;
+        using axes_type = X;
 
         using value_type = typename xexpression_type::value_type;
         using reference = value_type;
@@ -107,8 +118,8 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
-        template <class Func>
-        xreducer(Func&& func, CT e, const axis_storage& axis);
+        template <class Func, class AX>
+        xreducer(Func&& func, CT e, AX&& axes);
 
         size_type dimension() const noexcept;
         const shape_type& shape() const;
@@ -136,7 +147,7 @@ namespace xt
 
         CT m_e;
         functor_type m_f;
-        axis_storage m_axis;
+        axes_type m_axes;
         shape_type m_shape;
 
         using index_type = xindex_type_t<shape_type>;
@@ -162,10 +173,10 @@ namespace xt
      */
 
     template <class F, class E, class X>
-    inline auto reduce(F&& f, E&& e, const X& axes) noexcept
+    inline auto reduce(F&& f, E&& e, X&& axes) noexcept
     {
-        using reducer_type = xreducer<F, const_xclosure_t<E>, X>;
-        return reducer_type(std::forward<F>(f), std::forward<E>(e), axes);
+        using reducer_type = xreducer<F, const_xclosure_t<E>, const_closure_t<X>>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), std::forward<X>(axes));
     }
 
 #ifdef X_OLD_CLANG
@@ -194,7 +205,7 @@ namespace xt
     template <class ST, class X>
     struct xreducer_shape_type
     {
-        using type = promote_shape_t<ST, X>;
+        using type = promote_shape_t<ST, std::decay_t<X>>;
     };
 
     template <class I1, std::size_t N1, class I2, std::size_t N2>
@@ -210,10 +221,11 @@ namespace xt
                                    ExcludeIt e_first, ExcludeIt e_last,
                                    OutputIt d_first)
         {
+            using difference_type = typename std::iterator_traits<InputIt>::difference_type;
             InputIt iter = first;
             while (iter != last && e_first != e_last)
             {
-                if (std::distance(first, iter) != *e_first)
+                if (std::distance(first, iter) != difference_type(*e_first))
                 {
                     *d_first++ = *iter++;
                 }
@@ -231,10 +243,11 @@ namespace xt
                            ExcludeIt e_first, ExcludeIt e_last,
                            OutputIt d_first, T default_value)
         {
+            using difference_type = typename std::iterator_traits<InputIt>::difference_type;
             OutputIt d_first_bu = d_first;
             while (first != last && e_first != e_last)
             {
-                if (std::distance(d_first_bu, d_first) != *e_first)
+                if (std::distance(d_first_bu, d_first) != difference_type(*e_first))
                 {
                     *d_first++ = *first++;
                 }
@@ -281,7 +294,7 @@ namespace xt
 
             void increment();
 
-            size_type axis(size_type index) const;
+            size_type axes(size_type index) const;
             size_type shape(size_type index) const;
 
             const reducer_type& m_reducer;
@@ -342,17 +355,17 @@ namespace xt
         template <class F, class CT, class X>
         inline void reducing_iterator<F, CT, X>::increment()
         {
-            size_type i = m_reducer.m_axis.size();
+            size_type i = m_reducer.m_axes.size();
             while (i != 0)
             {
                 --i;
-                if (++(m_reducer.m_index[axis(i)]) != shape(axis(i)))
+                if (++(m_reducer.m_index[axes(i)]) != shape(axes(i)))
                 {
                     return;
                 }
                 else
                 {
-                    m_reducer.m_index[axis(i)] = 0;
+                    m_reducer.m_index[axes(i)] = 0;
                 }
             }
             if (i == 0)
@@ -362,9 +375,9 @@ namespace xt
         }
 
         template <class F, class CT, class X>
-        inline auto reducing_iterator<F, CT, X>::axis(size_type index) const -> size_type
+        inline auto reducing_iterator<F, CT, X>::axes(size_type index) const -> size_type
         {
-            return m_reducer.m_axis[index];
+            return m_reducer.m_axes[index];
         }
 
         template <class F, class CT, class X>
@@ -384,22 +397,25 @@ namespace xt
      //@{
      /**
       * Constructs an xreducer expression applying the specified
-      * function to the given expression over the given axis.
+      * function to the given expression over the given axes.
       *
       * @param func the function to apply
       * @param e the expression to reduce
-      * @param axis the axis along which the reduction is performed
+      * @param axes the axes along which the reduction is performed
       */
     template <class F, class CT, class X>
-    template <class Func>
-    inline xreducer<F, CT, X>::xreducer(Func&& func, CT e, const axis_storage& axis)
-        : m_e(e), m_f(std::forward<Func>(func)), m_axis(axis),
-          m_shape(make_sequence<shape_type>(m_e.dimension() - axis.size(), 0)),
+    template <class Func, class AX>
+    inline xreducer<F, CT, X>::xreducer(Func&& func, CT e, AX&& axes)
+        : m_e(e), m_f(std::forward<Func>(func)), m_axes(std::forward<AX>(axes)),
+          m_shape(make_sequence<shape_type>(m_e.dimension() - m_axes.size(), 0)),
           m_index(make_sequence<index_type>(m_e.dimension(), 0))
     {
-        std::sort(m_axis.begin(), m_axis.end());
+        if(!std::is_sorted(m_axes.cbegin(), m_axes.cend()))
+        {
+            throw std::runtime_error("Reducing axes should be sorted");
+        }
         detail::excluding_copy(m_e.shape().begin(), m_e.shape().end(),
-                               m_axis.begin(), m_axis.end(),
+                               m_axes.begin(), m_axes.end(),
                                m_shape.begin());
     }
     //@}
@@ -467,7 +483,7 @@ namespace xt
     template <class It>
     inline auto xreducer<F, CT, X>::element(It first, It last) const -> const_reference
     {
-        detail::inject(first, last, m_axis.cbegin(), m_axis.cend(),
+        detail::inject(first, last, m_axes.cbegin(), m_axes.cend(),
                        m_index.begin(), size_type(0));
         using iter_type = detail::reducing_iterator<F, CT, X>;
         iter_type iter = iter_type(*this);

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -598,34 +598,31 @@ namespace xt
      * closure implementation *
      **************************/
 
-    namespace detail
+    template <class S>
+    struct closure
     {
-        template <class S>
-        struct closure
-        {
-            using underlying_type = std::conditional_t<std::is_const<std::remove_reference_t<S>>::value,
-                                                       const std::decay_t<S>,
-                                                       std::decay_t<S>>;
-            using type = typename std::conditional<std::is_lvalue_reference<S>::value,
-                                                   underlying_type&,
-                                                   underlying_type>::type;
-        };
+        using underlying_type = std::conditional_t<std::is_const<std::remove_reference_t<S>>::value,
+                                                   const std::decay_t<S>,
+                                                   std::decay_t<S>>;
+        using type = typename std::conditional<std::is_lvalue_reference<S>::value,
+                                               underlying_type&,
+                                               underlying_type>::type;
+    };
 
-        template <class S>
-        using closure_t = typename closure<S>::type;
+    template <class S>
+    using closure_t = typename closure<S>::type;
 
-        template <class S>
-        struct const_closure
-        {
-            using underlying_type = const std::decay_t<S>;
-            using type = typename std::conditional<std::is_lvalue_reference<S>::value,
-                                                   underlying_type&,
-                                                   underlying_type>::type;
-        };
-        
-        template <class S>
-        using const_closure_t = typename const_closure<S>::type;
-    }
+    template <class S>
+    struct const_closure
+    {
+        using underlying_type = const std::decay_t<S>;
+        using type = typename std::conditional<std::is_lvalue_reference<S>::value,
+                                               underlying_type&,
+                                               underlying_type>::type;
+    };
+     
+    template <class S>
+    using const_closure_t = typename const_closure<S>::type;
 
     /***************************
      * apply_cv implementation *

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -16,20 +16,20 @@ namespace xt
 {
     struct xreducer_features
     {
-        using axis_type = std::array<std::size_t, 2>;
-        axis_type m_axis;
+        using axes_type = std::array<std::size_t, 2>;
+        axes_type m_axes;
         xarray<double> m_a;
         using shape_type = xarray<double>::shape_type;
 
         using func = std::plus<double>;
-        xreducer<func, const xarray<double>&, axis_type> m_red;
+        xreducer<func, const xarray<double>&, axes_type> m_red;
 
         xreducer_features();
     };
 
     xreducer_features::xreducer_features()
-        : m_axis({ 1, 3 }), m_a(ones<double>({3, 2, 4, 6, 5})),
-          m_red(func(), m_a, m_axis)
+        : m_axes({ 1, 3 }), m_a(ones<double>({3, 2, 4, 6, 5})),
+          m_red(func(), m_a, m_axes)
     {
         for (std::size_t i = 0; i < 2; ++i)
         {
@@ -78,7 +78,7 @@ namespace xt
     TEST(xreducer, sum)
     {
         xreducer_features features;
-        xarray<double> res = sum(features.m_a, features.m_axis);
+        xarray<double> res = sum(features.m_a, features.m_axes);
         xarray<double> expected = 12 * ones<double>({ 3, 4, 5 });
         expected(1, 1, 1) = 24;
         EXPECT_EQ(expected, res);


### PR DESCRIPTION
- Now storing a closure type on the axes sequence.
- The list of axes now must be sorted.