### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ docs/build/
 
 # Jupyter artefacts
 .ipynb_checkpoints/
+
+# Python packaging artefacts
+dist/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include include/xtensor/ *.*

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -27,3 +27,11 @@ xtensor has been packaged for the conda package manager. Once the new tag has be
 - Update the hash of the source tarball.
 - Check for the versions of the dependencies.
 - Optionally, rerender the conda-forge feedstock.
+
+Updating the pypi package
+-------------------------
+
+xtensor has been packaged for ``pypi``, the Python package index. Once the new tag has been pushed on GitHub, you can do
+
+- ``python setup.py sdist && python setup.py bdist_wheel``
+- ``twine upload dist/*``

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+from setuptools import setup
+from glob import glob
+import os
+
+long_description = '''
+`xtensor` is a C++ library meant for numerical analysis with multi-dimensional array expressions.
+
+`xtensor` provides
+
+- an extensible expression system enabling **lazy broadcasting**.
+- an API following the idioms of the **C++ standard library**.
+- tools to manipulate array expressions and build upon `xtensor`.
+
+Containers of `xtensor` are inspired by `NumPy`_, the Python array programming library. **Adaptors** for existing data structures to be plugged into our expression system can easily be written. In fact, `xtensor` can be used to **process numpy data structures inplace** using Python's `buffer protocol`_. For more details on the numpy bindings, check out the xtensor-python_ project.
+
+`xtensor` requires a modern C++ compiler supporting C++14. The following C++ compilers are supported:
+
+- On Windows platforms, Visual C++ 2015 Update 2, or more recent
+- On Unix platforms, gcc 4.9 or a recent version of Clang
+'''
+
+# Read version information in include/xtensor/xtensor_config.hp'
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'include', 'xtensor', 'xtensor_config.hpp')) as f:
+    versions = [line for line in f.readlines() if line.startswith('#define XTENSOR_VERSION_')]
+version = versions[0][30:-1] + '.' + versions[1][30:-1] + '.' + versions[2][30:-1]
+
+setup(
+    name='xtensor',
+    version=version,
+    description='Multi-dimensional arrays with broadcasting and lazy computing',
+    long_description=long_description,
+    url='https://github.com/QuantStack/xtensor',
+    zip_safe=False,
+    data_files=[
+        ('include/xtensor', glob('include/xtensor/*.hpp')),
+    ],
+)


### PR DESCRIPTION
Distribute the pure headers library on pypi.

This is meant for the pypi packaging of `xtensor-python`.

Instead of using distutils' `install_headers` directive which places headers under `include/pythonX.Y`, using wheels `data_files` feature to distribute headers in the same location as where it would be installed with cmake.

Problem: can we generate the `xtensorConfig.cmake` files without cmake?