### PR TITLE
No longer evaluate views with underlying container

### DIFF
--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -18,6 +18,27 @@ namespace xt
     {
         template <class T>
         using is_container = std::is_base_of<xcontainer<std::remove_const_t<T>>, T>;
+
+        template <class T, class E = void>
+        struct has_container_base_impl
+        {
+            static constexpr bool value = false;
+        };
+
+        template <class T>
+        struct has_container_base_impl<T, std::enable_if_t<is_container<std::decay_t<T>>::value>>
+        {
+            static constexpr bool value = true;
+        };
+
+        template<class CT, class... S>
+        struct has_container_base_impl<xview<CT, S...>, std::enable_if_t<is_container<std::decay_t<CT>>::value>>
+        {
+            static constexpr bool value = true;
+        };
+
+        template <class T>
+        using has_container_base = has_container_base_impl<T>;
     }
 
     /**
@@ -32,7 +53,7 @@ namespace xt
      */
     template <class T>
     inline auto eval(T&& t)
-        -> std::enable_if_t<detail::is_container<std::decay_t<T>>::value, T&&>
+        -> std::enable_if_t<detail::has_container_base<T>::value, T&&>
     {
         return t;
     }
@@ -40,14 +61,14 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
+        -> std::enable_if_t<!detail::has_container_base<T>::value && detail::is_array<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
     {
         return xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>(std::forward<T>(t));
     }
 
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
+        -> std::enable_if_t<!detail::has_container_base<T>::value && !detail::is_array<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
     {
         return xarray<typename I::value_type>(std::forward<T>(t));
     }

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -11,9 +11,29 @@
 #include "xtensor/xtensor_config.hpp"
 #include "xtensor/xeval.hpp"
 #include "xtensor/xbuilder.hpp"
+#include "xtensor/xview.hpp"
 
 namespace xt
 {
+
+    TEST(xeval, has_container_base)
+    {
+        xarray<double> a = {1,2,3,4};
+        xtensor<double, 2> b = {{1,2,3}, {4,5,6}};
+        auto c = linspace(0, 10);
+        auto va = view(a, range(0, 2));
+        auto vb = view(b, range(0, 2));
+        auto vc = view(c, range(0, 2));
+
+        EXPECT_TRUE(detail::has_container_base<decltype(a)>::value);
+        EXPECT_TRUE(detail::has_container_base<decltype(b)>::value);
+        EXPECT_TRUE(detail::has_container_base<decltype(va)>::value);
+        EXPECT_TRUE(detail::has_container_base<decltype(vb)>::value);
+        EXPECT_FALSE(detail::has_container_base<decltype(c)>::value);
+        EXPECT_FALSE(detail::has_container_base<decltype(vc)>::value);
+        EXPECT_FALSE(detail::has_container_base<decltype(a * b)>::value);
+    }
+
     TEST(xeval, array_tensor)
     {
         xarray<double> a = {1,2,3,4};


### PR DESCRIPTION
A view with underlying `xcontainer` type shouldn't be evaluated.

Or what do you think? This might not prevent dangling references, as the previous `eval` did. 

However, this is how I intend to use `eval` in the blas adapters as it's unnecessary to evaluate views. 