### PR TITLE
Enable reduce-all

### DIFF
--- a/docs/source/numpy.rst
+++ b/docs/source/numpy.rst
@@ -250,18 +250,20 @@ argument.
 Reducers
 --------
 
-Reducers accumulate values of tensor expressions along specified axes. When not specified, values
-are accumulated along all the axes of the expression. Like in the rest of xtensor, return values
-of e.g. ``sum`` and ``prod`` don't hold any values and are computed upon access or assigmnent.
-
-In the case of xtensor, the list of axes must be increasingly sorted.
+Reducers accumulate values of tensor expressions along specified axes. When no axis is specified,
+values are accumulated along all axes. Reducers are lazy, meaning that returned expressons don't
+hold any values and are computed upon access or assigmnent.
 
 +-----------------------------------------------+-----------------------------------------------+
 |            Python 3 - numpy                   |                C++ 14 - xtensor               |
 +===============================================+===============================================+
 | ``np.sum(a, axis=[0, 1])``                    | ``xt::sum(a, {0, 1})``                        |
 +-----------------------------------------------+-----------------------------------------------+
+| ``np.sum(a)``                                 | ``xt::sum(a)``                                |
++-----------------------------------------------+-----------------------------------------------+
 | ``np.prod(a, axis=1)``                        | ``xt::prod(a, {1})``                          |
++-----------------------------------------------+-----------------------------------------------+
+| ``np.prod(a)``                                | ``xt::prod(a)``                               |
 +-----------------------------------------------+-----------------------------------------------+
 
 Mathematical functions

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <array>
 #include <algorithm>
+#include <numeric>
 #include <iterator>
 #include <type_traits>
 #include <cstddef>
@@ -104,12 +105,14 @@ namespace xt
         template <class S>
         xbroadcast(CT e, S&& s) noexcept;
 
+        size_type size() const noexcept;
         size_type dimension() const noexcept;
-        const shape_type & shape() const noexcept;
+        const shape_type& shape() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It, It last) const;
@@ -199,6 +202,15 @@ namespace xt
      * @name Size and shape
      */
     /**
+     * Returns the size of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::size() const noexcept -> size_type
+    {
+        return std::accumulate(m_shape.begin(), m_shape.end(), size_type(1), std::multiplies<size_type>());
+    }
+
+    /**
      * Returns the number of dimensions of the expression.
      */
     template <class CT, class X>
@@ -244,7 +256,13 @@ namespace xt
     {
         return element(index.cbegin(), index.cend());
     }
-    
+
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+ 
     /**
      * Returns a constant reference to the element at the specified position in the expression.
      * @param first iterator starting the sequence of indices

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -105,13 +105,8 @@ namespace xt
                 return access_impl(args...);
             }
 
-            inline T operator[](const xindex& idx) const
-            {
-                return m_start + m_step * T(idx[0]);
-            }
-
             template <class It>
-            inline T element(It first, It /*last*/) const
+            inline T element(It first, It) const
             {
                 return m_start + m_step * T(*first);
             }
@@ -122,7 +117,7 @@ namespace xt
             value_type m_step;
 
             template <class T1, class... Args>
-            inline T access_impl(T1 t, Args... /*args*/) const
+            inline T access_impl(T1 t, Args...) const
             {
                 return m_start + m_step * T(t);
             }
@@ -154,11 +149,6 @@ namespace xt
             {
                 size_type idx [sizeof...(Args)] = {static_cast<size_type>(args)...};
                 return access_impl(std::begin(idx), std::end(idx));
-            }
-
-            inline value_type operator[](const xindex& idx) const
-            {
-                return access_impl(idx.begin(), idx.end());
             }
 
             template <class It>
@@ -302,17 +292,14 @@ namespace xt
             template <class... Args>
             inline value_type operator()(Args... args) const
             {
+                // TODO: avoid memory allocation
                 return access_impl(xindex({{static_cast<size_type>(args)...}}));
-            }
-
-            inline value_type operator[](const xindex& idx) const
-            {
-                return access_impl(idx);
             }
 
             template <class It>
             inline value_type element(It first, It last) const
             {
+                // TODO: avoid memory allocation
                 return access_impl(xindex(first, last));
             }
 
@@ -320,7 +307,8 @@ namespace xt
 
             inline value_type access_impl(xindex idx) const
             {
-                auto match = [this, &idx](auto& arr) {
+                auto match = [this, &idx](auto& arr)
+                {
                     if (idx[this->m_axis] >= arr.shape()[this->m_axis])
                     {
                         idx[this->m_axis] -= arr.shape()[this->m_axis];
@@ -329,7 +317,8 @@ namespace xt
                     return true;
                 };
 
-                auto get = [&idx](auto& arr) {
+                auto get = [&idx](auto& arr)
+                {
                     return arr[idx];
                 };
 
@@ -362,17 +351,14 @@ namespace xt
             template <class... Args>
             inline value_type operator()(Args... args) const
             {
+                // TODO: avoid memory allocation
                 return access_impl(xindex({{static_cast<size_type>(args)...}}));
-            }
-
-            inline value_type operator[](const xindex& idx) const
-            {
-                return access_impl(idx);
             }
 
             template <class It>
             inline value_type element(It first, It last) const
             {
+                // TODO: avoid memory allocation
                 return access_impl(xindex(first, last));
             }
 
@@ -380,7 +366,8 @@ namespace xt
 
             inline value_type access_impl(xindex idx) const
             {
-                auto get_item = [&idx](auto& arr) {
+                auto get_item = [&idx](auto& arr)
+                {
                     return arr[idx];
                 };
                 std::size_t i = idx[m_axis];
@@ -416,15 +403,10 @@ namespace xt
                 return m_source();
             }
 
-            value_type operator[](const xindex& idx) const
-            {
-                return m_source[{ idx[m_axis] }];
-            }
-
             template <class It>
             inline value_type element(It first, It) const
             {
-                return m_source[{*(first + m_axis)}];
+                return m_source(*(first + m_axis));
             }
 
         private:
@@ -570,7 +552,7 @@ namespace xt
             }
 
             template <class It>
-            inline value_type operator()(It begin, It /*end*/) const
+            inline value_type operator()(It begin, It) const
             {
                 return m_source(*begin, *begin);
             }
@@ -590,7 +572,7 @@ namespace xt
             }
 
             template <class It>
-            inline value_type operator()(It begin, It /*end*/) const
+            inline value_type operator()(It begin, It) const
             {
                 return *begin == *(begin + 1) ? m_source(*begin) : value_type(0);
             }
@@ -623,16 +605,13 @@ namespace xt
                 return m_source(m_shape_first - first_idx, args...);
             }
 
-            inline value_type operator[](xindex idx) const
-            {
-                idx.front() = m_shape_first - idx.front();
-                return m_source[idx];
-            }
-
             template <class It>
             inline value_type element(It first, It last) const
             {
-                return operator[](xindex(first, last));
+                // TODO: avoid memory allocation
+                xindex idx(first, last);
+                idx.front() = m_shape_first - idx.front();
+                return m_source.element(idx.begin(), idx.end());
             }
 
         private:
@@ -664,16 +643,13 @@ namespace xt
                 return m_source(args..., m_shape_last - last_idx);
             }
 
-            inline value_type operator[](xindex idx) const
-            {
-                idx.back() = m_shape_last - idx.back();
-                return m_source[idx];
-            }
-
             template <class It>
             inline value_type element(It first, It last) const
             {
-                return operator[](xindex(first, last));
+                // TODO: avoid memory allocation
+                xindex idx(first, last);
+                idx.back() = m_shape_last - idx.back();
+                return m_source.element(idx.begin(), idx.end());
             }
 
         private:

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -105,7 +105,9 @@ namespace xt
         const_reference operator()(Args... args) const;
 
         reference operator[](const xindex& index);
+        reference operator[](size_type i);
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         reference element(It first, It last);
@@ -187,7 +189,7 @@ namespace xt
         template <class S>
         void transpose_impl(S&& permutation, check_policy::full);
 
-        size_type data_size() const noexcept;
+        size_type compute_size() const noexcept;
 
         template <size_t dim = 0>
         size_type data_offset() const noexcept;
@@ -249,7 +251,7 @@ namespace xt
     }
 
     template <class D>
-    inline auto xcontainer<D>::data_size() const noexcept -> size_type
+    inline auto xcontainer<D>::compute_size() const noexcept -> size_type
     {
         return std::accumulate(m_shape.begin(), m_shape.end(), size_type(1), std::multiplies<size_type>());
     }
@@ -384,7 +386,7 @@ namespace xt
         m_strides = strides;
         resize_container(m_backstrides, m_strides.size());
         adapt_strides();
-        data().resize(data_size());
+        data().resize(compute_size());
     }
 
     /**
@@ -527,6 +529,12 @@ namespace xt
         return element(index.cbegin(), index.cend());
     }
 
+    template <class D>
+    inline auto xcontainer<D>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
     /**
      * Returns a constant reference to the element at the specified position in the container.
      * @param index a sequence of indices specifying the position in the container. Indices
@@ -537,6 +545,12 @@ namespace xt
     inline auto xcontainer<D>::operator[](const xindex& index) const -> const_reference
     {
         return element(index.cbegin(), index.cend());
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
     }
 
     /**

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <tuple>
 #include <algorithm>
+#include <numeric>
 #include <iterator>
 
 #include "xexpression.hpp"
@@ -130,6 +131,7 @@ namespace xt
         template <class Func>
         xfunction(Func&& f, CT... e) noexcept;
 
+        size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type& shape() const;
 
@@ -137,6 +139,7 @@ namespace xt
         const_reference operator()(Args... args) const;
 
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It first, It last) const;
@@ -324,6 +327,15 @@ namespace xt
      */
     //@{
     /**
+     * Returns the size of the expression.
+     */
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::size() const noexcept -> size_type
+    {
+        return std::accumulate(shape().begin(), shape().end(), size_type(1), std::multiplies<size_type>());
+    }
+
+    /**
      * Returns the number of dimensions of the function.
      */
     template <class F, class R, class... CT>
@@ -370,7 +382,13 @@ namespace xt
     {
         return element(index.cbegin(), index.cend());
     }
-    
+ 
+    template <class F, class R, class... CT>
+    inline auto xfunction<F, R, CT...>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+ 
     /**
      * Returns a constant reference to the element at the specified position in the function.
      * @param first iterator starting the sequence of indices

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <tuple>
 #include <algorithm>
+#include <numeric>
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"
@@ -86,12 +87,14 @@ namespace xt
         template <class Func>
         xgenerator(Func&& f, const S& shape) noexcept;
 
+        size_type size() const noexcept;
         size_type dimension() const noexcept;
-        const shape_type& shape() const;
+        const shape_type& shape() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It first, It last) const;
@@ -140,6 +143,15 @@ namespace xt
      */
     //@{
     /**
+     * Returns the size of the expression.
+     */
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::size() const noexcept -> size_type
+    {
+        return std::accumulate(m_shape.begin(), m_shape.end(), size_type(1), std::multiplies<size_type>());
+    }
+
+    /**
      * Returns the number of dimensions of the function.
      */
     template <class F, class R, class S>
@@ -152,7 +164,7 @@ namespace xt
      * Returns the shape of the xgenerator.
      */
     template <class F, class R, class S>
-    inline auto xgenerator<F, R, S>::shape() const -> const shape_type&
+    inline auto xgenerator<F, R, S>::shape() const noexcept -> const shape_type&
     {
         return m_shape;
     }
@@ -178,6 +190,12 @@ namespace xt
     inline auto xgenerator<F, R, S>::operator[](const xindex& index) const -> const_reference
     {
         return m_f[index];
+    }
+
+    template <class F, class R, class S>
+    inline auto xgenerator<F, R, S>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
     }
 
     /**

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -189,7 +189,7 @@ namespace xt
     template <class F, class R, class S>
     inline auto xgenerator<F, R, S>::operator[](const xindex& index) const -> const_reference
     {
-        return m_f[index];
+        return m_f.element(index.begin(), index.end());
     }
 
     template <class F, class R, class S>

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -110,12 +110,13 @@ namespace xt
         disable_xexpression<E, self_type>& operator=(const E& e);
 
         size_type dimension() const noexcept;
-        const shape_type& shape() const;
+        const shape_type& shape() const noexcept;
 
         reference operator()();
         template <class... Args>
         reference operator()(std::size_t idx, Args... /*args*/);
         reference operator[](const xindex& index);
+        reference operator[](size_type i);
 
         template <class It>
         reference element(It first, It last);
@@ -124,6 +125,7 @@ namespace xt
         template <class... Args>
         const_reference operator()(std::size_t idx, Args... /*args*/) const;
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It first, It last) const;
@@ -282,7 +284,7 @@ namespace xt
      * Returns the shape of the xindexview.
      */
     template <class CT, class I>
-    inline auto xindexview<CT, I>::shape() const -> const shape_type&
+    inline auto xindexview<CT, I>::shape() const noexcept -> const shape_type&
     {
         return m_shape;
     }
@@ -329,9 +331,21 @@ namespace xt
     }
 
     template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class I>
     inline auto xindexview<CT, I>::operator[](const xindex& index) const -> const_reference
     {
         return m_e[m_indices[index[0]]];
+    }
+
+    template <class CT, class I>
+    inline auto xindexview<CT, I>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
     }
 
     /**

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -825,6 +825,13 @@ namespace xt
         return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
     }
 
+    template <class E>
+    inline auto sum(E&& e) noexcept
+    {
+        using functor_type = std::plus<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
+    }
+
 #ifdef X_OLD_CLANG
     template <class E, class I>
     inline auto sum(E&& e, std::initializer_list<I> axes) noexcept
@@ -856,6 +863,13 @@ namespace xt
     {
         using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
         return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+    }
+
+    template <class E>
+    inline auto prod(E&& e) noexcept
+    {
+        using functor_type = std::multiplies<typename std::decay_t<E>::value_type>;
+        return reduce(functor_type(), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG

--- a/include/xtensor/xoffsetview.hpp
+++ b/include/xtensor/xoffsetview.hpp
@@ -40,7 +40,6 @@ namespace xt
     template <class CT, class M, std::size_t I>
     class xoffsetview;
 
-
     /*****************************
      * offsetview_temporary_type *
      *****************************/
@@ -125,12 +124,14 @@ namespace xt
         template <class E>
         disable_xexpression<E, self_type>& operator=(const E& e);
 
+        size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type & shape() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It, It last) const;
@@ -356,6 +357,15 @@ namespace xt
      * @name Size and shape
      */
     /**
+     * Returns the size of the expression.
+     */
+    template <class CT, class M, std::size_t I>
+    inline auto xoffsetview<CT, M, I>::size() const noexcept -> size_type
+    {
+        return m_e.size();
+    }
+
+    /**
      * Returns the number of dimensions of the expression.
      */
     template <class CT, class M, std::size_t I>
@@ -401,7 +411,13 @@ namespace xt
     {
         return forward_offset<value_type, I>(m_e[index]);
     }
-    
+ 
+    template <class CT, class M, std::size_t I>
+    inline auto xoffsetview<CT, M, I>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
+    }
+ 
     /**
      * Returns a constant reference to the element at the specified position in the expression.
      * @param first iterator starting the sequence of indices

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -92,11 +92,6 @@ namespace xt
                 return m_generator();
             }
 
-            inline value_type operator[](const xindex&) const
-            {
-                return m_generator();
-            }
-
             template <class It>
             inline value_type element(It, It) const
             {

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -87,18 +87,18 @@ namespace xt
             }
 
             template <class... Args>
-            inline value_type operator()(Args... /*args*/) const
+            inline value_type operator()(Args...) const
             {
                 return m_generator();
             }
 
-            inline value_type operator[](const xindex& /*idx*/) const
+            inline value_type operator[](const xindex&) const
             {
                 return m_generator();
             }
 
             template <class It>
-            inline value_type element(It /*first*/, It /*last*/) const
+            inline value_type element(It, It) const
             {
                 return m_generator();
             }

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -189,12 +189,10 @@ namespace xt
     template <class F, class E>
     inline auto reduce(F&& f, E&& e) noexcept
     {
-        using reducer_type = xreducer<F,
-                                      const_xclosure_t<E>,
-                                      xgenerator<detail::arange_impl<typename std::decay_t<E>::size_type>, 
-                                                 typename std::decay_t<E>::size_type,
-                                                 std::array<std::size_t, 1>>>;
-        return reducer_type(std::forward<F>(f), std::forward<E>(e), arange(e.dimension()));
+        auto ar = arange(e.dimension());
+        using AR = decltype(ar);
+        using reducer_type = xreducer<F, const_xclosure_t<E>, AR>;
+        return reducer_type(std::forward<F>(f), std::forward<E>(e), std::move(ar));
     }
 
 #ifdef X_OLD_CLANG

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -60,14 +60,17 @@ namespace xt
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
-
         const shape_type& shape() const noexcept;
 
         template <class... Args>
-        reference operator()(Args... args) noexcept;
+        reference operator()(Args...) noexcept;
+        reference operator[](const xindex&) noexcept;
+        reference operator[](size_type) noexcept;
 
         template <class... Args>
-        const_reference operator()(Args... args) const noexcept;
+        const_reference operator()(Args...) const noexcept;
+        const_reference operator[](const xindex&) const noexcept;
+        const_reference operator[](size_type) const noexcept;
 
         template <class It>
         reference element(It, It) noexcept;
@@ -266,8 +269,32 @@ namespace xt
     }
 
     template <class CT>
+    inline auto xscalar<CT>::operator[](const xindex&) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](size_type) noexcept -> reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
     template <class... Args>
     inline auto xscalar<CT>::operator()(Args...) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](const xindex&) const noexcept -> const_reference
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::operator[](size_type) const noexcept -> const_reference
     {
         return m_value;
     }

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -113,18 +113,21 @@ namespace xt
 
         size_type dimension() const noexcept;
 
+        size_type size() const noexcept;
         const shape_type& shape() const noexcept;
         const slice_type& slices() const noexcept;
 
         template <class... Args>
         reference operator()(Args... args);
         reference operator[](const xindex& index);
+        reference operator[](size_type i);
         template <class It>
         reference element(It first, It last);
 
         template <class... Args>
         const_reference operator()(Args... args) const;
         const_reference operator[](const xindex& index) const;
+        const_reference operator[](size_type i) const;
         template <class It>
         const_reference element(It first, It last) const;
 
@@ -353,6 +356,15 @@ namespace xt
      */
     //@{
     /**
+     * Returns the size of the expression.
+     */
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::size() const noexcept -> size_type
+    {
+        return std::accumulate(m_shape.begin(), m_shape.end(), size_type(1), std::multiplies<size_type>());
+    }
+
+    /**
      * Returns the number of dimensions of the view.
      */
     template <class CT, class... S>
@@ -407,6 +419,12 @@ namespace xt
     }
 
     template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](size_type i) -> reference
+    {
+        return operator()(i);
+    }
+
+    template <class CT, class... S>
     template <class It>
     inline auto xview<CT, S...>::element(It first, It last) -> reference
     {
@@ -434,6 +452,12 @@ namespace xt
     inline auto xview<CT, S...>::operator[](const xindex& index) const -> const_reference
     {
         return element(index.cbegin(), index.cend());
+    }
+
+    template <class CT, class... S>
+    inline auto xview<CT, S...>::operator[](size_type i) const -> const_reference
+    {
+        return operator()(i);
     }
 
     template <class CT, class... S>

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -83,4 +83,12 @@ namespace xt
         expected(1, 1, 1) = 24;
         EXPECT_EQ(expected, res);
     }
+
+    TEST(xreducer, sumi_all)
+    {
+        xreducer_features features;
+        auto res = sum(features.m_a);
+        double expected = 732;
+        EXPECT_EQ(res(), expected);
+    }
 }


### PR DESCRIPTION
This is an experiment for reducer with no specified axes that use `arange(dimension())` as a list of axes, i.e. use a 1-D tensor expression with no storage instead of traditional sequence.

The two blockers are
 - the need for a `size()` method (added here in xgenerator but which should be added everywhere). The containers already have it.
 - the need for `operator[]` with an integral type.

This shows that people could start using e.g. `linspace` instead of an std::vector for many use cases.