### PR TITLE
Resolve xtensor-python compilation warning

### DIFF
--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -345,7 +345,8 @@ namespace xt
         template <class R, class U, std::size_t... I>
         constexpr R initializer_shape(U t, std::index_sequence<I...>)
         {
-            return {initializer_shape_impl<I>::value(t)...};
+            using size_type = typename R::value_type;
+            return { size_type(initializer_shape_impl<I>::value(t))... };
         }
     }
 


### PR DESCRIPTION
In the case of numpy arrays, the size_type is different from `std::size_t`, which caused this to warn at build time.