### PR TITLE
Move semantics for assign-temporary

### DIFF
--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -73,6 +73,7 @@ namespace xt
         using shape_type = typename base_type::shape_type;
         using inner_shape_type = typename base_type::inner_shape_type;
         using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
         using inner_strides_type = typename base_type::inner_strides_type;
 
         xarray_container();
@@ -168,6 +169,7 @@ namespace xt
         using container_type = typename base_type::container_type;
         using shape_type = typename base_type::shape_type;
         using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
 
         using container_closure_type = adaptor_closure_t<container_type>;
 
@@ -194,7 +196,7 @@ namespace xt
         const container_type& data_impl() const noexcept;
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
 
 
         friend class xcontainer<xarray_adaptor<EC, L, SC>>;
@@ -509,15 +511,12 @@ namespace xt
     }
 
     template <class EC, layout_type L, class SC>
-    inline void xarray_adaptor<EC, L, SC>::assign_temporary_impl(temporary_type& tmp)
+    inline void xarray_adaptor<EC, L, SC>::assign_temporary_impl(temporary_type&& tmp)
     {
-        // TODO (performance improvement) : consider moving tmps
-        // shape and strides
-        base_type::shape_impl() = tmp.shape();
-        base_type::strides_impl() = tmp.strides();
-        base_type::backstrides_impl() = tmp.backstrides();
-        m_data.resize(tmp.size());
-        std::copy(tmp.data().cbegin(), tmp.data().cend(), m_data.begin());
+        base_type::shape_impl() = std::move(const_cast<shape_type&>(tmp.shape()));
+        base_type::strides_impl() = std::move(const_cast<strides_type&>(tmp.strides()));
+        base_type::backstrides_impl() = std::move(const_cast<backstrides_type&>(tmp.backstrides()));
+        m_data = std::move(tmp.data());
     }
 }
 

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -149,7 +149,7 @@ namespace xt
         {
             typename E1::temporary_type tmp(shape);
             assign_data(tmp, e2, trivial_broadcast);
-            de1.assign_temporary(tmp);
+            de1.assign_temporary(std::move(tmp));
         }
         else
         {

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -265,7 +265,7 @@ namespace xt
         functor_type m_functor;
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
         friend class xview_semantic<xfunctorview<F, CT>>;
     };
 
@@ -447,7 +447,7 @@ namespace xt
     }
 
     template <class F, class CT>
-    inline void xfunctorview<F, CT>::assign_temporary_impl(temporary_type& tmp)
+    inline void xfunctorview<F, CT>::assign_temporary_impl(temporary_type&& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), xbegin());
     }

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -151,7 +151,7 @@ namespace xt
         const indices_type m_indices;
         const inner_shape_type m_shape;
 
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
 
         friend class xview_semantic<xindexview<CT, I>>;
     };
@@ -260,7 +260,7 @@ namespace xt
     }
 
     template <class CT, class I>
-    inline void xindexview<CT, I>::assign_temporary_impl(temporary_type& tmp)
+    inline void xindexview<CT, I>::assign_temporary_impl(temporary_type&& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
     }

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -113,7 +113,7 @@ namespace xt
         using derived_type = D;
         using temporary_type = typename base_type::temporary_type;
 
-        derived_type& assign_temporary(temporary_type&);
+        derived_type& assign_temporary(temporary_type&&);
 
         template <class E>
         derived_type& assign_xexpression(const xexpression<E>& e);
@@ -160,7 +160,7 @@ namespace xt
         using derived_type = D;
         using temporary_type = typename base_type::temporary_type;
 
-        derived_type& assign_temporary(temporary_type&);
+        derived_type& assign_temporary(temporary_type&&);
 
         template <class E>
         derived_type& assign_xexpression(const xexpression<E>& e);
@@ -206,7 +206,7 @@ namespace xt
         using derived_type = D;
         using temporary_type = typename base_type::temporary_type;
 
-        derived_type& assign_temporary(temporary_type&);
+        derived_type& assign_temporary(temporary_type&&);
 
         template <class E>
         derived_type& assign_xexpression(const xexpression<E>& e);
@@ -410,7 +410,7 @@ namespace xt
     inline auto xsemantic_base<D>::operator=(const xexpression<E>& e) -> derived_type&
     {
         temporary_type tmp(e);
-        return this->derived_cast().assign_temporary(tmp);
+        return this->derived_cast().assign_temporary(std::move(tmp));
     }
 
     /**************************************
@@ -423,7 +423,7 @@ namespace xt
      * @return a reference to \c *this.
      */
     template <class D>
-    inline auto xcontainer_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    inline auto xcontainer_semantic<D>::assign_temporary(temporary_type&& tmp) -> derived_type&
     {
         using std::swap;
         swap(this->derived_cast(), tmp);
@@ -471,9 +471,9 @@ namespace xt
      * @return a reference to \c *this.
      */
     template <class D>
-    inline auto xadaptor_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    inline auto xadaptor_semantic<D>::assign_temporary(temporary_type&& tmp) -> derived_type&
     {
-        this->derived_cast().assign_temporary_impl(tmp);
+        this->derived_cast().assign_temporary_impl(std::move(tmp));
         return this->derived_cast();
     }
 
@@ -518,9 +518,9 @@ namespace xt
      * @return a reference to \c *this.
      */
     template <class D>
-    inline auto xview_semantic<D>::assign_temporary(temporary_type& tmp) -> derived_type&
+    inline auto xview_semantic<D>::assign_temporary(temporary_type&& tmp) -> derived_type&
     {
-        this->derived_cast().assign_temporary_impl(tmp);
+        this->derived_cast().assign_temporary_impl(std::move(tmp));
         return this->derived_cast();
     }
 

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -174,7 +174,7 @@ namespace xt
         template <class It>
         It data_xend_impl(It end) const noexcept;
 
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
 
         CT m_e;
         CD m_data;
@@ -243,7 +243,7 @@ namespace xt
     }
 
     template <class CT, class S, class CD>
-    inline void xstrided_view<CT, S, CD>::assign_temporary_impl(temporary_type& tmp)
+    inline void xstrided_view<CT, S, CD>::assign_temporary_impl(temporary_type&& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
     }

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -76,6 +76,7 @@ namespace xt
         using shape_type = typename base_type::shape_type;
         using inner_shape_type = typename base_type::inner_shape_type;
         using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
         using inner_strides_type = typename base_type::inner_strides_type;
 
         xtensor_container();
@@ -165,6 +166,7 @@ namespace xt
         using container_type = typename base_type::container_type;
         using shape_type = typename base_type::shape_type;
         using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
 
         using container_closure_type = adaptor_closure_t<container_type>;
 
@@ -191,7 +193,7 @@ namespace xt
         const container_type& data_impl() const noexcept;
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
 
         friend class xcontainer<xtensor_adaptor<EC, N, L>>;
         friend class xadaptor_semantic<xtensor_adaptor<EC, N, L>>;
@@ -441,14 +443,12 @@ namespace xt
     }
 
     template <class EC, std::size_t N, layout_type L>
-    inline void xtensor_adaptor<EC, N, L>::assign_temporary_impl(temporary_type& tmp)
+    inline void xtensor_adaptor<EC, N, L>::assign_temporary_impl(temporary_type&& tmp)
     {
-        // TODO (performance improvement) : consider moving tmps shape and strides
-        base_type::shape_impl() = tmp.shape();
-        base_type::strides_impl() = tmp.strides();
-        base_type::backstrides_impl() = tmp.backstrides();
-        m_data.resize(tmp.size());
-        std::copy(tmp.data().cbegin(), tmp.data().cend(), m_data.begin());
+        base_type::shape_impl() = std::move(const_cast<shape_type&>(tmp.shape()));
+        base_type::strides_impl() = std::move(const_cast<strides_type&>(tmp.strides()));
+        base_type::backstrides_impl() = std::move(const_cast<backstrides_type&>(tmp.backstrides()));
+        m_data = std::move(tmp.data());
     }
 }
 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -211,7 +211,7 @@ namespace xt
         template <class It>
         base_index_type make_index(It first, It last) const;
 
-        void assign_temporary_impl(temporary_type& tmp);
+        void assign_temporary_impl(temporary_type&& tmp);
 
         friend class xview_semantic<xview<CT, S...>>;
     };
@@ -708,7 +708,7 @@ namespace xt
     }
 
     template <class CT, class... S>
-    inline void xview<CT, S...>::assign_temporary_impl(temporary_type& tmp)
+    inline void xview<CT, S...>::assign_temporary_impl(temporary_type&& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
     }


### PR DESCRIPTION
This does two things:

 - makes the `assign_temporary` and `assign_temporary_impl` take rvalue references.
 - Move the members of temporaries to the adaptors.

I decided to not restrict to the second item, because otherwise it is not clear that the temporary may be destroyed.