### PR TITLE
Layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xio.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xiterable.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xiterator.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xlayout.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmath.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnoalias.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xoperation.hpp

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -103,12 +103,15 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
+        static constexpr xt::layout layout_type = xexpression_type::layout_type;
+
         template <class CTA, class S>
         xbroadcast(CTA&& e, S&& s) noexcept;
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const inner_shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
@@ -226,6 +229,15 @@ namespace xt
     inline auto xbroadcast<CT, X>::shape() const noexcept -> const inner_shape_type&
     {
         return m_shape;
+    }
+
+    /**
+     * Returns the layout of the expression.
+     */
+    template <class CT, class X>
+    inline xt::layout xbroadcast<CT, X>::layout() const noexcept
+    {
+        return m_e.layout();
     }
     //@}
 

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -104,6 +104,7 @@ namespace xt
         using const_iterator = typename iterable_base::const_iterator;
 
         static constexpr xt::layout layout_type = xexpression_type::layout_type;
+        static constexpr bool contiguous_layout = xexpression_type::contiguous_layout;
 
         template <class CTA, class S>
         xbroadcast(CTA&& e, S&& s) noexcept;

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -203,6 +203,7 @@ namespace xt
         using inner_backstrides_type = typename base_type::inner_backstrides_type;
 
         static constexpr xt::layout layout_type = L;
+        static constexpr bool contiguous_layout = layout_type != xt::layout::dynamic;
 
         void reshape(const shape_type& shape, bool force = false);
         void reshape(const shape_type& shape, xt::layout l);

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -208,7 +208,7 @@ namespace xt
         void reshape(const shape_type& shape, xt::layout l);
         void reshape(const shape_type& shape, const strides_type& strides);
 
-        xt::layout layout();
+        xt::layout layout() const noexcept;
 
     protected:
 
@@ -663,7 +663,7 @@ namespace xt
      * @return layout of the container
      */
     template <class D, layout L>
-    xt::layout xstrided_container<D, L>::layout()
+    xt::layout xstrided_container<D, L>::layout() const noexcept
     {
         return m_layout;
     }
@@ -676,12 +676,12 @@ namespace xt
     template <class D, layout L>
     inline void xstrided_container<D, L>::reshape(const shape_type& shape, bool force)
     {
-        if (m_layout == xt::layout::dynamic)
-        {
-            m_layout = xt::layout::row_major;  // fall back to row major
-        }
         if (shape != m_shape || force)
         {
+            if (m_layout == xt::layout::dynamic || m_layout == xt::layout::any)
+            {
+                m_layout = xt::layout::row_major;  // fall back to row major
+            }
             m_shape = shape;
             resize_container(m_strides, m_shape.size());
             resize_container(m_backstrides, m_shape.size());
@@ -722,6 +722,7 @@ namespace xt
         m_strides = strides;
         resize_container(m_backstrides, m_strides.size());
         adapt_strides(m_shape, m_strides, m_backstrides);
+        m_layout = xt::layout::dynamic;
         this->data().resize(compute_size(m_shape));
     }
 }

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -19,6 +19,7 @@
 
 #include "xexpression.hpp"
 #include "xiterator.hpp"
+#include "xlayout.hpp"
 #include "xutils.hpp"
 
 namespace xt
@@ -128,12 +129,15 @@ namespace xt
         using const_broadcast_iterator = xiterator<const_stepper, shape_type*>;
         using broadcast_iterator = const_broadcast_iterator;
 
+        static constexpr xt::layout layout_type = compute_layout(std::decay_t<CT>::layout_type...);
+
         template <class Func>
         xfunction(Func&& f, CT... e) noexcept;
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type& shape() const;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
@@ -175,6 +179,9 @@ namespace xt
         const_stepper stepper_end(const S& shape) const noexcept;
 
     private:
+
+        template <std::size_t... I>
+        xt::layout layout_impl(std::index_sequence<I...>) const noexcept;
 
         template <std::size_t... I, class... Args>
         const_reference access_impl(std::index_sequence<I...>, Args... args) const;
@@ -357,6 +364,15 @@ namespace xt
             m_shape_computed = true;
         }
         return m_shape;
+    }
+
+    /**
+     * Returns the layout of the xfunction.
+     */
+    template <class F, class R, class... CT>
+    inline xt::layout xfunction<F, R, CT...>::layout() const noexcept
+    {
+        return layout_impl(std::make_index_sequence<sizeof...(CT)>());
     }
     //@}
 
@@ -586,6 +602,13 @@ namespace xt
     {
         auto f = [&shape](const auto& e) noexcept { return e.stepper_end(shape); };
         return build_stepper(f, std::make_index_sequence<sizeof...(CT)>());
+    }
+
+    template <class F, class R, class... CT>
+    template <std::size_t... I>
+    inline xt::layout xfunction<F, R, CT...>::layout_impl(std::index_sequence<I...>) const noexcept
+    {
+        return compute_layout(std::get<I>(m_e).layout()...);
     }
 
     template <class F, class R, class... CT>

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -130,6 +130,7 @@ namespace xt
         using broadcast_iterator = const_broadcast_iterator;
 
         static constexpr xt::layout layout_type = compute_layout(std::decay_t<CT>::layout_type...);
+        static constexpr bool contiguous_layout = and_c<std::decay_t<CT>::contiguous_layout...>::value;
 
         template <class Func>
         xfunction(Func&& f, CT... e) noexcept;

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -116,6 +116,8 @@ namespace xt
         using iterator = xfunctor_iterator<functor_type, typename xexpression_type::iterator>;
         using const_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_iterator>;
 
+        static constexpr xt::layout layout_type = xexpression_type::layout_type;
+
         xfunctorview(CT) noexcept;
 
         template <class Func, class E>
@@ -130,6 +132,7 @@ namespace xt
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         reference operator()(Args... args);
@@ -395,6 +398,15 @@ namespace xt
     inline auto xfunctorview<F, CT>::shape() const noexcept -> const shape_type&
     {
         return m_e.shape();
+    }
+
+    /**
+     * Returns the layout of the expression.
+     */
+    template <class F, class CT>
+    inline xt::layout xfunctorview<F, CT>::layout() const noexcept
+    {
+        return m_e.layout();
     }
     //@}
 

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -117,6 +117,7 @@ namespace xt
         using const_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_iterator>;
 
         static constexpr xt::layout layout_type = xexpression_type::layout_type;
+        static constexpr bool contiguous_layout = false;
 
         xfunctorview(CT) noexcept;
 

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -86,7 +86,8 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
-        static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr xt::layout layout_type = xt::layout::any;
+        static constexpr bool contiguous_layout = true;
         
         template <class Func>
         xgenerator(Func&& f, const S& shape) noexcept;

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -86,12 +86,15 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
+        static constexpr xt::layout layout_type = xt::layout::dynamic;
+        
         template <class Func>
         xgenerator(Func&& f, const S& shape) noexcept;
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const inner_shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
@@ -170,6 +173,13 @@ namespace xt
     {
         return m_shape;
     }
+
+    template <class F, class R, class S>
+    inline xt::layout xgenerator<F, R, S>::layout() const noexcept
+    {
+        return layout_type;
+    }
+
     //@}
 
     /**

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -102,6 +102,8 @@ namespace xt
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
 
+        static constexpr xt::layout layout_type = xt::layout::dynamic;
+
         template <class I2>
         xindexview(CT e, I2&& indices) noexcept;
 
@@ -114,6 +116,7 @@ namespace xt
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const inner_shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         reference operator()();
         template <class... Args>
@@ -300,6 +303,13 @@ namespace xt
     {
         return m_shape;
     }
+
+    template <class CT, class I>
+    inline xt::layout xindexview<CT, I>::layout() const noexcept
+    {
+        return layout_type;
+    }
+
     //@}
 
     /**

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -103,6 +103,7 @@ namespace xt
         using base_index_type = xindex_type_t<shape_type>;
 
         static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr bool contiguous_layout = false;
 
         template <class I2>
         xindexview(CT e, I2&& indices) noexcept;

--- a/include/xtensor/xlayout.hpp
+++ b/include/xtensor/xlayout.hpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XLAYOUT_HPP
+#define XLAYOUT_HPP
+
+namespace xt
+{
+    /*! Layout enum for xcontainer based xexpressions */
+    enum class layout
+    {
+        dynamic = 0x00, /*! dynamic layout: you can reshape to row major, column major, or use custom strides */
+        any = 0xFF, /*! layout compatible with all others */
+        row_major = 0x01, /*! row major layout */
+        column_major = 0x02 /*! column major layout */
+    };
+
+    /**
+     * Implementation of the following logical table:
+     *
+     *   | d | a | r | c |
+     * --+---+---+---+---+
+     * d | d | d | d | d |
+     * a | d | a | r | c |
+     * r | d | r | r | d |
+     * c | d | c | d | c |
+     *
+     * d = dynamic, a = any, r = row_major, c = column_major.
+     * Using bitmasks to avoid nested if-else statements.
+     */
+    template <class... Args>
+    constexpr layout compute_layout(Args... args) noexcept;
+
+    /******************
+     * Implementation *
+     ******************/
+
+    namespace detail
+    {
+        constexpr layout compute_layout_impl() noexcept
+        {
+            return xt::layout::any;
+        }
+
+        constexpr layout compute_layout_impl(layout l) noexcept
+        {
+            return l;
+        }
+
+        constexpr layout compute_layout_impl(layout lhs, layout rhs) noexcept
+        {
+            using type = std::underlying_type_t<layout>;
+            return layout(static_cast<type>(lhs) & static_cast<type>(rhs));
+        }
+
+        template <class... Args>
+        constexpr layout compute_layout_impl(layout lhs, Args... args) noexcept
+        {
+            return compute_layout_impl(lhs, compute_layout_impl(args...));
+        }
+    }
+
+    template <class... Args>
+    constexpr layout compute_layout(Args... args) noexcept
+    {
+        return detail::compute_layout_impl(args...);
+    }
+
+
+}
+
+#endif

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -125,12 +125,15 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
+        static constexpr xt::layout layout_type = xt::layout::dynamic;
+
         template <class Func, class CTA, class AX>
         xreducer(Func&& func, CTA&& e, AX&& axes);
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const inner_shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
@@ -465,6 +468,15 @@ namespace xt
     inline auto xreducer<F, CT, X>::shape() const noexcept -> const inner_shape_type&
     {
         return m_shape;
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class F, class CT, class X>
+    inline xt::layout xreducer<F, CT, X>::layout() const noexcept
+    {
+        return layout_type;
     }
     //@}
 

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -126,6 +126,7 @@ namespace xt
         using const_iterator = typename iterable_base::const_iterator;
 
         static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr bool contiguous_layout = false;
 
         template <class Func, class CTA, class AX>
         xreducer(Func&& func, CTA&& e, AX&& axes);

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -58,6 +58,7 @@ namespace xt
         using const_iterator = const_broadcast_iterator;
 
         static constexpr xt::layout layout_type = xt::layout::any;
+        static constexpr bool contiguous_layout = true;
 
         xscalar(CT value) noexcept;
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include "xexpression.hpp"
+#include "xlayout.hpp"
 
 namespace xt
 {
@@ -56,11 +57,14 @@ namespace xt
         using iterator = broadcast_iterator;
         using const_iterator = const_broadcast_iterator;
 
+        static constexpr xt::layout layout_type = xt::layout::any;
+
         xscalar(CT value) noexcept;
 
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type& shape() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         reference operator()(Args...) noexcept;
@@ -259,6 +263,12 @@ namespace xt
     {
         static std::array<size_type, 0> zero_shape;
         return zero_shape;
+    }
+
+    template <class CT>
+    inline xt::layout xscalar<CT>::layout() const noexcept
+    {
+        return layout_type;
     }
 
     template <class CT>

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -11,6 +11,7 @@
 
 #include "xtensor_config.hpp"
 #include "xstorage.hpp"
+#include "xlayout.hpp"
 #include <memory>
 #include <vector>
 
@@ -18,14 +19,6 @@ namespace xt
 {
     template <class C>
     struct xcontainer_inner_types;
-
-    /*! Layout enum for xcontainer based xexpressions */
-    enum class layout
-    {
-        dynamic = 0, /*! dynamic layout: you can reshape to row major, column major, or use custom strides */
-        row_major = 1, /*! row major layout */
-        column_major = 2 /*! column major layout */
-    };
 
     template <class EC, layout L, class SC = DEFAULT_SHAPE_CONTAINER(typename EC::value_type,
                                                                      typename EC::allocator_type,

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -42,6 +42,12 @@ namespace xt
     template <class... T>
     struct and_;
 
+    template <bool... B>
+    struct or_c;
+
+    template <bool... B>
+    struct and_c;
+
     template <std::size_t I, class... Args>
     constexpr decltype(auto) argument(Args&&... args) noexcept;
 
@@ -177,9 +183,9 @@ namespace xt
     {
     };
 
-    /**********************
+    /***********************
      * and_ implementation *
-     **********************/
+     ***********************/
 
     template <>
     struct and_<> : std::integral_constant<bool, true>
@@ -189,6 +195,20 @@ namespace xt
     template <class T, class... Ts>
     struct and_<T, Ts...>
         : std::integral_constant<bool, T::value && and_<Ts...>::value>
+    {
+    };
+
+    /**********************************
+     * or_c and and_c implementations *
+     **********************************/
+
+    template <bool... B>
+    struct or_c : or_<std::integral_constant<bool, B>...>
+    {
+    };
+
+    template <bool... B>
+    struct and_c : and_<std::integral_constant<bool, B>...>
     {
     };
 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -104,6 +104,8 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
+        static constexpr xt::layout layout_type = xt::layout::dynamic;
+
         template <class CTA, class... SL>
         explicit xview(CTA&& e, SL&&... slices) noexcept;
 
@@ -118,6 +120,7 @@ namespace xt
         size_type size() const noexcept;
         const inner_shape_type& shape() const noexcept;
         const slice_type& slices() const noexcept;
+        xt::layout layout() const noexcept;
 
         template <class... Args>
         reference operator()(Args... args);
@@ -411,6 +414,15 @@ namespace xt
     inline auto xview<CT, S...>::slices() const noexcept -> const slice_type&
     {
         return m_slices;
+    }
+        
+    /**
+     * Returns the slices of the view.
+     */
+    template <class CT, class... S>
+    inline xt::layout xview<CT, S...>::layout() const noexcept
+    {
+        return layout_type;
     }
 
     /**

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -105,6 +105,7 @@ namespace xt
         using const_iterator = typename iterable_base::const_iterator;
 
         static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr bool contiguous_layout = false;
 
         template <class CTA, class... SL>
         explicit xview(CTA&& e, SL&&... slices) noexcept;

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -9,6 +9,8 @@
 #ifndef TEST_COMMON_HPP
 #define TEST_COMMON_HPP
 
+#include "xtensor/xlayout.hpp"
+
 namespace xt
 {
     template <class T, class A>
@@ -53,12 +55,14 @@ namespace xt
         strides_type m_strides;
         strides_type m_backstrides;
         vector_type m_data;
+        xt::layout m_layout;
         assigner_type m_assigner;
 
         inline size_type size() const { return m_data.size(); }
         inline const shape_type& shape() const { return m_shape; }
         inline const strides_type& strides() const { return m_strides; }
         inline const strides_type& backstrides() const { return m_backstrides; }
+        inline xt::layout layout() const { return m_layout; }
         inline const vector_type& data() const { return m_data; }
     };
 
@@ -72,6 +76,7 @@ namespace xt
             this->m_data = { -1, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                              10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                              20, 21, 22, 23 };
+            this->m_layout = xt::layout::row_major;
         }
     };
 
@@ -86,6 +91,7 @@ namespace xt
                               1, 9, 17, 5, 13, 21,
                               2, 10, 18, 6, 14, 22,
                               3, 11, 19, 7, 15, 23 };
+            this->m_layout = xt::layout::column_major;
         }
     };
 
@@ -99,6 +105,7 @@ namespace xt
             this->m_data = { -1, 4, 1, 5, 2, 6, 3, 7,
                               8, 12, 9, 13, 10, 14, 11, 15,
                              16, 20, 17, 21, 18, 22, 19, 23 };
+            this->m_layout = xt::layout::dynamic;
         }
     };
 
@@ -118,6 +125,7 @@ namespace xt
             m_strides = { 4, 0, 1 };
             m_backstrides = { 8, 0, 3 };
             m_data = { -1, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19 };
+            m_layout = xt::layout::dynamic;
             m_assigner.resize(m_shape[0]);
             for (std::size_t i = 0; i < m_shape[0]; ++i)
             {
@@ -132,22 +140,28 @@ namespace xt
         strides_type m_strides;
         strides_type m_backstrides;
         vector_type m_data;
+        xt::layout m_layout;
         assigner_type m_assigner;
 
         inline size_type size() const { return m_data.size(); }
         inline const shape_type& shape() const { return m_shape; }
         inline const strides_type& strides() const { return m_strides; }
         inline const strides_type& backstrides() const { return m_backstrides; }
+        inline xt::layout layout() const { return m_layout; }
         inline const vector_type& data() const { return m_data; }
     };
 
     template <class V, class R>
-    void compare_shape(V& vec, const R& result)
+    void compare_shape(V& vec, const R& result, bool compare_layout = true)
     {
         EXPECT_EQ(vec.shape(), result.shape());
         EXPECT_EQ(vec.strides(), result.strides());
         EXPECT_EQ(vec.backstrides(), result.backstrides());
         EXPECT_EQ(vec.size(), result.size());
+        if (compare_layout)
+        {
+            EXPECT_EQ(vec.layout(), result.layout());
+        }
     }
 
     template <class V, class C = std::vector<std::size_t>>
@@ -178,7 +192,8 @@ namespace xt
             SCOPED_TRACE("unit_shape reshape");
             unit_shape_result<C> usr;
             vec.reshape(usr.m_shape, layout::row_major);
-            compare_shape(vec, usr);
+            compare_shape(vec, usr, false);
+            EXPECT_EQ(vec.layout(), layout::row_major);
         }
     }
 

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -22,6 +22,7 @@ namespace xt
         ASSERT_EQ(1.0, m1_broadcast(0, 0, 0));
         ASSERT_EQ(4.0, m1_broadcast(0, 1, 0));
         ASSERT_EQ(5.0, m1_broadcast(0, 1, 1));
+        ASSERT_EQ(m1_broadcast.layout(), m1.layout());
 
         auto shape = std::vector<std::size_t> {1, 2, 3};
         auto m1_broadcast2 = broadcast(m1, shape);

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -74,6 +74,50 @@ namespace xt
         }
     }
 
+    TEST(xfunction, layout)
+    {
+        xarray<int, layout::dynamic> m_d;
+        xarray<int, layout::row_major> m_r;
+        xarray<int, layout::column_major> m_c;
+        xscalar<int> m_a(2);
+
+        auto res_dd = m_d + m_d;
+        EXPECT_EQ(res_dd.layout(), layout::dynamic);
+        auto res_dr = m_d + m_r;
+        EXPECT_EQ(res_dr.layout(), layout::dynamic);
+        auto res_dc = m_d + m_c;
+        EXPECT_EQ(res_dc.layout(), layout::dynamic);
+        auto res_da = m_d + m_a;
+        EXPECT_EQ(res_da.layout(), layout::dynamic);
+
+        auto res_rd = m_r + m_d;
+        EXPECT_EQ(res_rd.layout(), layout::dynamic);
+        auto res_rr = m_r + m_r;
+        EXPECT_EQ(res_rr.layout(), layout::row_major);
+        auto res_rc = m_r + m_c;
+        EXPECT_EQ(res_rc.layout(), layout::dynamic);
+        auto res_ra = m_r + m_a;
+        EXPECT_EQ(res_ra.layout(), layout::row_major);
+
+        auto res_cd = m_c + m_d;
+        EXPECT_EQ(res_cd.layout(), layout::dynamic);
+        auto res_cr = m_c + m_r;
+        EXPECT_EQ(res_cr.layout(), layout::dynamic);
+        auto res_cc = m_c + m_c;
+        EXPECT_EQ(res_cc.layout(), layout::column_major);
+        auto res_ca = m_c + m_a;
+        EXPECT_EQ(res_ca.layout(), layout::column_major);
+
+        auto res_ad = m_a + m_d;
+        EXPECT_EQ(res_ad.layout(), layout::dynamic);
+        auto res_ar = m_a + m_r;
+        EXPECT_EQ(res_ar.layout(), layout::row_major);
+        auto res_ac = m_a + m_c;
+        EXPECT_EQ(res_ac.layout(), layout::column_major);
+        auto res_aa = m_a + m_a;
+        EXPECT_EQ(res_aa.layout(), layout::any);
+    }
+
     TEST(xfunction, access)
     {
         xfunction_features f;

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -23,6 +23,7 @@ namespace xt
         xarray<double> e = xt::random::rand<double>({3, 3});
         xarray<double> e_copy = e;
         auto v = index_view(e, {{1, 1}, {1, 2}, {2, 2}});
+        EXPECT_EQ(v.layout(), layout::dynamic);
 
         using shape_type = typename decltype(v)::shape_type;
         EXPECT_EQ(shape_type{3}, v.shape());

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -46,6 +46,7 @@ namespace xt
         xreducer_features features;
         xreducer_features::shape_type s = { 3, 4, 5 };
         EXPECT_EQ(s, features.m_red.shape());
+        EXPECT_EQ(features.m_red.layout(), layout::dynamic);
     }
 
     TEST(xreducer, access)

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -34,6 +34,7 @@ namespace xt
         // The dimension of a xscalar is 0
         xscalar<int> x(2);
         EXPECT_EQ(x.dimension(), 0);
+        EXPECT_EQ(x.layout(), layout::any);
     }
 
     TEST(xscalar, iterator)

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -51,6 +51,7 @@ namespace xt
         EXPECT_EQ(a(1, 1), view1(0));
         EXPECT_EQ(a(1, 2), view1(1));
         EXPECT_EQ(1, view1.dimension());
+        EXPECT_EQ(layout::dynamic, view1.layout());
 
         auto view0 = view(a, 0, range(0, 3));
         EXPECT_EQ(a(0, 0), view0(0));


### PR DESCRIPTION
Here is a list of the main changes:

- `layout_type` and `layout` function added to all expression types.
- new value `layout::any` required for `xscalar`.
- values of `layout` enum changed so we can use bitmask operations when computing layouts.

@wolfv ready for review, that shouldn't break the code in your bindings for BLAS. Feel free to merge if you are ok with the implementation.