### PR TITLE
gtest build from local sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ OPTION(XTENSOR_ENABLE_ASSERT "xtensor bound check" OFF)
 OPTION(BUILD_TESTS "xtensor test suite" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 
+if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
+    set(BUILD_TESTS ON)
+endif()
+
 if(XTENSOR_ENABLE_ASSERT)
     add_definitions(-DXTENSOR_ENABLE_ASSERT)
 endif()

--- a/docs/source/build-options.rst
+++ b/docs/source/build-options.rst
@@ -14,9 +14,11 @@ Build
 
 - ``BUILD_TESTS``: enables the ``xtest`` and ``xbenchmark`` targets (see below).
 - ``DOWNLOAD_GTEST``: downloads ``gtest`` and builds it locally instead of using a binary installation.
+- ``GTEST_SRC_DIR``: indicates where to find the ``gtest`` sources instead of downloading them.
 - ``XTENSOR_ENABLE_ASSERT``: activates the assertions in ``xtensor``.
 
-All these options are disabled by default.
+All these options are disabled by default. Enabling ``DOWNLOAD_GTEST`` or setting ``GTEST_SRC_DIR``
+enables ``BUILD_TESTS``.
 
 If the ``BUILD_TESTS`` option is enabled, the following targets are available:
 
@@ -31,6 +33,16 @@ For instance, building the test suite of ``xtensor`` with assertions enabled:
     cd build
     cmake -DBUILD_TESTS=ON -DXTENSOR_ENABLE_ASSERT=ON ../
     make xtest
+
+Building the test suite of ``xtensor`` where the sources of ``gtest`` are located in e.g. ``/usr/share/gtest``:
+
+.. code::
+
+    mkdir build
+    cd build
+    cmake -DGTEST_SRC_DIR=/usr/share/gtest ../
+    make xtest
+
 
 Configuration
 -------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,9 +65,14 @@ if(MSVC)
     endforeach()
 endif()
 
-if (DOWNLOAD_GTEST)
-    # Download and unpack googletest at configure time
-    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
+    if(DOWNLOAD_GTEST)
+        # Download and unpack googletest at configure time
+        configure_file(downloadGTest.cmake.in googletest-download/CMakeLists.txt)
+    else()
+        # Copy local source of googletest at configure time
+        configure_file(copyGTest.cmake.in googletest-download/CMakeLists.txt)
+    endif()
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
                     RESULT_VARIABLE result
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
@@ -137,7 +142,7 @@ set(XTENSOR_TARGET test_xtensor)
 add_executable(${XTENSOR_TARGET} ${XTENSOR_TESTS} ${XTENSOR_HEADERS})
 target_link_libraries(${XTENSOR_TARGET} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-if(DOWNLOAD_GTEST)
+if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     add_custom_target(xtest COMMAND test_xtensor DEPENDS gtest_main ${XTENSOR_TARGET})
 else()
     add_custom_target(xtest COMMAND test_xtensor DEPENDS ${XTENSOR_TARGET})

--- a/test/copyGTest.cmake.in
+++ b/test/copyGTest.cmake.in
@@ -1,0 +1,23 @@
+############################################################################
+# Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     #
+#                                                                          #
+# Distributed under the terms of the BSD 3-Clause License.                 #
+#                                                                          #
+# The full license is in the file LICENSE, distributed with this software. #
+############################################################################
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+    URL               "${GTEST_SRC_DIR}"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+)
+

--- a/test/downloadGTest.cmake.in
+++ b/test/downloadGTest.cmake.in
@@ -12,12 +12,13 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.0
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
+    GIT_REPOSITORY    https://github.com/google/googletest.git
+    GIT_TAG           release-1.8.0
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
 )
+


### PR DESCRIPTION
@ghisvail This should allow you to use local source of gtest with the following cmake command:

```bash
cmake -DGTEST_SRC_DIR=full_path_to_source ../
make xtest
```

Please note you don't need to pass `-DBUILD_TESTS=ON` anymore, it is activated by default if either `DOWNLOAD_GTEST` or `GTEST_SRC_DIR` is set.