### PR TITLE
xview constructor is now explicit

### DIFF
--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -105,7 +105,7 @@ namespace xt
         using const_iterator = typename iterable_base::const_iterator;
 
         template <class CTA, class... SL>
-        xview(CTA&& e, SL&&... slices) noexcept;
+        explicit xview(CTA&& e, SL&&... slices) noexcept;
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);


### PR DESCRIPTION
This is really important to avoid problems that have been experienced while implementing axis iterators.