### PR TITLE
gtest downloaded and compiled

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake -c conda-forge
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY .
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON .
   - nmake test_xtensor
   - cd test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,9 @@ install:
     - source activate test-xtensor
     - cd ..
     - if [[ "$BOUND_CHECKS" == 1 ]]; then
-        cmake -DXTENSOR_ENABLE_ASSERT=ON .;
+        cmake -DXTENSOR_ENABLE_ASSERT=ON -DBUILD_TESTS=ON .;
       else
-        cmake .;
+        cmake -DBUILD_TESTS=ON .;
       fi
     - make -j2 test_xtensor
     - cd test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,6 @@ message(STATUS "xtensor v${${PROJECT_NAME}_VERSION}")
 # Build
 # =====
 
-if(XTENSOR_ENABLE_ASSERT)
-    add_definitions(-DXTENSOR_ENABLE_ASSERT)
-endif()
-
-OPTION(BUILD_TESTS "xtensor test suite" ON)
-
 set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xarray.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xassign.hpp
@@ -72,6 +66,14 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xcomplex.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xview_utils.hpp
 )
+
+OPTION(XTENSOR_ENABLE_ASSERT "xtensor bound check" OFF)
+OPTION(BUILD_TESTS "xtensor test suite" OFF)
+OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+
+if(XTENSOR_ENABLE_ASSERT)
+    add_definitions(-DXTENSOR_ENABLE_ASSERT)
+endif()
 
 if(BUILD_TESTS)
     add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,16 @@ Once `gtest` and `cmake` are installed, you can build and run the tests:
 ```bash
 mkdir build
 cd build
-cmake ../
+cmake -DBUILD_TESTS=ON ../
+make xtest
+```
+
+You can also use CMake to download the source of `gtest`, build it, and use the generated libraries:
+
+```bash
+mkdir build
+cd build
+cmake -DBUILD_TESTS=ON -DDOWNLOAD_GTEST=ON ../
 make xtest
 ```
 
@@ -206,7 +215,7 @@ cd test
 conda env create -f ./test-environment.yml
 source activate test-xtensor
 cd ..
-cmake .
+cmake -DBUILD_TESTS=ON .
 make xtest
 ```
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,6 +5,7 @@
 #                                                                          #
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
+
 cmake_minimum_required(VERSION 3.1)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/docs/source/build-options.rst
+++ b/docs/source/build-options.rst
@@ -1,0 +1,48 @@
+.. Copyright (c) 2016, Johan Mabille and Sylvain Corlay
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Build and configuration
+=======================
+
+Build
+-----
+
+``xtensor`` build supports the following options:
+
+- ``BUILD_TESTS``: enables the ``xtest`` and ``xbenchmark`` targets (see below).
+- ``DOWNLOAD_GTEST``: downloads ``gtest`` and builds it locally instead of using a binary installation.
+- ``XTENSOR_ENABLE_ASSERT``: activates the assertions in ``xtensor``.
+
+All these options are disabled by default.
+
+If the ``BUILD_TESTS`` option is enabled, the following targets are available:
+
+- xtest: builds an run the test suite.
+- xbenchmark: builds and runs the benchmarks.
+
+For instance, building the test suite of ``xtensor`` with assertions enabled:
+
+.. code::
+
+    mkdir build
+    cd build
+    cmake -DBUILD_TESTS=ON -DXTENSOR_ENABLE_ASSERT=ON ../
+    make xtest
+
+Configuration
+-------------
+
+``xtensor`` can be configured via macros, which must be defined *before* including any of its header. Here is a list of
+available macros:
+
+- ``XTENSOR_ENABLE_ASSERT``: enables assertions in xtensor, such as bound check.
+- ``DEFAULT_DATA_CONTAINER(T, A)``: defines the type used as the default data container for tensor and arrays. ``T``
+  is the ``value_type`` of the container and ``A`` its ``allocator_type``.
+- ``DEFAULT_SHAPE_CONTAINER(T, EA, SA)``: defines the type used as the default shape container for tensor and arrays.
+  ``T`` is the ``value_type`` of the data container, ``EA`` its ``allocator_type``, and ``SA`` is the ``allocator_type``
+  of the shape container.
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,6 +51,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
    operator
    view
    builder
+   missing
    related
 
 .. toctree::
@@ -67,6 +68,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
 
    compilers
    releasing
+   build-options
    external-structures
 
 .. toctree::

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
+cmake_minimum_required(VERSION 3.1)
+
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    project(xtensor-test)
+
+    find_package(xtensor REQUIRED CONFIG)
+    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIR})
+endif ()
+
 message(STATUS "Forcing tests build type to Release")
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
@@ -56,7 +65,36 @@ if(MSVC)
     endforeach()
 endif()
 
-find_package(GTest REQUIRED)
+if (DOWNLOAD_GTEST)
+    # Download and unpack googletest at configure time
+    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                    RESULT_VARIABLE result
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+    if(result)
+        message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                    RESULT_VARIABLE result
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+    if(result)
+        message(FATAL_ERROR "Build step for googletest failed: ${result}")
+    endif()
+
+    # Add googletest directly to our build. This defines
+    # the gtest and gtest_main targets.
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                     ${CMAKE_CURRENT_BINARY_DIR}/googletest-build)
+
+    set(GTEST_INCLUDE_DIRS "${gtest_SOURCE_DIR}/include")
+    set(GTEST_LIBRARY_DIRS "${gtest_BINARY_DIR}")
+    set(GTEST_LIBRARIES "${GTEST_LIBRARY_DIRS}/gtest.lib")
+    set(GTEST_MAIN_LIBRARIES "${GTEST_LIBRARY_DIRS}/gtest_main.lib")
+    set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
+else()
+    find_package(GTest REQUIRED)
+endif()
+
 find_package(Threads)
 
 include_directories(${XTENSOR_INCLUDE_DIR})
@@ -96,7 +134,7 @@ set(XTENSOR_TESTS
 )
 
 set(XTENSOR_TARGET test_xtensor)
-add_executable(${XTENSOR_TARGET} EXCLUDE_FROM_ALL ${XTENSOR_TESTS} ${XTENSOR_HEADERS})
+add_executable(${XTENSOR_TARGET} ${XTENSOR_TESTS} ${XTENSOR_HEADERS})
 target_link_libraries(${XTENSOR_TARGET} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-add_custom_target(xtest COMMAND test_xtensor DEPENDS ${XTENSOR_TARGET})
+add_custom_target(xtest COMMAND test_xtensor DEPENDS gtest_main ${XTENSOR_TARGET})

--- a/test/CMakeLists.txt.in
+++ b/test/CMakeLists.txt.in
@@ -1,0 +1,23 @@
+############################################################################
+# Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     #
+#                                                                          #
+# Distributed under the terms of the BSD 3-Clause License.                 #
+#                                                                          #
+# The full license is in the file LICENSE, distributed with this software. #
+############################################################################
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           release-1.8.0
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)


### PR DESCRIPTION
`gtest` can be downloaded and built as part of the build of `xtensor`. This can be enabled with:

```bash
cmake -DDOWNLOAD_GTEST=ON ../
```