### PR TITLE
Fixes in reverse broadcasting iterators

### DIFF
--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -315,7 +315,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     /**
@@ -327,7 +327,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     /**
@@ -339,7 +339,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     /**
@@ -351,7 +351,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     /**
@@ -363,7 +363,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     template <class EC, layout_type L, class SC>

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -661,7 +661,7 @@ namespace xt
     inline auto xcontainer<D>::stepper_begin(const S& shape) noexcept -> stepper
     {
         size_type offset = shape.size() - dimension();
-        return stepper(static_cast<derived_type*>(this), data().begin(), offset);
+        return stepper(static_cast<derived_type*>(this), data_xbegin(), offset);
     }
 
     template <class D>
@@ -677,7 +677,7 @@ namespace xt
     inline auto xcontainer<D>::stepper_begin(const S& shape) const noexcept -> const_stepper
     {
         size_type offset = shape.size() - dimension();
-        return const_stepper(static_cast<const derived_type*>(this), data().begin(), offset);
+        return const_stepper(static_cast<const derived_type*>(this), data_xbegin(), offset);
     }
 
     template <class D>

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -617,6 +617,7 @@ namespace xt
     {
         return derived_cast().stepper_begin(shape);
     }
+
     template <class D>
     template <class S>
     inline auto xconst_iterable<D>::get_stepper_end(const S& shape) const noexcept -> const_stepper

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -407,15 +407,19 @@ namespace xt
         while (i != 0)
         {
             --i;
-            if (++index[i] != shape[i])
+            if (index[i] != shape[i] - 1)
             {
+                ++index[i];
                 stepper.step(i);
                 return;
             }
-            else if (i != 0)
+            else
             {
                 index[i] = 0;
-                stepper.reset(i);
+                if (i != 0)
+                {
+                    stepper.reset(i);
+                }
             }
         }
         if (i == 0)
@@ -441,10 +445,13 @@ namespace xt
                 stepper.step_back(i);
                 return;
             }
-            else if (i != 0)
+            else
             {
                 index[i] = shape[i] - 1;
-                stepper.reset_back(i);
+                if (i != 0)
+                {
+                     stepper.reset_back(i);
+                }
             }
         }
         if (i == 0)
@@ -462,17 +469,21 @@ namespace xt
         using size_type = typename S::size_type;
         size_type size = index.size();
         size_type i = 0;
-        while (i < size)
+        while (i != size)
         {
-            if (++index[i] != shape[i])
+            if (index[i] != shape[i] - 1)
             {
+                ++index[i];
                 stepper.step(i);
                 return;
             }
-            else if (i != size - 1)
+            else
             {
                 index[i] = 0;
-                stepper.reset(i);
+                if (i != size - 1)
+                {
+                    stepper.reset(i);
+                }
             }
             ++i;
         }
@@ -491,7 +502,7 @@ namespace xt
         using size_type = typename S::size_type;
         size_type size = index.size();
         size_type i = 0;
-        while (i < size)
+        while (i != size)
         {
             if (index[i] != 0)
             {
@@ -499,10 +510,13 @@ namespace xt
                 stepper.step_back(i);
                 return;
             }
-            else if (i != size - 1)
+            else
             {
                 index[i] = shape[i] - 1;
-                stepper.reset_back(i);
+                if (i != size - 1)
+                {
+                    stepper.reset_back(i);
+                }
             }
             ++i;
         }
@@ -641,9 +655,9 @@ namespace xt
     {
         if (reverse)
         {
-            auto iter_end = m_index.end() - 1;
-            std::transform(m_index.begin(), iter_end, m_index.begin(),
-                           [](const auto& v) { return v - 1; });
+            auto iter_begin = (L == layout_type::row_major)  ? m_index.begin() : m_index.begin() + 1;
+            auto iter_end = (L == layout_type::row_major) ? m_index.end() - 1 : m_index.end();
+            std::transform(iter_begin, iter_end, iter_begin, [](const auto& v) { return v - 1; });
         }
     }
 

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -461,7 +461,8 @@ namespace xt
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
-        for (size_type i = 0; i < size; ++i)
+        size_type i = 0;
+        while (i < size)
         {
             if (++index[i] != shape[i])
             {
@@ -473,10 +474,11 @@ namespace xt
                 index[i] = 0;
                 stepper.reset(i);
             }
-            else
-            {
-                stepper.to_end();
-            }
+            ++i;
+        }
+        if (i == size)
+        {
+            stepper.to_end();
         }
     }
 

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -9,7 +9,11 @@
 #ifndef XITERATOR_HPP
 #define XITERATOR_HPP
 
+#include <array>
+#include <algorithm>
+#include <cstddef>
 #include <iterator>
+#include <vector>
 
 #include "xexception.hpp"
 #include "xlayout.hpp"
@@ -431,25 +435,21 @@ namespace xt
         while (i != 0)
         {
             --i;
-            if (index[i] == 0)
-            {
-                if (i != 0)
-                {
-                    index[i] = shape[i] - 1;
-                    stepper.reset_back(i);
-                }
-                else
-                {
-                    std::fill(index.begin(), index.end(), size_type(0));
-                    stepper.to_begin();
-                }
-            }
-            else
+            if (index[i] != 0)
             {
                 --index[i];
                 stepper.step_back(i);
                 return;
             }
+            else if (i != 0)
+            {
+                index[i] = shape[i] - 1;
+                stepper.reset_back(i);
+            }
+        }
+        if (i == 0)
+        {
+            stepper.to_begin();
         }
     }
 
@@ -490,27 +490,25 @@ namespace xt
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
-        for (size_type i = 0; i < size; ++i)
+        size_type i = 0;
+        while (i < size)
         {
-            if (index[i] == 0)
-            {
-                if (i != size - 1)
-                {
-                    index[i] = shape[i] - 1;
-                    stepper.reset_back(i);
-                }
-                else
-                {
-                    std::fill(index.begin(), index.end(), size_type(0));
-                    stepper.to_begin();
-                }
-            }
-            else
+            if (index[i] != 0)
             {
                 --index[i];
                 stepper.step_back(i);
                 return;
             }
+            else if (i != size - 1)
+            {
+                index[i] = shape[i] - 1;
+                stepper.reset_back(i);
+            }
+            ++i;
+        }
+        if (i == size)
+        {
+            stepper.to_begin();
         }
     }
 
@@ -565,6 +563,7 @@ namespace xt
     {
         std::fill(m_index.begin(), m_index.end(), size_type(0));
     }
+
     template <class C, bool is_const>
     inline void xindexed_stepper<C, is_const>::to_end()
     {

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -195,9 +195,9 @@ namespace xt
     bool operator!=(const xscalar_stepper<is_const, CT>& lhs,
                     const xscalar_stepper<is_const, CT>& rhs) noexcept;
 
-    /********************
+    /*******************
      * xdummy_iterator *
-     ********************/
+     *******************/
 
     template <bool is_const, class CT>
     class xdummy_iterator
@@ -541,9 +541,9 @@ namespace xt
         return !(lhs.equal(rhs));
     }
 
-    /***********************************
+    /**********************************
      * xdummy_iterator implementation *
-     ***********************************/
+     **********************************/
 
     template <bool is_const, class CT>
     inline xdummy_iterator<is_const, CT>::xdummy_iterator(container_type* c) noexcept

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -224,7 +224,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t), true);
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->xbegin(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
     }
 
     /**


### PR DESCRIPTION
This includes some bug fixes

 - The assignment operator from an `initializer_list` for `xtensor` and `xarray` was making the assumption that `xbegin` always gives a row-major iterator.
 - xiterator's increment stepper for column-major was buggy in the 0-D case.