### PR TITLE
Support pkg-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/build/
 
 # Jupyter artefacts
 .ipynb_checkpoints/
+
+# Generated files
+*.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,3 +126,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION ${XTENSOR_CMAKECONFIG_INSTALL_DIR})
 
+configure_file(${PROJECT_NAME}.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+                @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")

--- a/xtensor.pc.in
+++ b/xtensor.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: xtensor
+Description: xtensor is a C++ library meant for numerical analysis with multi-dimensional array expressions.
+Version: @xtensor_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
pkg-config is a tool to get build flags.

If xtensor supports pkg-config, users can set build flags easily.

For example, CMake supports pkg-config.

To support pkg-config, we just install .pc file that includes build
flags information.