### PR TITLE
Dynamic view (on top of the strided view)

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -273,7 +273,6 @@ namespace xt
         {
             return xall<std::size_t>(size);
         }
-
     private:
         A m_min;
         B m_max;

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -232,21 +232,21 @@ namespace xt
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<!std::is_integral<MI>::value && std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
-        get(std::size_t size)
+        get(std::size_t size) const
         {
             return xstepped_range<int>(m_step > 0 ? 0 : int(size) - 1, m_max, m_step);
         }
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<std::is_integral<MI>::value && !std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
-        get(std::size_t size)
+        get(std::size_t size) const
         {
             return xstepped_range<int>(m_min, m_step > 0 ? int(size) : -1, m_step);
         }
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<!std::is_integral<MI>::value && !std::is_integral<MA>::value && std::is_integral<STEP>::value, xstepped_range<int>>
-        get(std::size_t size)
+        get(std::size_t size) const
         {
             int min_val_arg = m_step > 0 ? 0 : int(size) - 1;
             int max_val_arg = m_step > 0 ? int(size) : -1;
@@ -255,21 +255,21 @@ namespace xt
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<std::is_integral<MI>::value && !std::is_integral<MA>::value && !std::is_integral<STEP>::value, xrange<std::size_t>>
-        get(std::size_t size)
+        get(std::size_t size) const
         {
             return xrange<std::size_t>((std::size_t)m_min, size);
         }
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<!std::is_integral<MI>::value && std::is_integral<MA>::value && !std::is_integral<STEP>::value, xrange<std::size_t>>
-            get(std::size_t /*size*/)
+        get(std::size_t /*size*/) const
         {
             return xrange<std::size_t>(0, (std::size_t)m_max);
         }
 
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<!std::is_integral<MI>::value && !std::is_integral<MA>::value && !std::is_integral<STEP>::value, xall<std::size_t>>
-        get(std::size_t size)
+        get(std::size_t size) const
         {
             return xall<std::size_t>(size);
         }

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -23,24 +23,24 @@
 
 namespace xt
 {
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     class xstrided_view;
 
-    template <class CT, class CD>
-    struct xcontainer_inner_types<xstrided_view<CT, CD>>
+    template <class CT, class S, class CD>
+    struct xcontainer_inner_types<xstrided_view<CT, S, CD>>
     {
         using xexpression_type = std::decay_t<CT>;
         using temporary_type = xarray<typename xexpression_type::value_type>;
     };
 
-    template <class CT, class CD>
-    struct xiterable_inner_types<xstrided_view<CT, CD>>
+    template <class CT, class S, class CD>
+    struct xiterable_inner_types<xstrided_view<CT, S, CD>>
     {
-        using inner_shape_type = typename std::decay_t<CT>::shape_type;
+        using inner_shape_type = S;
         using inner_strides_type = inner_shape_type;
         using inner_backstrides_type_type = inner_shape_type;
-        using const_stepper = xindexed_stepper<xstrided_view<CT, CD>>;
-        using stepper = xindexed_stepper<xstrided_view<CT, CD>, false>;
+        using const_stepper = xindexed_stepper<xstrided_view<CT, S, CD>>;
+        using stepper = xindexed_stepper<xstrided_view<CT, S, CD>, false>;
         using const_broadcast_iterator = xiterator<const_stepper, inner_shape_type*>;
         using broadcast_iterator = xiterator<stepper, inner_shape_type*>;
         using const_iterator = const_broadcast_iterator;
@@ -63,14 +63,14 @@ namespace xt
      * 
      * @sa stridedview, transpose
      */
-    template <class CT, class CD>
-    class xstrided_view : public xview_semantic<xstrided_view<CT, CD>>,
-                          public xexpression_iterable<xstrided_view<CT, CD>>
+    template <class CT, class S, class CD>
+    class xstrided_view : public xview_semantic<xstrided_view<CT, S, CD>>,
+                          public xexpression_iterable<xstrided_view<CT, S, CD>>
     {
 
     public:
 
-        using self_type = xstrided_view<CT, CD>;
+        using self_type = xstrided_view<CT, S, CD>;
         using xexpression_type = std::decay_t<CT>;
         using semantic_base = xview_semantic<self_type>;
 
@@ -100,11 +100,13 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
+        static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr bool contiguous_layout = false;
+
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
 
-        template <class I>
-        xstrided_view(CT e, I&& shape, I&& strides, std::size_t offset) noexcept;
+        xstrided_view(CT e, S&& shape, S&& strides, std::size_t offset) noexcept;
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);
@@ -171,7 +173,7 @@ namespace xt
 
         void assign_temporary_impl(temporary_type& tmp);
 
-        friend class xview_semantic<xstrided_view<CT, CD>>;
+        friend class xview_semantic<xstrided_view<CT, S, CD>>;
     };
 
     /*****************************
@@ -189,10 +191,9 @@ namespace xt
      * @param e the underlying xexpression for this view
      * @param indices the indices to select
      */
-    template <class CT, class CD>
-    template <class I>
-    inline xstrided_view<CT, CD>::xstrided_view(CT e, I&& shape, I&& strides, std::size_t offset) noexcept
-        : m_e(e), m_data(m_e.data()), m_shape(std::forward<I>(shape)), m_strides(std::forward<I>(strides)), m_offset(offset)
+    template <class CT, class S, class CD>
+    inline xstrided_view<CT, S, CD>::xstrided_view(CT e, S&& shape, S&& strides, std::size_t offset) noexcept
+        : m_e(e), m_data(m_e.data()), m_shape(std::forward<S>(shape)), m_strides(std::forward<S>(strides)), m_offset(offset)
     {
         m_backstrides = make_sequence<backstrides_type>(m_shape.size(), 0);
         adapt_strides(m_shape, m_strides, m_backstrides);
@@ -206,24 +207,24 @@ namespace xt
     /**
      * The extended assignment operator.
      */
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class E>
-    inline auto xstrided_view<CT, CD>::operator=(const xexpression<E>& e) -> self_type&
+    inline auto xstrided_view<CT, S, CD>::operator=(const xexpression<E>& e) -> self_type&
     {
         return semantic_base::operator=(e);
     }
     //@}
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class E>
-    inline auto xstrided_view<CT, CD>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    inline auto xstrided_view<CT, S, CD>::operator=(const E& e) -> disable_xexpression<E, self_type>&
     {
         std::fill(this->begin(), this->end(), e);
         return *this;
     }
 
-    template <class CT, class CD>
-    inline void xstrided_view<CT, CD>::assign_temporary_impl(temporary_type& tmp)
+    template <class CT, class S, class CD>
+    inline void xstrided_view<CT, S, CD>::assign_temporary_impl(temporary_type& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
     }
@@ -235,8 +236,8 @@ namespace xt
     /**
      * Returns the size of the xstrided_view.
      */
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::size() const noexcept -> size_type
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::size() const noexcept -> size_type
     {
         return compute_size(shape());
     }
@@ -244,8 +245,8 @@ namespace xt
     /**
      * Returns the number of dimensions of the xstrided_view.
      */
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::dimension() const noexcept -> size_type
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::dimension() const noexcept -> size_type
     {
         return m_shape.size();
     }
@@ -253,50 +254,50 @@ namespace xt
     /**
      * Returns the shape of the xstrided_view.
      */
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::shape() const noexcept -> const shape_type&
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::shape() const noexcept -> const shape_type&
     {
         return m_shape;
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::strides() const noexcept -> const strides_type&
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::strides() const noexcept -> const strides_type&
     {
         return m_strides;
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::backstrides() const noexcept -> const backstrides_type&
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::backstrides() const noexcept -> const backstrides_type&
     {
         return m_backstrides;
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::data() noexcept -> underlying_container_type&
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data() noexcept -> underlying_container_type&
     {
         return m_e.data();
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::data() const noexcept -> const underlying_container_type&
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::data() const noexcept -> const underlying_container_type&
     {
         return m_e.data();
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::raw_data() noexcept -> value_type*
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data() noexcept -> value_type*
     {
         return m_e.raw_data();
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::raw_data() const noexcept -> const value_type*
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data() const noexcept -> const value_type*
     {
         return m_e.raw_data();
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::raw_data_offset() const noexcept -> size_type
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::raw_data_offset() const noexcept -> size_type
     {
         return m_offset;
     }
@@ -305,21 +306,21 @@ namespace xt
     /**
      * @name Data
      */
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator()() -> reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator()() -> reference
     {
         return m_e();
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator()() const -> const_reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator()() const -> const_reference
     {
         return m_e();
     }
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class... Args>
-    inline auto xstrided_view<CT, CD>::operator()(Args... args) -> reference
+    inline auto xstrided_view<CT, S, CD>::operator()(Args... args) -> reference
     {
         XTENSOR_ASSERT(check_index(shape(), args...));
         size_type index = m_offset + data_offset<size_type>(strides(), static_cast<size_type>(args)...);
@@ -331,35 +332,35 @@ namespace xt
      * 
      * @param idx the position in the view
      */
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class... Args>
-    inline auto xstrided_view<CT, CD>::operator()(Args... args) const -> const_reference
+    inline auto xstrided_view<CT, S, CD>::operator()(Args... args) const -> const_reference
     {
         XTENSOR_ASSERT(check_index(shape(), args...));
         size_type index = m_offset + data_offset<size_type>(strides(), static_cast<size_type>(args)...);
         return m_data[index];
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator[](const xindex& index) -> reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](const xindex& index) -> reference
     {
         return element(index.cbegin(), index.cend());
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator[](size_type i) -> reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](size_type i) -> reference
     {
         return operator()(i);
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator[](const xindex& index) const -> const_reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](const xindex& index) const -> const_reference
     {
         return element(index.cbegin(), index.cend());
     }
 
-    template <class CT, class CD>
-    inline auto xstrided_view<CT, CD>::operator[](size_type i) const -> const_reference
+    template <class CT, class S, class CD>
+    inline auto xstrided_view<CT, S, CD>::operator[](size_type i) const -> const_reference
     {
         return operator()(i);
     }
@@ -369,16 +370,16 @@ namespace xt
      * @param first iterator starting the sequence of indices
      * The number of indices in the squence should be equal to or greater 1.
      */
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class It>
-    inline auto xstrided_view<CT, CD>::element(It first, It last) -> reference
+    inline auto xstrided_view<CT, S, CD>::element(It first, It last) -> reference
     {
         return m_data[m_offset + element_offset<size_type>(strides(), first, last)];
     }
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class It>
-    inline auto xstrided_view<CT, CD>::element(It first, It last) const -> const_reference
+    inline auto xstrided_view<CT, S, CD>::element(It first, It last) const -> const_reference
     {
         return m_data[m_offset + element_offset<size_type>(strides(), first, last)];
     }
@@ -393,9 +394,9 @@ namespace xt
      * @param shape the result shape
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class O>
-    inline bool xstrided_view<CT, CD>::broadcast_shape(O& shape) const
+    inline bool xstrided_view<CT, S, CD>::broadcast_shape(O& shape) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }
@@ -405,9 +406,9 @@ namespace xt
      * the broadcasting is trivial.
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class O>
-    inline bool xstrided_view<CT, CD>::is_trivial_broadcast(const O& str) const noexcept
+    inline bool xstrided_view<CT, S, CD>::is_trivial_broadcast(const O& str) const noexcept
     {
         return str.size() == strides().size() &&
             std::equal(str.cbegin(), str.cend(), strides().begin());
@@ -418,33 +419,33 @@ namespace xt
      * stepper api *
      ***************/
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class ST>
-    inline auto xstrided_view<CT, CD>::stepper_begin(const ST& shape) -> stepper
+    inline auto xstrided_view<CT, S, CD>::stepper_begin(const ST& shape) -> stepper
     {
         size_type offset = shape.size() - dimension();
         return stepper(this, offset);
     }
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class ST>
-    inline auto xstrided_view<CT, CD>::stepper_end(const ST& shape) -> stepper
+    inline auto xstrided_view<CT, S, CD>::stepper_end(const ST& shape) -> stepper
     {
         size_type offset = shape.size() - dimension();
         return stepper(this, offset, true);
     }
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class ST>
-    inline auto xstrided_view<CT, CD>::stepper_begin(const ST& shape) const -> const_stepper
+    inline auto xstrided_view<CT, S, CD>::stepper_begin(const ST& shape) const -> const_stepper
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, offset);
     }
 
-    template <class CT, class CD>
+    template <class CT, class S, class CD>
     template <class ST>
-    inline auto xstrided_view<CT, CD>::stepper_end(const ST& shape) const -> const_stepper
+    inline auto xstrided_view<CT, S, CD>::stepper_end(const ST& shape) const -> const_stepper
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, offset, true);
@@ -466,7 +467,7 @@ namespace xt
     template <class E, class I>
     inline auto strided_view(E&& e, I&& shape, I&& strides, std::size_t offset = 0) noexcept
     {
-        using view_type = xstrided_view<xclosure_t<E>, decltype(e.data())>;
+        using view_type = xstrided_view<xclosure_t<E>, I, decltype(e.data())>;
         return view_type(std::forward<E>(e), std::forward<I>(shape), std::forward<I>(strides), offset);
     }
 
@@ -502,7 +503,7 @@ namespace xt
                 temp_shape[i] = e.shape()[permutation[i]];
                 temp_strides[i] = e.strides()[permutation[i]];
             }
-            using view_type = xstrided_view<xclosure_t<E>, decltype(e.data())>;
+            using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(e.data())>;
             return view_type(std::forward<E>(e), std::move(temp_shape), std::move(temp_strides), 0);
         }
 
@@ -537,7 +538,7 @@ namespace xt
         resize_container(strides, e.strides().size());
         std::copy(e.strides().rbegin(), e.strides().rend(), strides.begin());
 
-        using view_type = xstrided_view<xclosure_t<E>, decltype(e.data())>;
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(e.data())>;
         return view_type(std::forward<E>(e), std::move(shape), std::move(strides), 0);
     }
 
@@ -568,6 +569,170 @@ namespace xt
     }
 #endif
 
+    class slice_vector : private std::vector<std::array<long int, 3>>
+    {
+
+    public:
+
+        using base_type = std::vector<std::array<long int, 3>>;
+        using index_type = long int;
+
+        // propagating interface
+        using base_type::begin;
+        using base_type::cbegin;
+        using base_type::end;
+        using base_type::cend;
+        using base_type::size;
+        using base_type::operator[];
+        using base_type::push_back;
+
+        inline slice_vector() = default;
+
+        template <class E, class... Args>
+        inline slice_vector(const xexpression<E>& e, Args... args)
+        {
+            const auto& de = e.derived_cast();
+            m_shape.resize(de.shape().size());
+            std::copy(de.shape().begin(), de.shape().end(), m_shape.begin());
+
+            append(args...);
+        }
+
+        template <class... Args>
+        inline slice_vector(const std::vector<std::size_t>& shape, Args... args)
+        {
+            m_shape = shape;
+            append(args...);
+        }
+
+        template <class T, class... Args>
+        inline void append(const T& s, Args... args)
+        {
+            push_back(s);
+            append(args...);
+        }
+
+        inline void append()
+        {
+            // noop
+        }
+
+        inline void push_back(const std::array<long int, 3>& s)
+        {
+            base_type::push_back(s);
+        }
+
+        template <class T>
+        inline void push_back(const xslice<T>& s)
+        {
+            auto ds = s.derived_cast();
+            base_type::push_back({ds(0), (index_type) ds.size(), (index_type) ds.step_size()});
+        }
+
+        template <class A, class B, class C>
+        inline void push_back(const xrange_adaptor<A, B, C>& s)
+        {
+            auto idx = size() - newaxis_count;
+            if (idx >= m_shape.size())
+            {
+                throw std::runtime_error("too many slices in slice vector for shape");
+            }
+            auto ds = s.get(m_shape[idx]);
+            base_type::push_back({(index_type) ds(0), (index_type) ds.size(), (index_type) ds.step_size()});
+        }
+
+        inline void push_back(xall_tag /*s*/)
+        {
+            auto idx = size() - newaxis_count;
+            if (idx >= m_shape.size())
+            {
+                throw std::runtime_error("too many slices in slice vector for shape");
+            }
+            base_type::push_back({0, (index_type) m_shape[idx], 1});
+        }
+
+        inline void push_back(xnewaxis_tag /*s*/)
+        {
+            ++newaxis_count;
+            base_type::push_back({-1, 0, 0});
+        }
+
+        inline void push_back(index_type i)
+        {
+            base_type::push_back({i, 0, 0});
+        }
+
+    private:
+         std::vector<std::size_t> m_shape;
+         std::size_t newaxis_count = 0;
+    };
+
+    template <class E, class S>
+    inline auto dynamic_view(E&& e, S&& slices)
+    {
+        std::size_t offset = e.raw_data_offset();
+        using shape_type = typename std::vector<std::size_t>;
+
+        auto old_shape = e.shape();
+        auto old_strides = e.strides();
+
+        shape_type new_shape;
+        shape_type new_strides;
+
+        std::size_t shape_size = old_shape.size();
+
+        for (const auto& el : slices)
+        {
+            if (el[0] >= 0 && el[1] == 0)
+            {
+                // treat this like a single int and remove from shape
+                shape_size = shape_size - 1;
+            }
+            else if (el[0] == -1 && el[1] == 0)
+            {
+                // treat this like a new axis
+                shape_size += 1;
+            }
+        }
+
+        new_shape.resize(shape_size);
+        new_strides.resize(shape_size);
+
+        std::size_t i = 0;
+        std::size_t idx = 0;
+        std::size_t newaxis_skip = 0;
+
+        for (; i < slices.size(); ++i) {
+            if (slices[i][0] >= 0)
+            {
+                offset += slices[i][0] * old_strides[i];
+            }
+
+            if (slices[i][1] != 0 && slices[i][2] != 0)
+            {
+                new_shape[idx] = slices[i][1];
+                new_strides[idx] = slices[i][2] * old_strides[i - newaxis_skip];
+                idx++;
+            }
+            else if (slices[i][0] == -1) // newaxis
+            {
+                new_shape[idx] = 1;
+                new_strides[idx] = 0;
+                newaxis_skip++;
+                idx++;
+            }
+        }
+
+        for (; i < old_shape.size(); ++i)
+        {
+            new_shape[idx] = old_shape[i];
+            new_strides[idx] = old_strides[i];
+            idx++;
+        }
+
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, decltype(e.data())>;
+        return view_type(std::forward<E>(e), std::move(new_shape), std::move(new_strides), offset);
+    }
 }
 
 #endif

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -100,7 +100,7 @@ namespace xt
         using iterator = typename iterable_base::iterator;
         using const_iterator = typename iterable_base::const_iterator;
 
-        static constexpr xt::layout layout_type = xt::layout::dynamic;
+        static constexpr layout_type static_layout = layout_type::dynamic;
         static constexpr bool contiguous_layout = false;
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
@@ -595,7 +595,7 @@ namespace xt
             {
                 resize_container(m_index, m_e.dimension());
                 m_size = compute_size(m_e.shape());
-                compute_strides(m_e.shape(), layout::row_major, m_strides);
+                compute_strides(m_e.shape(), layout_type::row_major, m_strides);
             }
 
             const reference operator[](std::size_t idx) const
@@ -763,7 +763,7 @@ namespace xt
         {
             std::vector<std::size_t> strides;
             strides.resize(e.shape().size());
-            compute_strides(e.shape(), layout::row_major, strides);
+            compute_strides(e.shape(), layout_type::row_major, strides);
             return strides;
         }
     }

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -154,24 +154,24 @@ namespace xt
         const_stepper stepper_end(const ST& shape) const;
 
         template <class T = xexpression_type>
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::container_type&>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const typename T::container_type&>
         data() const;
 
         template <class T = xexpression_type>
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::strides_type>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const typename T::strides_type>
         strides() const;
 
         template <class T = xexpression_type>
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const value_type*>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const value_type*>
         raw_data() const;
 
         template <class T = xexpression_type>
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, value_type*>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, value_type*>
         raw_data();
 
         template <class T = xexpression_type>
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::size_type>
-        raw_data_offset() const;
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const std::size_t>
+        raw_data_offset() const noexcept;
 
     private:
 
@@ -434,7 +434,7 @@ namespace xt
     template <class E, class... S>
     template <class T>
     inline auto xview<E, S...>::data() const ->
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::container_type&>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const typename T::container_type&>
     {
         return m_e.data();
     }
@@ -445,7 +445,7 @@ namespace xt
     template <class E, class... S>
     template <class T>
     inline auto xview<E, S...>::strides() const ->
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::strides_type>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const typename T::strides_type>
     {
         using strides_type = typename T::strides_type;
         strides_type temp = m_e.strides();
@@ -466,7 +466,7 @@ namespace xt
     template <class E, class... S>
     template <class T>
     inline auto xview<E, S...>::raw_data() const ->
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const value_type*>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const value_type*>
     {
         return m_e.raw_data();
     }
@@ -474,7 +474,7 @@ namespace xt
     template <class E, class... S>
     template <class T>
     inline auto xview<E, S...>::raw_data() ->
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, value_type*>
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, value_type*>
     {
         return m_e.raw_data();
     }
@@ -484,8 +484,8 @@ namespace xt
      */
     template <class E, class... S>
     template <class T>
-    inline auto xview<E, S...>::raw_data_offset() const ->
-        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<T>>, T>::value, const typename T::size_type>
+    inline auto xview<E, S...>::raw_data_offset() const noexcept ->
+        std::enable_if_t<std::is_base_of<xcontainer<std::remove_const_t<std::decay_t<T>>>, T>::value, const std::size_t>
     {
         auto func = [](const auto& s) { return xt::value(s, 0); };
         typename T::size_type offset = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(XTENSOR_TESTS
     test_xbroadcast.cpp
     test_xbuilder.cpp
     test_xcontainer_semantic.cpp
+    test_xdynamicview.cpp
     test_xeval.cpp
     test_xfunction.cpp
     test_xindexview.cpp

--- a/test/test_xdynamicview.cpp
+++ b/test/test_xdynamicview.cpp
@@ -137,30 +137,30 @@ namespace xt
         EXPECT_EQ(iter2, iter_end2);
     }
 
-    // TEST(xdynview, xdynview_on_xfunction)
-    // {
-    //     view_shape_type shape = {3, 4};
-    //     xarray<int> a(shape);
-    //     std::vector<int> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-    //     std::copy(data.cbegin(), data.cend(), a.begin());
+    TEST(xdynview, xdynview_on_xfunction)
+    {
+        view_shape_type shape = {3, 4};
+        xarray<int> a(shape);
+        std::vector<int> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        std::copy(data.cbegin(), data.cend(), a.begin());
 
-    //     view_shape_type shape2 = { 3 };
-    //     xarray<int> b(shape2);
-    //     std::vector<int> data2 = { 1, 2, 3 };
-    //     std::copy(data2.cbegin(), data2.cend(), b.begin());
+        view_shape_type shape2 = { 3 };
+        xarray<int> b(shape2);
+        std::vector<int> data2 = { 1, 2, 3 };
+        std::copy(data2.cbegin(), data2.cend(), b.begin());
 
-    //     auto func = dynamic_view(a, slice_vector(a, 1, range(1, 4))) + b;
-    //     auto iter = func.begin();
-    //     auto iter_end = func.end();
+        auto func = dynamic_view(a, slice_vector(a, 1, range(1, 4))) + b;
+        auto iter = func.begin();
+        auto iter_end = func.end();
 
-    //     EXPECT_EQ(7, *iter);
-    //     ++iter;
-    //     EXPECT_EQ(9, *iter);
-    //     ++iter;
-    //     EXPECT_EQ(11, *iter);
-    //     ++iter;
-    //     EXPECT_EQ(iter, iter_end);
-    // }
+        EXPECT_EQ(7, *iter);
+        ++iter;
+        EXPECT_EQ(9, *iter);
+        ++iter;
+        EXPECT_EQ(11, *iter);
+        ++iter;
+        EXPECT_EQ(iter, iter_end);
+    }
 
     TEST(xdynview, xdynview_on_xtensor)
     {

--- a/test/test_xdynamicview.cpp
+++ b/test/test_xdynamicview.cpp
@@ -1,0 +1,381 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xstridedview.hpp"
+#include <algorithm>
+
+namespace xt
+{
+    using std::size_t;
+    using view_shape_type = std::vector<size_t>;
+
+    TEST(xdynview, simple)
+    {
+        view_shape_type shape = {3, 4};
+        xarray<double> a(shape);
+        std::vector<double> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, 1, range(1, 4)));
+        EXPECT_EQ(a(1, 1), view1(0));
+        EXPECT_EQ(a(1, 2), view1(1));
+        EXPECT_EQ(1, view1.dimension());
+
+        auto view0 = dynamic_view(a, slice_vector(a, 0, range(0, 3)));
+        EXPECT_EQ(a(0, 0), view0(0));
+        EXPECT_EQ(a(0, 1), view0(1));
+        EXPECT_EQ(1, view0.dimension());
+        EXPECT_EQ(3, view0.shape()[0]);
+
+        auto view2 = dynamic_view(a, slice_vector(a, range(0, 2), 2));
+        EXPECT_EQ(a(0, 2), view2(0));
+        EXPECT_EQ(a(1, 2), view2(1));
+        EXPECT_EQ(1, view2.dimension());
+        EXPECT_EQ(2, view2.shape()[0]);
+
+        auto view4 = dynamic_view(a, slice_vector(a, 1));
+        EXPECT_EQ(1, view4.dimension());
+        EXPECT_EQ(4, view4.shape()[0]);
+
+        auto view5 = dynamic_view(view4, slice_vector(a, 1));
+        EXPECT_EQ(0, view5.dimension());
+        EXPECT_EQ(0, view5.shape().size());
+
+        auto view6 = dynamic_view(a, slice_vector(a, 1, all()));
+        EXPECT_EQ(a(1, 0), view6(0));
+        EXPECT_EQ(a(1, 1), view6(1));
+        EXPECT_EQ(a(1, 2), view6(2));
+        EXPECT_EQ(a(1, 3), view6(3));
+
+        auto view7 = dynamic_view(a, slice_vector(a, all(), 2));
+        EXPECT_EQ(a(0, 2), view7(0));
+        EXPECT_EQ(a(1, 2), view7(1));
+        EXPECT_EQ(a(2, 2), view7(2));
+    }
+
+    TEST(xdynview, three_dimensional)
+    {
+        view_shape_type shape = {3, 4, 2};
+        std::vector<double> data {
+            1, 2,
+            3, 4,
+            5, 6,
+            7, 8,
+
+            9, 10,
+            11, 12,
+            21, 22, 
+            23, 24,
+
+            25, 26,
+            27, 28,
+            29, 210,
+            211, 212
+        };
+        xarray<double> a(shape);
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, 1));
+        EXPECT_EQ(2, view1.dimension());
+        view_shape_type expected_shape = {4, 2};
+        EXPECT_EQ(expected_shape, view1.shape());
+        EXPECT_EQ(a(1, 0, 0), view1(0, 0));
+        EXPECT_EQ(a(1, 0, 1), view1(0, 1));
+        EXPECT_EQ(a(1, 1, 0), view1(1, 0));
+        EXPECT_EQ(a(1, 1, 1), view1(1, 1));
+        
+        std::array<std::size_t, 2> idx = {1, 1};
+        EXPECT_EQ(a(1, 1, 1), view1.element(idx.cbegin(), idx.cend()));
+    }
+
+    TEST(xdynview, iterator)
+    {
+        view_shape_type shape = {2, 3, 4};
+        xarray<double> a(shape);
+        std::vector<double> data {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                  13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, range(0, 2), 1, range(1, 4)));
+        auto iter = view1.begin();
+        auto iter_end = view1.end();
+
+        EXPECT_EQ(6, *iter);
+        ++iter;
+        EXPECT_EQ(7, *iter);
+        ++iter;
+        EXPECT_EQ(8, *iter);
+        ++iter;
+        EXPECT_EQ(18, *iter);
+        ++iter;
+        EXPECT_EQ(19, *iter);
+        ++iter;
+        EXPECT_EQ(20, *iter);
+        ++iter;
+        EXPECT_EQ(iter, iter_end);
+
+        auto view2 = dynamic_view(view1, slice_vector(view1, range(0, 2), range(1, 3)));
+        auto iter2 = view2.begin();
+        auto iter_end2 = view2.end();
+
+        EXPECT_EQ(7, *iter2);
+        ++iter2;
+        EXPECT_EQ(8, *iter2);
+        ++iter2;
+        EXPECT_EQ(19, *iter2);
+        ++iter2;
+        EXPECT_EQ(20, *iter2);
+        ++iter2;
+        EXPECT_EQ(iter2, iter_end2);
+    }
+
+    // TEST(xdynview, xdynview_on_xfunction)
+    // {
+    //     view_shape_type shape = {3, 4};
+    //     xarray<int> a(shape);
+    //     std::vector<int> data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    //     std::copy(data.cbegin(), data.cend(), a.begin());
+
+    //     view_shape_type shape2 = { 3 };
+    //     xarray<int> b(shape2);
+    //     std::vector<int> data2 = { 1, 2, 3 };
+    //     std::copy(data2.cbegin(), data2.cend(), b.begin());
+
+    //     auto func = dynamic_view(a, slice_vector(a, 1, range(1, 4))) + b;
+    //     auto iter = func.begin();
+    //     auto iter_end = func.end();
+
+    //     EXPECT_EQ(7, *iter);
+    //     ++iter;
+    //     EXPECT_EQ(9, *iter);
+    //     ++iter;
+    //     EXPECT_EQ(11, *iter);
+    //     ++iter;
+    //     EXPECT_EQ(iter, iter_end);
+    // }
+
+    TEST(xdynview, xdynview_on_xtensor)
+    {
+        xtensor<int, 2> a({ 3, 4 });
+        std::vector<int> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, 1, range(1, 4)));
+        EXPECT_EQ(a(1, 1), view1(0));
+        EXPECT_EQ(a(1, 2), view1(1));
+        EXPECT_EQ(1, view1.dimension());
+
+        auto iter = view1.begin();
+        auto iter_end = view1.end();
+
+        EXPECT_EQ(6, *iter);
+        ++iter;
+        EXPECT_EQ(7, *iter);
+        ++iter;
+        EXPECT_EQ(8, *iter);
+
+        xarray<int> b({ 3 }, 2);
+        xtensor<int, 1> res = view1 + b;
+        EXPECT_EQ(8, res(0));
+        EXPECT_EQ(9, res(1));
+        EXPECT_EQ(10, res(2));
+    }
+
+    TEST(xdynview, const_view)
+    {
+        const xtensor<double, 3> arr{ {1, 2, 3}, 2.5 };
+        xtensor<double, 2> arr2{ {2, 3}, 0.0 };
+        xtensor<double, 2> ref{ {2, 3}, 2.5 };
+        arr2 = dynamic_view(arr, slice_vector(arr, 0));
+        EXPECT_EQ(ref, arr2);
+    }
+
+    TEST(xdynview, newaxis)
+    {
+        view_shape_type shape = { 3, 4 };
+        xarray<double> a(shape);
+        std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, all(), newaxis(), all()));
+        EXPECT_EQ(a(1, 1), view1(1, 0, 1));
+        EXPECT_EQ(a(1, 2), view1(1, 0, 2));
+        EXPECT_EQ(3, view1.dimension());
+        EXPECT_EQ(3, view1.shape()[0]);
+        EXPECT_EQ(1, view1.shape()[1]);
+        EXPECT_EQ(4, view1.shape()[2]);
+
+        auto view2 = dynamic_view(a, slice_vector(a, all(), all(), newaxis()));
+        EXPECT_EQ(a(1, 1), view2(1, 1, 0));
+        EXPECT_EQ(a(1, 2), view2(1, 2, 0));
+        EXPECT_EQ(3, view2.dimension());
+        EXPECT_EQ(3, view2.shape()[0]);
+        EXPECT_EQ(4, view2.shape()[1]);
+        EXPECT_EQ(1, view2.shape()[2]);
+
+        auto view3 = dynamic_view(a, slice_vector(a, 1, newaxis(), all()));
+        EXPECT_EQ(a(1, 1), view3(0, 1));
+        EXPECT_EQ(a(1, 2), view3(0, 2));
+        EXPECT_EQ(2, view3.dimension());
+
+        auto view4 = dynamic_view(a, slice_vector(a, 1, all(), newaxis()));
+        EXPECT_EQ(a(1, 1), view4(1, 0));
+        EXPECT_EQ(a(1, 2), view4(2, 0));
+        EXPECT_EQ(2, view4.dimension());
+
+        auto view5 = dynamic_view(view1, slice_vector(a, 1));
+        EXPECT_EQ(a(1, 1), view5(0, 1));
+        EXPECT_EQ(a(1, 2), view5(0, 2));
+        EXPECT_EQ(2, view5.dimension());
+
+        auto view6 = dynamic_view(view2, slice_vector(a, 1));
+        EXPECT_EQ(a(1, 1), view6(1, 0));
+        EXPECT_EQ(a(1, 2), view6(2, 0));
+        EXPECT_EQ(2, view6.dimension());
+
+        std::array<std::size_t, 3> idx1 = { 1, 0, 2 };
+        EXPECT_EQ(a(1, 2), view1.element(idx1.begin(), idx1.end()));
+
+        std::array<std::size_t, 3> idx2 = { 1, 2, 0 };
+        EXPECT_EQ(a(1, 2), view2.element(idx2.begin(), idx2.end()));
+    }
+
+    TEST(xdynview, newaxis_iterating)
+    {
+        view_shape_type shape = { 3, 4 };
+        xarray<double> a(shape);
+        std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        auto view1 = dynamic_view(a, slice_vector(a, all(), all(), newaxis()));
+        auto iter1 = view1.begin();
+        auto iter1_end = view1.end();
+
+        EXPECT_EQ(a(0, 0), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(0, 1), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(0, 2), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(0, 3), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(1, 0), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(1, 1), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(1, 2), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(1, 3), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(2, 0), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(2, 1), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(2, 2), *iter1);
+        ++iter1;
+        EXPECT_EQ(a(2, 3), *iter1);
+        ++iter1;
+        EXPECT_EQ(iter1_end, iter1);
+
+        auto view2 = dynamic_view(a, slice_vector(a, all(), newaxis(), all()));
+        auto iter2 = view2.begin();
+        auto iter2_end = view2.end();
+
+        EXPECT_EQ(a(0, 0), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(0, 1), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(0, 2), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(0, 3), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(1, 0), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(1, 1), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(1, 2), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(1, 3), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(2, 0), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(2, 1), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(2, 2), *iter2);
+        ++iter2;
+        EXPECT_EQ(a(2, 3), *iter2);
+        ++iter2;
+        EXPECT_EQ(iter2_end, iter2);
+    }
+
+    TEST(xdynview, newaxis_function)
+    {
+        view_shape_type shape = { 3, 4 };
+        xarray<double> a(shape);
+        std::vector<double> data{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        std::copy(data.cbegin(), data.cend(), a.begin());
+
+        xarray<double> b(view_shape_type(1, 4));
+        auto data_end = data.cbegin();
+        data_end += 4;
+        std::copy(data.cbegin(), data_end, b.begin());
+
+        auto v = dynamic_view(b, slice_vector(b, newaxis(), all()));
+        xarray<double> res = a + v;
+
+        std::vector<double> data2{ 2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16 };
+        xarray<double> expected(shape);
+        std::copy(data2.cbegin(), data2.cend(), expected.begin());
+
+        EXPECT_EQ(expected, res);
+    }
+
+    TEST(xdynview, range_adaptor)
+    {
+        using namespace xt::placeholders;
+        using t = xarray<int>;
+        t a = {1, 2, 3, 4, 5};
+
+        auto n = xnone();
+
+        auto v1 = dynamic_view(a, slice_vector(a, range(3, _)));
+        t v1e = {4, 5};
+        EXPECT_TRUE(v1e == v1);
+
+        auto v2 = dynamic_view(a, slice_vector(a, range(_, 2)));
+        t v2e = {1, 2};
+        EXPECT_TRUE(v2e == v2);
+
+        auto v3 = dynamic_view(a, slice_vector(a, range(n, n)));
+        t v3e = {1, 2, 3, 4, 5};
+        EXPECT_TRUE(v3e == v3);
+
+        auto v4 = dynamic_view(a, slice_vector(a, range(n, 2, -1)));
+        t v4e = {5, 4};
+        EXPECT_TRUE(v4e == v4);
+
+        auto v5 = dynamic_view(a, slice_vector(a, range(2, n, -1)));
+        t v5e = {3, 2, 1};
+        EXPECT_TRUE(v5e == v5);
+
+        auto v6 = dynamic_view(a, slice_vector(a, range(n, n, n)));
+        t v6e = {1, 2, 3, 4, 5};
+        EXPECT_TRUE(v6e == v6);
+
+        auto v7 = dynamic_view(a, slice_vector(a, range(1, n, 2)));
+        t v7e = {2, 4};
+        EXPECT_TRUE(v7e == v7);
+
+        auto v8 = dynamic_view(a, slice_vector(a, range(2, n, 2)));
+        t v8e = {3, 5};
+        EXPECT_TRUE(v8e == v8);
+    }
+}


### PR DESCRIPTION
This adds a new class, the slices_vector. A container type that can be initialized with a shape or xexpression. Then one can append xslice's, or range_adaptors, or xall_tags/xnewaxis_tags and the corresponding `{offset, n_elements, step_size}` arrays are calculated which can be used in the dynamic_view.