### PR TITLE
Install the cmake config files under libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,8 @@ include(CMakePackageConfigHelpers)
 install(FILES ${XTENSOR_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor)
 
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(XTENSOR_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for xtensorConfig.cmake")
+set(XTENSOR_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE
+    STRING "install path for xtensorConfig.cmake")
 
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"


### PR DESCRIPTION
To be consistent with the recently introduced pkgconfig files. It also simplifies the Debian packaging slightly, since only `CMAKE_INSTALL_LIBDIR` needs to be modified to install everything under a (non-)multiarch path.