### PR TITLE
Initial missing value support, xoptional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xutils.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xvectorize.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xview.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xoptional.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xmissing.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xoptional_sequence.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xoffsetview.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xcomplex.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xview_utils.hpp

--- a/docs/source/missing.rst
+++ b/docs/source/missing.rst
@@ -1,0 +1,41 @@
+.. Copyright (c) 2016, Johan Mabille and Sylvain Corlay
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Handling of missing values
+==========================
+
+``xtensor`` supports missing values and comprises specialized container types for an optimized support of missing values.
+
+Missing values
+--------------
+
+Support of missing values in xtensor is primarily provided through the ``xoptional`` value type and the ``xtensor_optional`` and
+``xarray_optional`` containers. In the following example, we instantiate a 2-D tensor with a missing value:
+
+.. code:: cpp
+
+    xtensor_optional<double, 2> m
+        {{ 1.0 ,       2.0          },
+         { 3.0 , missing<double>()} };
+
+This code is semantically equivalent to
+
+.. code:: cpp
+
+    xtensor<xoptional<double>, 2> m
+        {{ 1.0 ,       2.0          },
+         { 3.0 , missing<double>()} };
+
+The ``xtensor_optional`` container is optimized to handle missing values. Internally, instead of holding a single container
+of optional values, it holds an array of ``double`` and a boolean container where each value occupies a single bit instead of ``sizeof(bool)``
+bytes.
+
+The ``xtensor_optional::reference`` typedef, which is the return type of ``operator()`` is a reference proxy which can be used as an
+lvalue for assigning new values in the array. It happens to be an instance of ``xoptional<T, B>`` where ``T`` and ``B`` are actually
+the reference types of the underlying storage for values and boolean flags.
+
+This technique enables performance improvements in mathematical operations over boolean arrays including SIMD optimizations, and
+reduces the memory footprint of optional arrays. It should be transparent to the user.

--- a/include/xtensor/xmissing.hpp
+++ b/include/xtensor/xmissing.hpp
@@ -1,0 +1,19 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XMISSING_HPP
+#define XMISSING_HPP
+
+#include "xtensor_forward.hpp"
+#include "xoptional.hpp"
+#include "xoptional_sequence.hpp"
+#include "xarray.hpp"
+#include "xtensor.hpp"
+
+#endif
+

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -1,0 +1,401 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XOPTIONAL_HPP
+#define XOPTIONAL_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "xtensor/xutils.hpp"
+
+namespace xt
+{
+    /********************
+     * optional helpers *
+     ********************/
+
+    template <class T, class B>
+    auto optional(T&& t, B&& b) noexcept;
+
+    template <class T>
+    auto missing() noexcept;
+
+    /*************************
+     * xoptional declaration *
+     *************************/
+
+    template <class CT, class CB>
+    class xoptional;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xoptional_impl
+        {
+            static constexpr bool value = false;
+        };
+
+        template <class CT, class CB>
+        struct is_xoptional_impl<xoptional<CT, CB>> : std::true_type
+        {
+        };
+    }
+
+    template <class E>
+    using is_xoptional = detail::is_xoptional_impl<E>;
+
+    template <class E, class R = void>
+    using disable_xoptional = typename std::enable_if<!is_xoptional<E>::value, R>::type;
+
+    /**
+     * @class xoptional
+     * @brief Closure-type based optional handler.
+     *
+     * The xoptional is an optional proxy. It holds a closure on a value and a closure on a boolean-convertible type.
+     *
+     * xoptional is different from std::optional
+     *
+     *  - no `operator->()` that returns a pointer, since pointer to an rvalue may be an issue.
+     *  - no `operator*()` that returns a value.
+     *
+     * The only way to access the underlying value is with the `value` and `value_or` methods.
+     *
+     *  - no explicit convertion to bool. This may lead to confusion when the underlying value type is boolean too.
+     *
+     * @tparam CT Closure type for the value.
+     * @tparam CB Closure type for the missing flag. A falsy flag means that the value is missing. 
+     */
+    template <class CT, class CB=bool>
+    class xoptional
+    {
+    public:
+        using value_type = std::decay_t<CT>;
+        using flag_type = std::decay_t<CB>;
+
+        // Constructors
+        xoptional();
+        xoptional(const xoptional&) = default;
+        xoptional(xoptional&&) = default;
+
+        template <class CTO, class CBO>
+        xoptional(const xoptional<CTO, CBO>&);
+
+        template <class CTO, class CBO>
+        xoptional(xoptional<CTO, CBO>&&);
+
+        xoptional(const value_type&);
+        xoptional(value_type&&);
+
+        xoptional(value_type&&, flag_type&&);
+        xoptional(std::add_lvalue_reference_t<CT>, std::add_lvalue_reference_t<CB>);
+        xoptional(value_type&&, std::add_lvalue_reference_t<CB>);
+        xoptional(std::add_lvalue_reference_t<CT>, flag_type&&);
+
+        // Assignment
+        xoptional& operator=(const xoptional&) = default;
+
+        template <class CTO, class CBO>
+        xoptional& operator=(const xoptional<CTO, CBO>&);
+
+        template <class CTO, class CBO>
+        xoptional& operator=(xoptional<CTO, CBO>&&);
+
+        xoptional& operator=(const value_type&);
+        xoptional& operator=(value_type&&);
+
+        // Operators
+        template <class CTO, class CBO>
+        xoptional& operator+=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator-=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator*=(const xoptional<CTO, CBO>&);
+        template <class CTO, class CBO>
+        xoptional& operator/=(const xoptional<CTO, CBO>&);
+
+        template <class T>
+        disable_xoptional<T, xoptional&> operator+=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator-=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator*=(const T&);
+        template <class T>
+        disable_xoptional<T, xoptional&> operator/=(const T&);
+
+        // Access
+        std::add_lvalue_reference_t<CT> value() & noexcept;
+        std::add_const_t<std::add_lvalue_reference_t<CT>> value() const & noexcept;
+        std::conditional_t<std::is_reference<CT>::value, value_type&, value_type&&> value() && noexcept;
+        std::conditional_t<std::is_reference<CT>::value, const value_type&, const value_type&&> value() const && noexcept;
+
+        template <class U> 
+        value_type value_or(U&&) const & noexcept;
+        template <class U> 
+        value_type value_or(U&&) const && noexcept;
+
+        // Access
+        bool has_value() const;
+
+        // Swap
+        void swap(xoptional& other);
+
+    private:
+        template <class CTO, class CBO>
+        friend class xoptional;
+
+        CT m_value;
+        CB m_flag;
+    };
+
+
+    /***************************************
+     * optional and missing implementation *
+     ***************************************/
+    /**
+     * @brief Returns an \ref xoptional holding closure types on the specified parameters
+     *
+     * @tparam t the optional value
+     * @tparam b the boolean flag
+     */
+    template <class T, class B>
+    inline auto optional(T&& t, B&& b) noexcept
+    {
+        using optional_type = xoptional<closure_t<T>, closure_t<B>>;
+        return optional_type(std::forward<T>(t), std::forward<B>(b));
+    }
+
+    /**
+     * @brief Returns an \ref xoptional for a missig value
+     */
+    template <class T>
+    auto missing() noexcept
+    {
+        return xoptional<T, bool>(T(), false);
+    }
+
+    /****************************
+     * xoptional implementation *
+     ****************************/
+
+    // Constructors
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional() : m_value(), m_flag(false)
+    {
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    xoptional<CT, CB>::xoptional(const xoptional<CTO, CBO>& opt) : m_value(opt.m_value), m_flag(opt.m_flag)
+    {
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    xoptional<CT, CB>::xoptional(xoptional<CTO, CBO>&& opt) : m_value(std::move(opt.m_value)), m_flag(std::move(opt.m_flag))
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(const value_type& value) : m_value(value), m_flag(true)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value) : m_value(value), m_flag(true)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value, flag_type&& flag): m_value(std::move(value)), m_flag(std::move(flag))
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(std::add_lvalue_reference_t<CT> value, std::add_lvalue_reference_t<CB> flag) : m_value(value), m_flag(flag)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(value_type&& value, std::add_lvalue_reference_t<CB> flag) : m_value(std::move(value)), m_flag(flag)
+    {
+    }
+
+    template <class CT, class CB>
+    xoptional<CT, CB>::xoptional(std::add_lvalue_reference_t<CT> value, flag_type&& flag) : m_value(value), m_flag(std::move(flag))
+    {
+    }
+
+    // Assignment
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = rhs.m_flag;
+        m_value = rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator=(xoptional<CTO, CBO>&& rhs) -> xoptional&
+    {
+        m_flag = std::move(rhs.m_flag);
+        m_value = std::move(rhs.m_value);
+        return *this;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::operator=(const value_type& value) -> xoptional&
+    {
+        m_flag = true;
+        m_value = value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::operator=(value_type&& value) -> xoptional&
+    {
+        m_flag = true;
+        m_value = std::move(value);
+        return *this;
+    }
+
+    // Operators
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator+=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if(m_flag)
+            m_value += rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator-=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if(m_flag)
+            m_value -= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator*=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if(m_flag)
+            m_value *= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class CTO, class CBO>
+    auto xoptional<CT, CB>::operator/=(const xoptional<CTO, CBO>& rhs) -> xoptional&
+    {
+        m_flag = m_flag && rhs.m_flag;
+        if(m_flag)
+            m_value /= rhs.m_value;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator+=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if(m_flag)
+            m_value += rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator-=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    {
+        if(m_flag)
+            m_value -= rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator*=(const T& rhs) -> disable_xoptional<T, xoptional&> 
+    {
+        if(m_flag)
+            m_value *= rhs;
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator/=(const T& rhs) -> disable_xoptional<T, xoptional&> 
+    {
+        if(m_flag)
+            m_value /= rhs;
+        return *this;
+    }
+
+    // Access
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() & noexcept -> std::add_lvalue_reference_t<CT>
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() const & noexcept -> std::add_const_t<std::add_lvalue_reference_t<CT>> 
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() && noexcept -> std::conditional_t<std::is_reference<CT>::value, value_type&, value_type&&> 
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    auto xoptional<CT, CB>::value() const && noexcept -> std::conditional_t<std::is_reference<CT>::value, const value_type&, const value_type&&> 
+    {
+        return m_value;
+    }
+
+    template <class CT, class CB>
+    template <class U> 
+    auto xoptional<CT, CB>::value_or(U&& default_value) const & noexcept -> value_type 
+    {
+        return m_flag ? m_value : std::forward<U>(default_value);
+    }
+
+    template <class CT, class CB>
+    template <class U> 
+    auto xoptional<CT, CB>::value_or(U&& default_value) const && noexcept -> value_type
+    {
+        return m_flag ? m_value : std::forward<U>(default_value);
+    }
+
+    // Access
+    template <class CT, class CB>
+    bool xoptional<CT, CB>::has_value() const
+    {
+        return m_flag;
+    }
+
+    // Swap
+    template <class CT, class CB>
+    void xoptional<CT, CB>::swap(xoptional& other)
+    {
+        std::swap(m_value, other.m_flag);
+        std::swap(m_flag, other.m_flag);
+    }
+}
+
+#endif

--- a/include/xtensor/xoptional_sequence.hpp
+++ b/include/xtensor/xoptional_sequence.hpp
@@ -1,0 +1,543 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XNILSEQUENCE_HPP
+#define XNILSEQUENCE_HPP
+
+#include <cstddef>
+#include <array>
+#include <vector>
+#include <iterator>
+#include <memory>
+
+#include "xoptional.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+
+    /**************************************
+     * Optimized 1-D xoptional containers *
+     **************************************/
+
+    template <class T>
+    class xoptional_sequence_inner_types;    
+
+    template <class ITV, class ITB>
+    class xoptional_iterator;
+    
+    template <class D>
+    class xoptional_sequence
+    {
+    public:
+        // Internal typedefs
+        using inner_types = xoptional_sequence_inner_types<D>;
+
+        using base_container_type = typename inner_types::base_container_type;
+        using base_value_type = typename base_container_type::value_type;
+        using base_reference = typename base_container_type::reference;
+        using base_const_reference = typename base_container_type::const_reference;
+
+        using flag_container_type = typename inner_types::flag_container_type;
+        using flag_type = typename flag_container_type::value_type;
+        using flag_reference = typename flag_container_type::reference;
+        using flag_const_reference = typename flag_container_type::const_reference;
+
+        // Container typedefs
+        using value_type = xoptional<base_value_type, flag_type>;
+        using reference = xoptional<base_reference, flag_reference>;
+        using const_reference = xoptional<base_const_reference, flag_const_reference>;
+        using pointer = std::nullptr_t;
+        using const_pointer = std::nullptr_t;
+
+        // Other typedefs
+        using size_type = typename base_container_type::size_type;
+        using difference_type = typename base_container_type::difference_type;
+        using iterator = xoptional_iterator<typename base_container_type::iterator,
+                                            typename flag_container_type::iterator>;
+        using const_iterator = xoptional_iterator<typename base_container_type::const_iterator,
+                                                  typename flag_container_type::const_iterator>;
+
+        using reverse_iterator = xoptional_iterator<typename base_container_type::reverse_iterator,
+                                                    typename flag_container_type::reverse_iterator>;
+        using const_reverse_iterator = xoptional_iterator<typename base_container_type::const_reverse_iterator,
+                                                          typename flag_container_type::const_reverse_iterator>;
+
+        xoptional_sequence() = default;
+        xoptional_sequence(size_type s, const base_value_type& v);
+
+        template <class CTO, class CBO>
+        xoptional_sequence(size_type s, const xoptional<CTO, CBO>& v);
+
+        bool empty() const noexcept;
+        size_type size() const noexcept;
+        
+        reference operator[](size_type i);
+        const_reference operator[](size_type i) const;
+
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator begin() const;
+        const_iterator end() const;
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
+        reverse_iterator rbegin();
+        reverse_iterator rend();
+
+        const_reverse_iterator rbegin() const;
+        const_reverse_iterator rend() const;
+        const_reverse_iterator crbegin() const;
+        const_reverse_iterator crend() const;
+
+    protected:
+        base_container_type m_values;
+        flag_container_type m_flags;
+    };
+
+    /****************************************************
+     * xoptional_vector and xoptional_array inner types *
+     ****************************************************/
+
+    template <class T, std::size_t I>
+    class xoptional_array;
+
+    template <class T, std::size_t I>
+    class xoptional_sequence_inner_types<xoptional_array<T, I>>
+    {
+    public:
+        using base_container_type = std::array<T, I>;
+        using flag_container_type = std::array<bool, I>;
+    };
+
+    template <class T, class A, class BA>
+    class xoptional_vector;
+
+    template <class T, class A, class BA>
+    class xoptional_sequence_inner_types<xoptional_vector<T, A, BA>>
+    {
+    public:
+        using base_container_type = std::vector<T, A>;
+        using flag_container_type = std::vector<bool, BA>;
+    };
+
+    /*****************************************************
+     * xoptional_vector and xoptional_array declarations *
+     *****************************************************/
+
+    template <class T, std::size_t I>
+    class xoptional_array : public xoptional_sequence<xoptional_array<T, I>>
+    {
+    public:
+        using self_type = xoptional_array;
+        using base_type = xoptional_sequence<self_type>;
+        using base_value_type = typename base_type::base_value_type;
+        using size_type = typename base_type::size_type;
+
+        xoptional_array() = default;
+        xoptional_array(size_type s, const base_value_type& v);
+
+        template <class CTO, class CBO>
+        xoptional_array(size_type s, const xoptional<CTO, CBO>& v);
+    };
+
+    template <class T, class A=std::allocator<T>, class BA=std::allocator<bool>>
+    class xoptional_vector : public xoptional_sequence<xoptional_vector<T, A, BA>>
+    {
+    public:
+        using self_type = xoptional_vector;
+        using base_type = xoptional_sequence<self_type>;
+        using base_value_type = typename base_type::base_value_type;
+
+        using value_type = typename base_type::value_type;
+        using size_type = typename base_type::size_type;
+        using difference_type = typename base_type::difference_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator;
+        using reverse_iterator = typename base_type::reverse_iterator;
+        using const_reverse_iterator = typename base_type::const_reverse_iterator;
+
+        xoptional_vector() = default;
+        xoptional_vector(size_type, const base_value_type&);
+
+        template <class CTO, class CBO>
+        xoptional_vector(size_type, const xoptional<CTO, CBO>&);
+
+        void resize(size_type);
+        void resize(size_type, const base_value_type&);
+        template <class CTO, class CBO>
+        void resize(size_type, const xoptional<CTO, CBO>&);
+    };
+
+    /**********************************
+     * xoptional_iterator declaration *
+     **********************************/
+
+    template <class ITV, class ITB>
+    class xoptional_iterator
+    {
+    public:
+
+        using self_type = xoptional_iterator<ITV, ITB>;
+
+        // Internal typedefs
+        using base_value_type = typename ITV::value_type;
+        using base_reference = typename ITV::reference;
+
+        using flag_type = typename ITB::value_type;
+        using flag_reference = typename ITB::reference;
+
+        // Container typedefs
+        using value_type = xoptional<base_value_type, flag_type>;
+        using reference = xoptional<base_reference, flag_reference>;
+
+        using pointer = std::nullptr_t;
+        using difference_type = typename ITV::difference_type;
+        using iterator_category = std::random_access_iterator_tag;
+
+        xoptional_iterator() = default;
+        xoptional_iterator(ITV itv, ITB itb);
+
+        self_type& operator++();
+        self_type operator++(int);
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        self_type& operator--();
+        self_type operator--(int);
+
+        self_type& operator+=(difference_type n);
+        self_type& operator-=(difference_type n);
+
+        self_type operator+(difference_type n) const;
+        self_type operator-(difference_type n) const;
+        self_type operator-(const self_type& rhs) const;
+
+        bool equal(const xoptional_iterator& rhs) const;
+
+    private:
+
+        ITV m_itv;
+        ITB m_itb;
+    };
+
+    template <class ITV, class ITB>
+    bool operator==(const xoptional_iterator<ITV, ITB>&, const xoptional_iterator<ITV, ITB>&);
+
+    template <class ITV, class ITB>
+    bool operator!=(const xoptional_iterator<ITV, ITB>&, const xoptional_iterator<ITV, ITB>&);
+
+    /*************************************
+     * xoptional_sequence implementation *
+     *************************************/
+
+    template <class D>
+    xoptional_sequence<D>::xoptional_sequence(size_type s, const base_value_type& v)
+        : m_values(make_sequence<base_container_type>(s, v)),
+          m_flags(make_sequence<flag_container_type>(s, true))
+    {
+    }
+
+    template <class D>
+    template <class CTO, class CBO>
+    xoptional_sequence<D>::xoptional_sequence(size_type s, const xoptional<CTO, CBO>& v)
+        : m_values(make_sequence<base_container_type>(s, v.value())), m_flags(make_sequence<flag_container_type>(s, v.has_value()))
+    {
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::empty() const noexcept -> bool
+    {
+        return m_values.empty();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::size() const noexcept -> size_type
+    {
+        return m_values.size();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::operator[](size_type i) -> reference
+    {
+        return reference(m_values[i], m_flags[i]);
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::operator[](size_type i) const -> const_reference
+    {
+        return const_reference(m_values[i], m_flags[i]);
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::front() -> reference
+    {
+        return reference(m_values.front(), m_flags.front());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::front() const -> const_reference
+    {
+        return const_reference(m_values.front(), m_flags.front());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::back() -> reference
+    {
+        return reference(m_values.back(), m_flags.back());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::back() const -> const_reference
+    {
+        return const_reference(m_values.back(), m_flags.back());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::begin() -> iterator
+    {
+        return iterator(m_values.begin(), m_flags.begin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::end() -> iterator
+    {
+        return iterator(m_values.end(), m_flags.end());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::begin() const -> const_iterator
+    {
+        return cbegin();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::end() const -> const_iterator
+    {
+        return cend();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::cbegin() const -> const_iterator
+    {
+        return const_iterator(m_values.cbegin(), m_flags.cbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::cend() const -> const_iterator
+    {
+        return const_iterator(m_values.cend(), m_flags.cend());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rbegin() -> reverse_iterator
+    {
+        return reverse_iterator(m_values.rbegin(), m_flags.rbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rend() -> reverse_iterator
+    {
+        return reverse_iterator(m_values.rend(), m_flags.rend());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rbegin() const -> const_reverse_iterator
+    {
+        return crbegin();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::rend() const -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::crbegin() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_values.crbegin(), m_flags.crbegin());
+    }
+
+    template <class D>
+    auto xoptional_sequence<D>::crend() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(m_values.crend(), m_flags.crend());
+    }
+
+    /*******************************************************
+     * xoptional_array and xoptional_vector implementation *
+     *******************************************************/
+
+    template <class T, std::size_t I>
+    xoptional_array<T, I>::xoptional_array(size_type s, const base_value_type& v) : base_type(s, v)
+    {
+    }
+
+    template <class T, std::size_t I>
+    template <class CTO, class CBO>
+    xoptional_array<T, I>::xoptional_array(size_type s, const xoptional<CTO, CBO>& v) : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    xoptional_vector<T, A, BA>::xoptional_vector(size_type s, const base_value_type& v) : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    template <class CTO, class CBO>
+    xoptional_vector<T, A, BA>::xoptional_vector(size_type s, const xoptional<CTO, CBO>& v) : base_type(s, v)
+    {
+    }
+
+    template <class T, class A, class BA>
+    void xoptional_vector<T, A, BA>::resize(size_type s)
+    {
+        // Default to missing
+        this->m_values.resize(s);
+        this->m_flags.resize(s, false);
+    }
+
+    template <class T, class A, class BA>
+    void xoptional_vector<T, A, BA>::resize(size_type s, const base_value_type& v)
+    {
+        this->m_values.resize(s, v);
+        this->m_flags.resize(s, true);
+    }
+
+    template <class T, class A, class BA>
+    template <class CTO, class CBO>
+    void xoptional_vector<T, A, BA>::resize(size_type s, const xoptional<CTO, CBO>& v)
+    {
+        this->m_values.resize(s, v.value());
+        this->m_flags.resize(s, v.has_value());
+    }
+
+    /*************************************
+     * xoptional_iterator implementation *
+     *************************************/
+
+    template <class ITV, class ITB>
+    xoptional_iterator<ITV, ITB>::xoptional_iterator(ITV itv, ITB itb) : m_itv(itv), m_itb(itb)
+    {
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator++() -> self_type&
+    {
+        ++m_itv;
+        ++m_itb;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator++(int) -> self_type
+    {
+        self_type tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator--() -> self_type&
+    {
+        --m_itv;
+        --m_itb;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator--(int) -> self_type
+    {
+        self_type tmp(*this);
+        --(*this);
+        return tmp;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator+=(difference_type n) -> self_type&
+    {
+        m_itv += n;
+        m_itb += n;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-=(difference_type n) -> self_type&
+    {
+        m_itv -= n;
+        m_itb -= n;
+        return *this;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator+(difference_type n) const -> self_type
+    {
+        return self_type(m_itv + n, m_itb + n);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-(difference_type n) const -> self_type
+    {
+        return self_type(m_itv - n, m_itb - n);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator-(const self_type& rhs) const -> self_type
+    {
+        self_type tmp(*this);
+        tmp -= (m_itv - rhs.m_itv);
+        return tmp;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator*() const -> reference
+    {
+        return reference(*m_itv, *m_itb);
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::operator->() const -> std::nullptr_t
+    {
+        return nullptr;
+    }
+
+    template <class ITV, class ITB>
+    auto xoptional_iterator<ITV, ITB>::equal(const xoptional_iterator& rhs) const -> bool
+    {
+        return m_itv == rhs.m_itv && m_itb == rhs.m_itb;
+    }
+
+    template <class ITV, class ITB>
+    bool operator==(const xoptional_iterator<ITV, ITB>& lhs, const xoptional_iterator<ITV, ITB>& rhs)
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class ITV, class ITB>
+    bool operator!=(const xoptional_iterator<ITV, ITB>& lhs, const xoptional_iterator<ITV, ITB>& rhs)
+    {
+        return !lhs.equal(rhs);
+    }
+}
+
+#endif

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -37,11 +37,11 @@ namespace xt
      * \endcode
      * 
      * @tparam T The value type of the elements.
-     * @tparam EA The allocator of the container holding the elements.
+     * @tparam A The allocator of the container holding the elements.
      * @tparam SA The allocator of the containers holding the shape and the strides.
      */
-    template <class T, class EA = std::allocator<T>, class SA = std::allocator<typename std::vector<T, EA>::size_type>>
-    using xarray = xarray_container<DEFAULT_DATA_CONTAINER(T, EA), DEFAULT_SHAPE_CONTAINER(T, EA, SA)>;
+    template <class T, class A = std::allocator<T>, class SA = std::allocator<typename std::vector<T, A>::size_type>>
+    using xarray = xarray_container<DEFAULT_DATA_CONTAINER(T, A), DEFAULT_SHAPE_CONTAINER(T, A, SA)>;
 
     template <class EC, std::size_t N>
     class xtensor_container;
@@ -70,6 +70,34 @@ namespace xt
 
     template <class CT, class... S>
     class xview;
+
+    template <class T, class A, class BA>
+    class xoptional_vector;
+
+    /**
+     * @typedef xarray_optional
+     * Alias template on xarray_container for handling missing values
+     *
+     * @tparam T The value type of the elements.
+     * @tparam A The allocator of the container holding the elements.
+     * @tparam BA The allocator of the container holding the missing flags.
+     * @tparam SA The allocator of the containers holding the shape and the strides.
+     */
+    template <class T, class A = std::allocator<T>, class BA = std::allocator<bool>, class SA = std::allocator<typename std::vector<T, A>::size_type>>
+    using xarray_optional = xarray_container<xoptional_vector<T, A, BA>, DEFAULT_SHAPE_CONTAINER(T, A, SA)>;
+
+    /**
+     * @typedef xtensor_optional
+     * Alias template on xtensor_container for handling missing values
+     *
+     * @tparam T The value type of the elements.
+     * @tparam N The dimension of the tensor.
+     * @tparam A The allocator of the containers holding the elements.
+     * @tparam BA The allocator of the container holding the missing flags.
+     */
+    template <class T, std::size_t N, class A = std::allocator<T>, class BA = std::allocator<bool>>
+    using xtensor_optional = xtensor_container<xoptional_vector<T, A, BA>, N>;
+
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,7 @@ set(XTENSOR_TESTS
     test_xview_semantic.cpp
     test_xutils.cpp
     test_xcomplex.cpp
+    test_xoptional.cpp
 )
 
 set(XTENSOR_TARGET test_xtensor)

--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include <vector>
+#include <algorithm>
+
+#include "xtensor/xmissing.hpp"
+
+namespace xt
+{
+    TEST(xoptional, scalar_tests)
+    {
+        // Test uninitialized == missing
+        xoptional<double, bool> v0;
+        ASSERT_FALSE(v0.has_value());
+
+        // Test initialization from value
+        xoptional<double, bool> v1(1.0);
+        ASSERT_TRUE(v1.has_value());
+        ASSERT_EQ(v1.value(), 1.0);
+
+        // Test lvalue closure types
+        double value1 = 3.0;
+        int there = 0;
+        auto opt1 = optional(value1, there);
+        ASSERT_FALSE(opt1.has_value());
+        opt1 = 1.0;
+        ASSERT_TRUE(opt1.has_value());
+        ASSERT_EQ(value1, 1.0);
+
+        // Test rvalue closure type for boolean
+        double value2 = 3.0;
+        auto opt2 = optional(value2, true);
+        opt2 = 2.0;
+        ASSERT_TRUE(opt2.has_value());
+        ASSERT_EQ(value2, 2.0);
+    }
+
+    TEST(xoptional, vector)
+    {
+        xoptional_vector<double> v(3, 2.0);
+        ASSERT_TRUE(v.front().has_value());
+        ASSERT_TRUE(v[0].has_value());
+        ASSERT_EQ(v[0].value(), 2.0);
+        v[1] = missing<double>();
+        ASSERT_FALSE(v[1].has_value());
+    }
+
+    TEST(xoptional, vector_iteration)
+    {
+        xoptional_vector<double> v(4, 2.0);
+        v[0] = missing<double>();
+        std::vector<double> res;
+        for(auto it = v.cbegin(); it != v.cend(); ++it)
+        {
+            res.push_back((*it).value_or(0.0));
+        }
+        std::vector<double> expect = {0.0, 2.0, 2.0, 2.0};
+        ASSERT_TRUE(std::equal(res.begin(), res.end(), expect.begin()));
+    }
+
+    TEST(xoptional, tensor)
+    {
+        xtensor_optional<double, 2> m
+
+            {{ 1.0 ,       2.0          },
+             { 3.0 , missing<double>()} };
+
+        ASSERT_EQ(m(0, 0).value(), 1.0);
+        ASSERT_EQ(m(1, 0).value(), 3.0);
+        ASSERT_FALSE(m(1, 1).has_value());
+    }
+}
+


### PR DESCRIPTION
**Prerequisite 1:** One interesting fact in the STL, is that `std::vector` template is specialized for `bool` so that` std::vector<bool>` is *actually coalescing vector elements such that each element occupies a single bit instead of `sizeof(bool)` bytes*. This is a first feature that we are going to take advantage of in the following.

**Prerequisite 2:** Also, the return type of `operator[]` for `std::vector<bool>` is not a reference on a boolean, but an instance of **reference proxy** to which one can assign a boolean. Reference proxies occur in other places in the STL, and we are going to use this sort of things in the missing value support.

**Initial goals:**
 - create a specialized container, whose value type behaves very much like C++17's `std::optional` but such that the actual storage is a regular container plus a bit mask.
 - The reference type will in fact be a **reference proxy** to which one can assign a value or an optional value.

**Implementation details:**

 - The`xoptional<V, B>` does most of the magic. Depending on the parameters V and B, it can serve both as a reference proxy and a value type. In the former case, V and B are typically reference types, while in the latter case V and B are value types.

- `xoptional_sequence` is a 1-D container type that has a `xoptional<reference, flag_reference>` proxy as a reference type and `xoptional<value_type, flag_type>` as a value type an is implemented as a value container and a bitmask.

- `xoptional_sequence` will underlie the `xoptional_vector` and `xoptional_array` optional containers.

We then just have to do

```cpp
template<class T>
using xoptional_array = xarray_container<xoptional_vector<T>>
```
