### PR TITLE
Expand on related projects

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,7 @@
    The full license is in the file LICENSE, distributed with this software.
 
 .. image:: http://quantstack.net/assets/images/xtensor.svg
+   :alt: xtensor
 
 Multi-dimensional arrays with broadcasting and lazy computing.
 
@@ -52,7 +53,6 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
    view
    builder
    missing
-   related
 
 .. toctree::
    :caption: API REFERENCE
@@ -77,6 +77,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
    numpy
    numpy-differences
    closure-semantics
+   related
 
 .. _NumPy: http://www.numpy.org
 .. _Buffer Protocol: https://docs.python.org/3/c-api/buffer.html

--- a/docs/source/related.rst
+++ b/docs/source/related.rst
@@ -7,16 +7,124 @@
 Related projects
 ================
 
-Python bindings
----------------
+.. image:: http://quantstack.net/assets/images/xtensor-python.svg
+   :alt: xtensor-python
 
 The xtensor-python_ project provides the implementation of container types compatible with ``xtensor``'s expression
 system,  ``pyarray`` and ``pytensor`` which effectively wrap numpy arrays, allowing operating on numpy arrays inplace.
 
-Extension Cookiecutter
-----------------------
+Example 1: Use an algorithm of the C++ library on a numpy array inplace
+-----------------------------------------------------------------------
+
+**C++ code**
+
+.. code::
+
+    #include <numeric>                        // Standard library import for std::accumulate
+    #include "pybind11/pybind11.h"            // Pybind11 import to define Python bindings
+    #include "xtensor/xmath.hpp"              // xtensor import for the C++ universal functions
+    #include "xtensor-python/pyarray.hpp"     // Numpy bindings
+
+    double sum_of_sines(xt::pyarray<double> &m)
+    {
+        auto sines = xt::sin(m);
+        // sines does not actually hold any value, which are only computed upon access
+        return std::accumulate(sines.begin(), sines.end(), 0.0);
+    }
+
+    PYBIND11_PLUGIN(xtensor_python_test)
+    {
+        pybind11::module m("xtensor_python_test", "Test module for xtensor python bindings");
+
+        m.def("sum_of_sines", sum_of_sines,
+            "Computes the sum of the sines of the values of the input array");
+
+        return m.ptr();
+    }
+
+**Python code:**
+
+.. code::
+
+    Python Code
+
+    import numpy as np
+    import xtensor_python_test as xt
+
+    a = np.arange(15).reshape(3, 5)
+    s = xt.sum_of_sines(v)
+    s
+
+**Outputs**
+
+.. code::
+
+    1.2853996391883833
+
+
+Example 2: Create a universal function from a C++ scalar function
+-----------------------------------------------------------------
+
+**C++ code**
+
+.. code::
+
+    #include "pybind11/pybind11.h"
+    #include "xtensor-python/pyvectorize.hpp"
+    #include <numeric>
+    #include <cmath>
+
+    namespace py = pybind11;
+
+    double scalar_func(double i, double j)
+    {
+        return std::sin(i) - std::cos(j);
+    }
+
+    PYBIND11_PLUGIN(xtensor_python_test)
+    {
+        py::module m("xtensor_python_test", "Test module for xtensor python bindings");
+
+        m.def("vectorized_func", xt::pyvectorize(scalar_func), "");
+
+        return m.ptr();
+    }
+
+**Python code:**
+
+.. code::
+
+    import numpy as np
+    import xtensor_python_test as xt
+
+    x = np.arange(15).reshape(3, 5)
+    y = [1, 2, 3, 4, 5]
+    z = xt.vectorized_func(x, y)
+    z
+
+**Outputs**
+
+.. code::
+
+    [[-0.540302,  1.257618,  1.89929 ,  0.794764, -1.040465],
+     [-1.499227,  0.136731,  1.646979,  1.643002,  0.128456],
+     [-1.084323, -0.583843,  0.45342 ,  1.073811,  0.706945]]
+
+.. image:: http://quantstack.net/assets/images/xtensor-cookiecutter.png
+   :alt: xtensor-cookiecutter
 
 The xtensor-cookiecutter_ project helps extension authors create Python extension modules making use of `xtensor`.
+
+It takes care of the initial work of generating a project skeleton with
+
+- A complete setup.py compiling the extension module
+
+A few examples included in the resulting project including
+
+- A universal function defined from C++
+- A function making use of an algorithm from the STL on a numpy array
+- Unit tests
+- The generation of the HTML documentation with sphinx
 
 .. _xtensor-python: https://github.com/QuantStack/xtensor-python
 .. _xtensor-cookiecutter: https://github.com/QuantStack/xtensor-cookiecutter

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -769,6 +769,7 @@ namespace xt
      * @brief xexpression with values of arr on the diagonal, zeroes otherwise
      *
      * @param arr the 1D input array of length n
+     * @param k the offset of the considered diagonal
      * @returns xexpression function with shape n x n and arr on the diagonal
      *
      * \code{.cpp}

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -321,7 +321,6 @@ namespace xt
      * Constructs an xfunctorview expression wrappering the specified \ref xexpression.
      *
      * @param e the underlying expression
-     * @param s the shape to apply
      */
     template <class F, class CT>
     inline xfunctorview<F, CT>::xfunctorview(CT e) noexcept

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -363,7 +363,6 @@ namespace xt
     /**
      * Returns a reference to the element at the specified position in the xindexview.
      * @param first iterator starting the sequence of indices
-     * @param last iterator ending the sequence of indices
      * The number of indices in the squence should be equal to or greater 1.
      */
     template <class CT, class I>


### PR DESCRIPTION
- Moving the `related projects` section to miscelaneous.
- Expanding on `xtensor-python` and `xtensor-cookiecutter`.