### PR TITLE
begin / end behavior on strided containers

### DIFF
--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -149,12 +149,6 @@ namespace xt
         using container_iterator = typename container_type::iterator;
         using const_container_iterator = typename container_type::const_iterator;
 
-        container_iterator data_xbegin() noexcept;
-        const_container_iterator data_xbegin() const noexcept;
-
-        container_iterator data_xend(layout_type l) noexcept;
-        const_container_iterator data_xend(layout_type l) const noexcept;
-
     protected:
 
         xcontainer() = default;
@@ -166,7 +160,15 @@ namespace xt
         xcontainer(xcontainer&&) = default;
         xcontainer& operator=(xcontainer&&) = default;
 
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+        container_iterator data_xend(layout_type l) noexcept;
+        const_container_iterator data_xend(layout_type l) const noexcept;
+
     private:
+
+        template <class C>
+        friend class xstepper;
 
         template <class It>
         It data_xend_impl(It end, layout_type l) const noexcept;

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -152,12 +152,6 @@ namespace xt
         using container_iterator = typename std::decay_t<CD>::iterator;
         using const_container_iterator = typename std::decay_t<CD>::const_iterator;
 
-        container_iterator data_xbegin() noexcept;
-        const_container_iterator data_xbegin() const noexcept;
-
-        container_iterator data_xend(layout_type l) noexcept;
-        const_container_iterator data_xend(layout_type l) const noexcept;
-
         underlying_container_type& data() noexcept;
         const underlying_container_type& data() const noexcept;
 
@@ -166,7 +160,17 @@ namespace xt
 
         size_type raw_data_offset() const noexcept;
 
+    protected:
+
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+        container_iterator data_xend(layout_type l) noexcept;
+        const_container_iterator data_xend(layout_type l) const noexcept;
+
     private:
+
+        template <class C>
+        friend class xstepper;
 
         template <class It>
         It data_xbegin_impl(It begin) const noexcept;


### PR DESCRIPTION
- make `data_xbegin` and `data_xend` protected...