### PR TITLE
Add data API (xview, xcontainer)

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -129,6 +129,10 @@ namespace xt
         container_type& data() noexcept;
         const container_type& data() const noexcept;
 
+        value_type* raw_data() noexcept;
+        const value_type* raw_data() const noexcept;
+        const size_type raw_data_offset() const noexcept;
+
         template <class S>
         bool broadcast_shape(S& shape) const;
 
@@ -539,6 +543,30 @@ namespace xt
     inline auto xcontainer<D>::data() const noexcept -> const container_type&
     {
         return derived_cast().data_impl();
+    }
+
+    /**
+     * Returns the offset to the first element in the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::raw_data() noexcept -> value_type*
+    {
+        return data().data();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::raw_data() const noexcept -> const value_type*
+    {
+        return data().data();
+    }
+
+    /**
+     * Returns the offset to the first element in the container.
+     */
+    template <class D>
+    inline auto xcontainer<D>::raw_data_offset() const noexcept -> const size_type
+    {
+        return size_type(0);
     }
     //@}
 


### PR DESCRIPTION
This adds `strides()`, `data()`, and `offset()` to the xview class as well as `offset()` to the xcontainer class.

Maybe it would be useful to have a `data_pointer()` API? 

Also, maybe `data_offset()` would be a better name. 

What do you think?

In my opinion, with this PR, integration with external BLAS libraries should be fairly straight forward.