### PR TITLE
Fixup docs clean target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -49,6 +49,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf xml
 
 html:
 	doxygen


### PR DESCRIPTION
Remove the additional `xml` folder generated by `doxygen`