### PR TITLE
add empty fn access operator

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -144,6 +144,12 @@ namespace xt
             {
             }
 
+            inline value_type operator()() const
+            {
+                size_type idx[1] = {0ul};
+                return access_impl(std::begin(idx), std::end(idx));
+            }
+
             template <class... Args>
             inline value_type operator()(Args... args) const
             {


### PR DESCRIPTION
This is apparently needed. I think I removed it sometime earlier ... 

Is this the correct way to implement it?