### PR TITLE
Make benchmark a standalone project

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,6 +5,14 @@
 #                                                                          #
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
+cmake_minimum_required(VERSION 3.1)
+
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    project(xtensor-benchmark)
+
+    find_package(xtensor REQUIRED CONFIG)
+    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIR})
+endif ()
 
 message(STATUS "Forcing tests build type to Release")
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)


### PR DESCRIPTION
This PR provides a similar setup as [pybind11](https://github.com/pybind/pybind11/blob/master/tests/CMakeLists.txt) to enable building the benchmarks standalone using a system installed version of `xtensor`.

This is a desirable feature for CI purposes (for example on Debian), whereby the packaged `xtensor` library could be tested for each supported C++ compilers or on each CMake update for instance. Ideally, I'd also want the test suite to be made standalone, but #187 should probably be solved first.