### PR TITLE
Iterator refactoring

### DIFF
--- a/docs/source/api/xiterable.rst
+++ b/docs/source/api/xiterable.rst
@@ -17,10 +17,3 @@ Defined in ``xtensor/xiterable.hpp``
    :project: xtensor
    :members:
 
-.. doxygenclass:: xt::xexpression_const_iterable
-   :project: xtensor
-   :members:
-
-.. doxygenclass:: xt::xexpression_iterable
-   :project: xtensor
-   :members:

--- a/docs/source/expression.rst
+++ b/docs/source/expression.rst
@@ -161,19 +161,15 @@ Element access
 Iterators
 ~~~~~~~~~
 
-- ``xbegin()`` and ``xend()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the expression. The layout of the iteration can be specified
+- ``begin()`` and ``end()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the expression. The layout of the iteration can be specified
   through the ``layout_type`` template parameter, accepted values are ``layout_type::row_major`` and ``layout_type::column_major``. If not specified, ``DEFAULT_LAYOUT`` is used.
   This iterator pair permits to use algorithms of the STL with ``xexpression`` as if they were simple containers.
-- ``xbegin(shape)`` and ``xend(shape)`` are similar but take a *broadcasting shape* as an argument. Elements are iterated upon in ``DEFAULT_LAYOUT`` if no ``layout_type`` template
+- ``begin(shape)`` and ``end(shape)`` are similar but take a *broadcasting shape* as an argument. Elements are iterated upon in ``DEFAULT_LAYOUT`` if no ``layout_type`` template
   parameter is specified. Certain dimensions are repeated to match the provided shape as per the rules described above. For an expression ``e``, ``e.xbegin(e.shape())`` and ``e.begin()``
   are equivalent.
-- ``begin()`` and ``end()`` return iterators on the buffer containing the elements of the ``xexpression`` when it is an in-memory container. Otherwise, they are similar to ``xbegin()``
-  and ``xend()`` with default ``layout_type`` parameter. For in-memory containers, the iteration is done directly on the buffer and may be faster than the one provided by
-  ``xbegin()`` / ``xend()`` .
-- ``xrbegin()`` and ``xrend()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the reversed expression. As ``xbegin()`` and ``xend()``, the
+- ``rbegin()`` and ``rend()`` return instances of ``xiterator`` which can be used to iterate over all the elements of the reversed expression. As ``begin()`` and ``end()``, the
   layout of the iteration can be specified through the ``layout_type`` parameter.
-- ``xrbegin(shape)`` and ``xrend(shape)`` are the reversed counterpart of ``xbegin(shape)`` and ``xend(shape)``.
-- ``rbegin()`` and ``rend()`` are the reversed counterpart of ``begin()`` and ``end()``.
+- ``rbegin(shape)`` and ``rend(shape)`` are the reversed counterpart of ``begin(shape)`` and ``end(shape)``.
 
 .. _NumPy: http://www.numpy.org
 .. _libdynd: http://libdynd.org

--- a/docs/source/external-structures.rst
+++ b/docs/source/external-structures.rst
@@ -63,6 +63,7 @@ with the following simple example:
         shape_type m_shape;
         shape_type m_strides;
         shape_type m_backstrides;
+        static constexpr layout_type layout = layout_type::dynamic;
     };
 
 Define inner types
@@ -82,6 +83,7 @@ The following tells ``xtensor`` which types must be used for getting shape, stri
         using shape_type = inner_shape_type;
         using strides_type = inner_shape_type;
         using backstrides_type = inner_shape_type;
+        static constexpr layout_type layout = raw_tensor<T>::layout;
     };
 
 The ``inner_XXX_type`` are the types used to store and read the shape, strides an backstrides, while the
@@ -94,7 +96,7 @@ Next, bring all the iterable features with this simple definition:
 
     template <class T>
     struct xiterable_inner_types<raw_tensor<T>>
-        : xcontainer_iteratble_types<raw_tensor<T>>
+        : xcontainer_iterable_types<raw_tensor<T>>
     {
     };
 
@@ -279,10 +281,6 @@ The following definitions are required:
         using inner_shape_type = typename table<T>::shape_type;
         using stepper = xindexed_stepper<table<T>, false>;
         using const_stepper = xindexed_stepper<table<T>, true>;
-        using iterator = xiterator<stepper, inner_shape_type*>;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*>;
-        using broadcast_iterator = iterator;
-        using const_broadcast_iterator = const_iterator;
     };
 
 Inheritance
@@ -294,7 +292,7 @@ and to define a bunch of typedefs.
 .. code::
 
     template<class T>
-    class table_adaptor : public xexpression_iterable<table_adaptor<T>>,
+    class table_adaptor : public xiterable<table_adaptor<T>>,
                           public xcontainer_semantic<table_adaptor<T>>
     {
 
@@ -318,10 +316,6 @@ and to define a bunch of typedefs.
         using iterable_base = xexpression_iterable<self_type>;
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
-        using iterator = typename iterable_base::iterator;
-        using const_iterator = typename iterable_base::const_iterator;
-        using broadcast_iterator = typename iterable_base::iterator;
-        using const_broadcast_iterator = typename iterable_base::const_broadcast_iterator;
     };
 
 The iterator and stepper used here may not be the most optimal for ``table``, however they
@@ -341,7 +335,7 @@ constructor and assign operator.
 .. code::
 
     template <class T>
-    class table_adaptor : public xexpression_iterable<table_adaptor<T>>,
+    class table_adaptor : public xiterable<table_adaptor<T>>,
                           public xcontainer_semantic<table_adaptor<T>>
     {
 

--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -35,6 +35,7 @@ namespace xt
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = xarray_container<EC, L, SC>;
+        static constexpr layout_type layout = L;
     };
 
     template <class EC, layout_type L, class SC>
@@ -56,13 +57,13 @@ namespace xt
      * @sa xarray
      */
     template <class EC, layout_type L, class SC>
-    class xarray_container : public xstrided_container<xarray_container<EC, L, SC>, L>,
+    class xarray_container : public xstrided_container<xarray_container<EC, L, SC>>,
                              public xcontainer_semantic<xarray_container<EC, L, SC>>
     {
     public:
 
         using self_type = xarray_container<EC, L, SC>;
-        using base_type = xstrided_container<self_type, L>;
+        using base_type = xstrided_container<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
         using container_type = typename base_type::container_type;
         using value_type = typename base_type::value_type;
@@ -135,6 +136,7 @@ namespace xt
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = xarray_container<EC, L, SC>;
+        static constexpr layout_type layout = L;
     };
 
     template <class EC, layout_type L, class SC>
@@ -158,13 +160,13 @@ namespace xt
      * @tparam SC The type of the containers holding the shape and the strides.
      */
     template <class EC, layout_type L, class SC>
-    class xarray_adaptor : public xstrided_container<xarray_adaptor<EC, L, SC>, L>,
+    class xarray_adaptor : public xstrided_container<xarray_adaptor<EC, L, SC>>,
                            public xadaptor_semantic<xarray_adaptor<EC, L, SC>>
     {
     public:
 
         using self_type = xarray_adaptor<EC, L, SC>;
-        using base_type = xstrided_container<self_type, L>;
+        using base_type = xstrided_container<self_type>;
         using semantic_base = xadaptor_semantic<self_type>;
         using container_type = typename base_type::container_type;
         using shape_type = typename base_type::shape_type;
@@ -315,7 +317,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     /**
@@ -327,7 +329,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     /**
@@ -339,7 +341,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     /**
@@ -351,7 +353,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     /**
@@ -363,7 +365,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t));
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     template <class EC, layout_type L, class SC>

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -256,7 +256,7 @@ namespace xt
     template <class E1, class E2>
     inline void trivial_assigner<false>::run(E1& e1, const E2& e2)
     {
-        std::copy(e2.cbegin(), e2.cend(), e1.begin());
+        std::copy(e2.storage_cbegin(), e2.storage_cend(), e1.storage_begin());
     }
 }
 

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -54,10 +54,6 @@ namespace xt
         using inner_shape_type = promote_shape_t<typename xexpression_type::shape_type, X>;
         using const_stepper = typename xexpression_type::const_stepper;
         using stepper = const_stepper;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using iterator = const_iterator;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /**
@@ -75,7 +71,7 @@ namespace xt
      */
     template <class CT, class X>
     class xbroadcast : public xexpression<xbroadcast<CT, X>>,
-                       public xexpression_const_iterable<xbroadcast<CT, X>>
+                       public xconst_iterable<xbroadcast<CT, X>>
     {
 
     public:
@@ -90,7 +86,7 @@ namespace xt
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
-        using iterable_base = xexpression_const_iterable<self_type>;
+        using iterable_base = xconst_iterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
 

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -28,13 +28,11 @@ namespace xt
     {
         using inner_shape_type = typename xcontainer_inner_types<D>::inner_shape_type;
         using container_type = typename xcontainer_inner_types<D>::container_type;
-        using iterator = typename container_type::iterator;
-        using const_iterator = typename container_type::const_iterator;
-        using reverse_iterator = typename container_type::reverse_iterator;
-        using const_reverse_iterator = typename container_type::const_reverse_iterator;
         using stepper = xstepper<D>;
         using const_stepper = xstepper<const D>;
     };
+
+#define DL DEFAULT_LAYOUT
 
     /**
      * @class xcontainer
@@ -48,7 +46,7 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xcontainer : public xiterable<D>
+    class xcontainer : private xiterable<D>
     {
     public:
 
@@ -73,15 +71,11 @@ namespace xt
         using inner_backstrides_type = typename inner_types::inner_backstrides_type;
 
         using iterable_base = xiterable<D>;
-
-        using iterator = typename iterable_base::iterator;
-        using const_iterator = typename iterable_base::const_iterator;
-
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
 
-        using reverse_iterator = typename iterable_base::reverse_iterator;
-        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
+        static constexpr layout_type static_layout = inner_types::layout;
+        static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
 
         size_type size() const noexcept;
 
@@ -120,22 +114,6 @@ namespace xt
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
 
-        iterator begin() noexcept;
-        iterator end() noexcept;
-
-        const_iterator begin() const noexcept;
-        const_iterator end() const noexcept;
-        const_iterator cbegin() const noexcept;
-        const_iterator cend() const noexcept;
-
-        reverse_iterator rbegin() noexcept;
-        reverse_iterator rend() noexcept;
-
-        const_reverse_iterator rbegin() const noexcept;
-        const_reverse_iterator rend() const noexcept;
-        const_reverse_iterator crbegin() const noexcept;
-        const_reverse_iterator crend() const noexcept;
-
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
         template <class S>
@@ -146,11 +124,137 @@ namespace xt
         template <class S>
         const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
 
-        using container_iterator = typename container_type::iterator;
-        using const_container_iterator = typename container_type::const_iterator;
-
         reference data_element(size_type i);
         const_reference data_element(size_type i) const;
+
+
+        template <layout_type L>
+        using layout_iterator = typename iterable_base::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
+        template <layout_type L>
+        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
+
+        using storage_iterator = typename container_type::iterator;
+        using const_storage_iterator = typename container_type::const_iterator;
+        using reverse_storage_iterator = typename container_type::reverse_iterator;
+        using const_reverse_storage_iterator = typename container_type::const_reverse_iterator;
+
+        template <layout_type L, class It1, class It2>
+        using select_iterator_impl = std::conditional_t<L == static_layout, It1, It2>;
+        
+        template <layout_type L>
+        using select_iterator = select_iterator_impl<L, storage_iterator, layout_iterator<L>>;
+        template <layout_type L>
+        using select_const_iterator = select_iterator_impl<L, const_storage_iterator, const_layout_iterator<L>>;
+        template <layout_type L>
+        using select_reverse_iterator = select_iterator_impl<L, reverse_storage_iterator, reverse_layout_iterator<L>>;
+        template <layout_type L>
+        using select_const_reverse_iterator = select_iterator_impl<L, const_reverse_storage_iterator, const_reverse_layout_iterator<L>>;
+        
+        using iterator = select_iterator<DL>;
+        using const_iterator = select_const_iterator<DL>;
+        using reverse_iterator = select_reverse_iterator<DL>;
+        using const_reverse_iterator = select_const_reverse_iterator<DL>;
+
+        template <layout_type L = DL>
+        select_iterator<L> begin() noexcept;
+        template <layout_type L = DL>
+        select_iterator<L> end() noexcept;
+
+        template <layout_type L = DL>
+        select_const_iterator<L> begin() const noexcept;
+        template <layout_type L = DL>
+        select_const_iterator<L> end() const noexcept;
+        template <layout_type L = DL>
+        select_const_iterator<L> cbegin() const noexcept;
+        template <layout_type L = DL>
+        select_const_iterator<L> cend() const noexcept;
+
+        template <layout_type L = DL>
+        select_reverse_iterator<L> rbegin() noexcept;
+        template <layout_type L = DL>
+        select_reverse_iterator<L> rend() noexcept;
+
+        template <layout_type L = DL>
+        select_const_reverse_iterator<L> rbegin() const noexcept;
+        template <layout_type L = DL>
+        select_const_reverse_iterator<L> rend() const noexcept;
+        template <layout_type L = DL>
+        select_const_reverse_iterator<L> crbegin() const noexcept;
+        template <layout_type L = DL>
+        select_const_reverse_iterator<L> crend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+        template <layout_type L = DL>
+        storage_iterator storage_begin() noexcept;
+        template <layout_type L = DL>
+        storage_iterator storage_end() noexcept;
+
+        template <layout_type L = DL>
+        const_storage_iterator storage_begin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_end() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cbegin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cend() const noexcept;
+
+        template <layout_type L = DL>
+        reverse_storage_iterator storage_rbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_storage_iterator storage_rend() noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crend() const noexcept;
+
+        using container_iterator = storage_iterator;
+        using const_container_iterator = const_storage_iterator;
 
     protected:
 
@@ -170,6 +274,9 @@ namespace xt
 
     private:
 
+        friend class xiterable<D>;
+        friend class xconst_iterable<D>;
+
         template <class C>
         friend class xstepper;
 
@@ -184,6 +291,8 @@ namespace xt
         const derived_type& derived_cast() const;
     };
 
+#undef DL
+
     /**
      * @class xstrided_container
      * @brief Partial implementation of xcontainer that embeds the strides and the shape
@@ -195,9 +304,8 @@ namespace xt
      *
      * @tparam D The derived type, i.e. the inheriting class for which xstrided_container
      *           provides the partial imlpementation of xcontainer.
-     * @tparam L The layout_type of the xstrided_container.
      */
-    template <class D, layout_type L>
+    template <class D>
     class xstrided_container : public xcontainer<D>
     {
     public:
@@ -215,9 +323,6 @@ namespace xt
         using inner_shape_type = typename base_type::inner_shape_type;
         using inner_strides_type = typename base_type::inner_strides_type;
         using inner_backstrides_type = typename base_type::inner_backstrides_type;
-
-        static constexpr layout_type static_layout = L;
-        static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
 
         template <class S = shape_type>
         void reshape(const S& shape, bool force = false);
@@ -255,7 +360,7 @@ namespace xt
         inner_shape_type m_shape;
         inner_strides_type m_strides;
         inner_backstrides_type m_backstrides;
-        layout_type m_layout = L;
+        layout_type m_layout = base_type::static_layout;
     };
 
     /******************************
@@ -534,138 +639,316 @@ namespace xt
     //@}
 
     /****************
-     * iterator api *
+     * Iterator api *
      ****************/
 
-    /**
-     * @name Iterators
-     */
-    //@{
-    /**
-     * Returns an iterator to the first element of the buffer containing
-     * the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::begin() noexcept -> iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::begin() noexcept -> select_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_begin<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template begin<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::end() noexcept -> select_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_end<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template end<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::begin() const noexcept -> select_const_iterator<L>
+    {
+        return cbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::end() const noexcept -> select_const_iterator<L>
+    {
+        return cend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::cbegin() const noexcept -> select_const_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_cbegin<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template cbegin<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::cend() const noexcept -> select_const_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_cend<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template cend<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::rbegin() noexcept -> select_reverse_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_rbegin<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template rbegin<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::rend() noexcept -> select_reverse_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_rend<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template rend<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::rbegin() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return crbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::rend() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return crend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::crbegin() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_crbegin<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template crbegin<L>();
+        });
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::crend() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).template storage_crend<L>();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template crend<L>();
+        });
+    }
+
+    /*****************************
+     * Broadcasting iterator api *
+     *****************************/
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cbegin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cend<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crbegin<S, L>(shape);
+    }
+
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xcontainer<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crend<S, L>(shape);
+    }
+
+    /***********************
+     * Linear iterator api *
+     ***********************/
+
+    template <class D>
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_begin() noexcept -> storage_iterator
     {
         return data().begin();
     }
 
-    /**
-     * Returns an iterator to the element following the last element of
-     * the buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::end() noexcept -> iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_end() noexcept -> storage_iterator
     {
         return data().end();
     }
 
-    /**
-     * Returns a constant iterator to the first element of the buffer
-     * containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::begin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_begin() const noexcept -> const_storage_iterator
     {
-        return cbegin();
+        return data().begin();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::end() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_end() const noexcept -> const_storage_iterator
     {
-        return cend();
+        return data().end();
     }
 
-    /**
-     * Returns a constant iterator to the first element of the buffer
-     * containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::cbegin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_cbegin() const noexcept -> const_storage_iterator
     {
         return data().cbegin();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::cend() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_cend() const noexcept -> const_storage_iterator
     {
         return data().cend();
     }
-    //@}
 
-    /**
-     * @name Reverse iterators
-     */
-    //@{
-    /**
-     * Returns an iterator to the first element of the reversed buffer containing
-     * the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::rbegin() noexcept -> reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_rbegin() noexcept -> reverse_storage_iterator
     {
         return data().rbegin();
     }
 
-    /**
-     * Returns an iterator to the element following the last element of
-     * the reversed buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::rend() noexcept -> reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_rend() noexcept -> reverse_storage_iterator
     {
         return data().rend();
     }
 
-    /**
-     * Returns a constant iterator to the first element of the reversed
-     * buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::rbegin() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
     {
         return data().rbegin();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the reversed buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::rend() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_rend() const noexcept -> const_reverse_storage_iterator
     {
         return data().rend();
     }
 
-    /**
-     * Returns a constant iterator to the first element of the reversed
-     * buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::crbegin() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
     {
         return data().crbegin();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the reversed buffer containing the elements of the container.
-     */
     template <class D>
-    inline auto xcontainer<D>::crend() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xcontainer<D>::storage_crend() const noexcept -> const_reverse_storage_iterator
     {
         return data().crend();
     }
-    //@}
 
     /***************
      * stepper api *
@@ -743,53 +1026,53 @@ namespace xt
      * xstrided_container implementation *
      *************************************/
 
-    template <class D, layout_type L>
-    inline xstrided_container<D, L>::xstrided_container() noexcept
+    template <class D>
+    inline xstrided_container<D>::xstrided_container() noexcept
         : base_type()
     {
         m_shape = make_sequence<inner_shape_type>(base_type::dimension(), 1);
     }
 
-    template <class D, layout_type L>
-    inline xstrided_container<D, L>::xstrided_container(inner_shape_type&& shape, inner_strides_type&& strides) noexcept
+    template <class D>
+    inline xstrided_container<D>::xstrided_container(inner_shape_type&& shape, inner_strides_type&& strides) noexcept
         : base_type(), m_shape(std::move(shape)), m_strides(std::move(strides))
     {
         m_backstrides = make_sequence<inner_backstrides_type>(m_shape.size(), 0);
         adapt_strides(m_shape, m_strides, m_backstrides);
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::shape_impl() noexcept -> inner_shape_type&
+    template <class D>
+    inline auto xstrided_container<D>::shape_impl() noexcept -> inner_shape_type&
     {
         return m_shape;
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::shape_impl() const noexcept -> const inner_shape_type&
+    template <class D>
+    inline auto xstrided_container<D>::shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::strides_impl() noexcept -> inner_strides_type&
+    template <class D>
+    inline auto xstrided_container<D>::strides_impl() noexcept -> inner_strides_type&
     {
         return m_strides;
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::strides_impl() const noexcept -> const inner_strides_type&
+    template <class D>
+    inline auto xstrided_container<D>::strides_impl() const noexcept -> const inner_strides_type&
     {
         return m_strides;
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::backstrides_impl() noexcept -> inner_backstrides_type&
+    template <class D>
+    inline auto xstrided_container<D>::backstrides_impl() noexcept -> inner_backstrides_type&
     {
         return m_backstrides;
     }
 
-    template <class D, layout_type L>
-    inline auto xstrided_container<D, L>::backstrides_impl() const noexcept -> const inner_backstrides_type&
+    template <class D>
+    inline auto xstrided_container<D>::backstrides_impl() const noexcept -> const inner_backstrides_type&
     {
         return m_backstrides;
     }
@@ -798,8 +1081,8 @@ namespace xt
      * Return the layout_type of the container
      * @return layout_type of the container
      */
-    template <class D, layout_type L>
-    layout_type xstrided_container<D, L>::layout() const noexcept
+    template <class D>
+    layout_type xstrided_container<D>::layout() const noexcept
     {
         return m_layout;
     }
@@ -809,9 +1092,9 @@ namespace xt
      * @param shape the new shape
      * @param force force reshaping, even if the shape stays the same (default: false)
      */
-    template <class D, layout_type L>
+    template <class D>
     template <class S>
-    inline void xstrided_container<D, L>::reshape(const S& shape, bool force)
+    inline void xstrided_container<D>::reshape(const S& shape, bool force)
     {
         if (m_shape.size() != shape.size() || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape)) || force)
         {
@@ -832,11 +1115,11 @@ namespace xt
      * @param shape the new shape
      * @param l the new layout_type
      */
-    template <class D, layout_type L>
+    template <class D>
     template <class S>
-    inline void xstrided_container<D, L>::reshape(const S& shape, layout_type l)
+    inline void xstrided_container<D>::reshape(const S& shape, layout_type l)
     {
-        if (L != layout_type::dynamic && l != L)
+        if (base_type::static_layout != layout_type::dynamic && l != base_type::static_layout)
         {
             throw std::runtime_error("Cannot change layout_type if template parameter not layout_type::dynamic.");
         }
@@ -849,11 +1132,11 @@ namespace xt
      * @param shape the new shape
      * @param strides the new strides
      */
-    template <class D, layout_type L>
+    template <class D>
     template <class S>
-    inline void xstrided_container<D, L>::reshape(const S& shape, const strides_type& strides)
+    inline void xstrided_container<D>::reshape(const S& shape, const strides_type& strides)
     {
-        if (L != layout_type::dynamic)
+        if (base_type::static_layout != layout_type::dynamic)
         {
             throw std::runtime_error("Cannot reshape with custom strides when layout() is != layout_type::dynamic.");
         }

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -94,17 +94,15 @@ namespace xt
     struct xiterable_inner_types<xfunction<F, R, CT...>>
     {
         using inner_shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
-        using const_iterator = xfunction_iterator<F, R, CT...>;
-        using iterator = const_iterator;
         using const_stepper = xfunction_stepper<F, R, CT...>;
         using stepper = const_stepper;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /*************
      * xfunction *
      *************/
+
+#define DL DEFAULT_LAYOUT
 
     /**
      * @class xfunction
@@ -119,7 +117,7 @@ namespace xt
      */
     template <class F, class R, class... CT>
     class xfunction : public xexpression<xfunction<F, R, CT...>>,
-                      public xconst_iterable<xfunction<F, R, CT...>>
+                      private xconst_iterable<xfunction<F, R, CT...>>
     {
     public:
 
@@ -138,17 +136,39 @@ namespace xt
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
 
-        using iterator = typename iterable_base::iterator;
-        using const_iterator = typename iterable_base::const_iterator;
-
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
 
-        using reverse_iterator = typename iterable_base::reverse_iterator;
-        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
-
         static constexpr layout_type static_layout = compute_layout(std::decay_t<CT>::static_layout...);
         static constexpr bool contiguous_layout = and_c<std::decay_t<CT>::contiguous_layout...>::value;
+
+        template <layout_type L>
+        using layout_iterator = typename iterable_base::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
+        template <layout_type L>
+        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
+
+        using const_storage_iterator = xfunction_iterator<F, R, CT...>;
+        using storage_iterator = const_storage_iterator;
+        using const_reverse_storage_iterator = std::reverse_iterator<const_storage_iterator>;
+        using reverse_storage_iterator = std::reverse_iterator<storage_iterator>;
+
+        using iterator = typename iterable_base::iterator;
+        using const_iterator = typename iterable_base::const_iterator;
+        using reverse_iterator = typename iterable_base::reverse_iterator;
+        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
 
         template <class Func>
         xfunction(Func&& f, CT... e) noexcept;
@@ -173,15 +193,32 @@ namespace xt
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
 
-        const_iterator begin() const noexcept;
-        const_iterator end() const noexcept;
-        const_iterator cbegin() const noexcept;
-        const_iterator cend() const noexcept;
+        using iterable_base::begin;
+        using iterable_base::end;
+        using iterable_base::cbegin;
+        using iterable_base::cend;
+        using iterable_base::rbegin;
+        using iterable_base::rend;
+        using iterable_base::crbegin;
+        using iterable_base::crend;
 
-        const_reverse_iterator rbegin() const noexcept;
-        const_reverse_iterator rend() const noexcept;
-        const_reverse_iterator crbegin() const noexcept;
-        const_reverse_iterator crend() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_begin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_end() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cbegin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cend() const noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crend() const noexcept;
 
         template <class S>
         const_stepper stepper_begin(const S& shape) const noexcept;
@@ -208,7 +245,7 @@ namespace xt
         const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
 
         template <class Func, std::size_t... I>
-        const_iterator build_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
+        const_storage_iterator build_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
 
         size_type compute_dimension() const noexcept;
 
@@ -219,7 +256,10 @@ namespace xt
 
         friend class xfunction_iterator<F, R, CT...>;
         friend class xfunction_stepper<F, R, CT...>;
+        friend class xconst_iterable<self_type>;
     };
+
+#undef DL
 
     /**********************
      * xfunction_iterator *
@@ -233,13 +273,13 @@ namespace xt
         template <class C>
         struct get_iterator_impl
         {
-            using type = typename C::iterator;
+            using type = typename C::storage_iterator;
         };
 
         template <class C>
         struct get_iterator_impl<const C>
         {
-            using type = typename C::const_iterator;
+            using type = typename C::const_storage_iterator;
         };
 
         template <class CT>
@@ -502,96 +542,63 @@ namespace xt
     }
     //@}
 
-    /**
-     * @name Iterators
-     */
-    /**
-     * Returns an iterator to the first element of the buffer
-     * containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::begin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_begin() const noexcept -> const_storage_iterator
+    {
+        return storage_cbegin<L>();
+    }
+
+    template <class F, class R, class... CT>
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_end() const noexcept -> const_storage_iterator
+    {
+        return storage_cend<L>();
+    }
+
+    template <class F, class R, class... CT>
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_cbegin() const noexcept -> const_storage_iterator
     {
         auto f = [](const auto& e) noexcept { return detail::trivial_begin(e); };
         return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::end() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_cend() const noexcept -> const_storage_iterator
     {
         auto f = [](const auto& e) noexcept { return detail::trivial_end(e); };
         return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    /**
-     * Returns a constant iterator to the first element of the buffer
-     * containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::cbegin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return begin();
+        return storage_crbegin<L>();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the buffer containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::cend() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_rend() const noexcept -> const_reverse_storage_iterator
     {
-        return end();
-    }
-    //@}
-
-    /**
-     * @name Reverse iterators
-     */
-    //@{
-    /**
-     * Returns an iterator to the first element of the reversed buffer
-     * containing the elements of the function.
-     */
-    template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::rbegin() const noexcept -> const_reverse_iterator
-    {
-        return crbegin();
+        return storage_crend<L>();
     }
 
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the reversed buffer containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::rend() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return crend();
+        return const_reverse_storage_iterator(storage_cend<L>());
     }
 
-    /**
-     * Returns an iterator to the first element of the reversed buffer
-     * containing the elements of the function.
-     */
     template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::crbegin() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunction<F, R, CT...>::storage_crend() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_iterator(cend());
+        return const_reverse_storage_iterator(storage_cbegin<L>());
     }
-
-    /**
-     * Returns a constant iterator to the element following the last
-     * element of the reversed buffer containing the elements of the function.
-     */
-    template <class F, class R, class... CT>
-    inline auto xfunction<F, R, CT...>::crend() const noexcept -> const_reverse_iterator
-    {
-        return const_reverse_iterator(cbegin());
-    }
-    //@}
 
     template <class F, class R, class... CT>
     template <class S>
@@ -652,9 +659,9 @@ namespace xt
 
     template <class F, class R, class... CT>
     template <class Func, std::size_t... I>
-    inline auto xfunction<F, R, CT...>::build_iterator(Func&& f, std::index_sequence<I...>) const noexcept -> const_iterator
+    inline auto xfunction<F, R, CT...>::build_iterator(Func&& f, std::index_sequence<I...>) const noexcept -> const_storage_iterator
     {
-        return const_iterator(this, f(std::get<I>(m_e))...);
+        return const_storage_iterator(this, f(std::get<I>(m_e))...);
     }
 
     template <class F, class R, class... CT>

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -79,7 +79,7 @@ namespace xt
      * The xfunctorview class is an expression addressing its elements by applying a functor to the
      * corresponding element of an underlying expression. Unlike e.g. xgenerator, an xfunctorview is
      * an lvalue. It is used e.g. to access real and imaginary parts of complex expressions.
-     * expressions.
+     *
      * xfunctorview is not meant to be used directly, but through helper functions such
      * as \ref real or \ref imag.
      *
@@ -108,37 +108,41 @@ namespace xt
 
         using shape_type = typename xexpression_type::shape_type;
 
+        static constexpr layout_type static_layout = xexpression_type::static_layout;
+        static constexpr bool contiguous_layout = false;
+
         using stepper = xfunctor_stepper<functor_type, typename xexpression_type::stepper>;
         using const_stepper = xfunctor_stepper<functor_type, typename xexpression_type::const_stepper>;
 
+        template <layout_type L>
+        using layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template layout_iterator<L>>;
+        template <layout_type L>
+        using const_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_layout_iterator<L>>;
+
+        template <layout_type L>
+        using reverse_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_layout_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_layout_iterator<L>>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::stepper, S, L>>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::const_stepper, S, L>>;
+
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_broadcast_iterator<S, L>>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_broadcast_iterator<S, L>>;
+
+        using storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::storage_iterator>;
+        using const_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_storage_iterator>;
+        using reverse_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_storage_iterator>;
+        using const_reverse_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_storage_iterator>;
+
         using iterator = xfunctor_iterator<functor_type, typename xexpression_type::iterator>;
         using const_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_iterator>;
-
-        template <layout_type L>
-        using broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template broadcast_iterator<L>>;
-        template <layout_type L>
-        using const_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_broadcast_iterator<L>>;
-
-        template <class S, layout_type L>
-        using shaped_xiterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::stepper, S, L>>;
-        template <class S, layout_type L>
-        using const_shaped_xiterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::const_stepper, S, L>>;
-
         using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
         using const_reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_iterator>;
-
-        template <layout_type L>
-        using reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_broadcast_iterator<L>>;
-        template <layout_type L>
-        using const_reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_broadcast_iterator<L>>;
-
-        template <class S, layout_type L>
-        using reverse_shaped_xiterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_shaped_xiterator<S, L>>;
-        template <class S, layout_type L>
-        using const_reverse_shaped_xiterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_shaped_xiterator<S, L>>;
-
-        static constexpr layout_type static_layout = xexpression_type::static_layout;
-        static constexpr bool contiguous_layout = false;
 
         xfunctorview(CT) noexcept;
 
@@ -178,77 +182,89 @@ namespace xt
         template <class S>
         bool is_trivial_broadcast(const S& strides) const;
 
-        iterator begin() noexcept;
-        iterator end() noexcept;
-
-        const_iterator begin() const noexcept;
-        const_iterator end() const noexcept;
-        const_iterator cbegin() const noexcept;
-        const_iterator cend() const noexcept;
+        template <layout_type L = DL>
+        auto begin() noexcept;
+        template <layout_type L = DL>
+        auto end() noexcept;
 
         template <layout_type L = DL>
-        broadcast_iterator<L> xbegin() noexcept;
+        auto begin() const noexcept;
         template <layout_type L = DL>
-        broadcast_iterator<L> xend() noexcept;
+        auto end() const noexcept;
+        template <layout_type L = DL>
+        auto cbegin() const noexcept;
+        template <layout_type L = DL>
+        auto cend() const noexcept;
 
         template <layout_type L = DL>
-        const_broadcast_iterator<L> xbegin() const noexcept;
+        auto rbegin() noexcept;
         template <layout_type L = DL>
-        const_broadcast_iterator<L> xend() const noexcept;
-        template <layout_type L = DL>
-        const_broadcast_iterator<L> cxbegin() const noexcept;
-        template <layout_type L = DL>
-        const_broadcast_iterator<L> cxend() const noexcept;
-
-        template <class S, layout_type L = DL>
-        shaped_xiterator<S, L> xbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        shaped_xiterator<S, L> xend(const S& shape) noexcept;
-
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> xbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> xend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> cxbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> cxend(const S& shape) const noexcept;
-
-        reverse_iterator rbegin() noexcept;
-        reverse_iterator rend() noexcept;
-
-        const_reverse_iterator rbegin() const noexcept;
-        const_reverse_iterator rend() const noexcept;
-        const_reverse_iterator crbegin() const noexcept;
-        const_reverse_iterator crend() const noexcept;
+        auto rend() noexcept;
 
         template <layout_type L = DL>
-        reverse_broadcast_iterator<L> xrbegin() noexcept;
+        auto rbegin() const noexcept;
         template <layout_type L = DL>
-        reverse_broadcast_iterator<L> xrend() noexcept;
-
+        auto rend() const noexcept;
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> xrbegin() const noexcept;
+        auto crbegin() const noexcept;
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> xrend() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> cxrbegin() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> cxrend() const noexcept;
+        auto crend() const noexcept;
 
         template <class S, layout_type L = DL>
-        reverse_shaped_xiterator<S, L> xrbegin(const S& shape) noexcept;
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
         template <class S, layout_type L = DL>
-        reverse_shaped_xiterator<S, L> xrend(const S& shape) noexcept;
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
 
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> xrbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> xrend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> cxrbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> cxrend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+        template <layout_type L = DL>
+        storage_iterator storage_begin() noexcept;
+        template <layout_type L = DL>
+        storage_iterator storage_end() noexcept;
+
+        template <layout_type L = DL>
+        const_storage_iterator storage_begin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_end() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cbegin() const noexcept;
+        template <layout_type L = DL>
+        const_storage_iterator storage_cend() const noexcept;
+
+        template <layout_type L = DL>
+        reverse_storage_iterator storage_rbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_storage_iterator storage_rend() noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_storage_iterator storage_crend() const noexcept;
 
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
@@ -449,7 +465,7 @@ namespace xt
     template <class F, class CT>
     inline void xfunctorview<F, CT>::assign_temporary_impl(temporary_type&& tmp)
     {
-        std::copy(tmp.cbegin(), tmp.cend(), xbegin());
+        std::copy(tmp.cbegin(), tmp.cend(), begin());
     }
 
     /**
@@ -621,59 +637,75 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::begin() noexcept -> iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::begin() noexcept
     {
-        return iterator(m_e.begin(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template begin<L>())>
+            (m_e.template begin<L>(), &m_functor);
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::end() noexcept -> iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::end() noexcept
     {
-        return iterator(m_e.end(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template end<L>())>
+            (m_e.template end<L>(), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::begin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::begin() const noexcept
     {
-        return const_iterator(m_e.cbegin(), &m_functor);
+        return cbegin<L>();
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::end() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::end() const noexcept
     {
-        return const_iterator(m_e.cend(), &m_functor);
+        return cend<L>();
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::cbegin() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cbegin() const noexcept
     {
-        return const_iterator(m_e.cbegin(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template cbegin<L>())>
+            (m_e.template cbegin<L>(), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::cend() const noexcept -> const_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::cend() const noexcept
     {
-        return const_iterator(m_e.cend(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template cend<L>())>
+            (m_e.template cend<L>(), &m_functor);
     }
     //@}
 
@@ -682,75 +714,6 @@ namespace xt
      */
     //@{
     /**
-     * Returns an iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xbegin() noexcept -> broadcast_iterator<L>
-    {
-        return broadcast_iterator<L>(m_e.template xbegin<L>(), &m_functor);
-    }
-
-    /**
-     * Returns an iterator to the element following the last element
-     * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xend() noexcept -> broadcast_iterator<L>
-    {
-        return broadcast_iterator<L>(m_e.template xend<L>(), &m_functor);
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xbegin() const noexcept -> const_broadcast_iterator<L>
-    {
-        return cxbegin<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xend() const noexcept -> const_broadcast_iterator<L>
-    {
-        return cxend<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::cxbegin() const noexcept -> const_broadcast_iterator<L>
-    {
-        return const_broadcast_iterator<L>(m_e.template cxbegin<L>(), &m_functor);
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::cxend() const noexcept -> const_broadcast_iterator<L>
-    {
-        return const_broadcast_iterator<L>(m_e.template cxend<L>(), &m_functor);
-    }
-
-    /**
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
@@ -759,9 +722,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xbegin(const S& shape) noexcept -> shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return shaped_xiterator<S, L>(m_e.template xbegin<S, L>(shape), &m_functor);
+        return broadcast_iterator<S, L>(m_e.template begin<S, L>(shape), &m_functor);
     }
 
     /**
@@ -773,9 +736,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xend(const S& shape) noexcept -> shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return shaped_xiterator<S, L>(m_e.template xend<S, L>(shape), &m_functor);
+        return broadcast_iterator<S, L>(m_e.template end<S, L>(shape), &m_functor);
     }
 
     /**
@@ -787,9 +750,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cxbegin<S, L>(shape);
+        return cbegin<S, L>(shape);
     }
 
     /**
@@ -801,9 +764,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cxend<S, L>(shape);
+        return cend<S, L>(shape);
     }
 
     /**
@@ -815,9 +778,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::cxbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_shaped_xiterator<S, L>(m_e.template cxbegin<S, L>(shape), &m_functor);
+        return const_broadcast_iterator<S, L>(m_e.template cxbegin<S, L>(shape), &m_functor);
     }
 
     /**
@@ -829,9 +792,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::cxend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_shaped_xiterator<S, L>(m_e.template cxend<S, L>(shape), &m_functor);
+        return const_broadcast_iterator<S, L>(m_e.template cxend<S, L>(shape), &m_functor);
     }
     //@}
 
@@ -841,135 +804,81 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::rbegin() noexcept -> reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::rbegin() noexcept
     {
-        return reverse_iterator(m_e.rbegin(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
+            (m_e.template rbegin<L>(), &m_functor);
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::rend() noexcept -> reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::rend() noexcept
     {
-        return reverse_iterator(m_e.rend(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
+            (m_e.template rend<L>(), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::rbegin() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::rbegin() const noexcept
     {
-        return crbegin();
+        return crbegin<L>();
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::rend() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::rend() const noexcept
     {
-        return crend();
+        return crend<L>();
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::crbegin() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::crbegin() const noexcept
     {
-        return const_reverse_iterator(m_e.crbegin(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
+            (m_e.template rbegin<L>(), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class F, class CT>
-    inline auto xfunctorview<F, CT>::crend() const noexcept -> const_reverse_iterator
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::crend() const noexcept
     {
-        return const_reverse_iterator(m_e.crend(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
+            (m_e.template rend<L>(), &m_functor);
     }
     //@}
 
     /**
      * @name Reverse broadcast iterators
      */
-    //@{
-    /**
-     * Returns an iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xrbegin() noexcept -> reverse_broadcast_iterator<L>
-    {
-        return reverse_broadcast_iterator<L>(m_e.template xrbegin<L>(), &m_functor);
-    }
-
-    /**
-     * Returns an iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xrend() noexcept -> reverse_broadcast_iterator<L>
-    {
-        return reverse_broadcast_iterator<L>(m_e.template xrend<L>(), &m_functor);
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return cxrbegin<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::xrend() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return cxrend<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::cxrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return const_reverse_broadcast_iterator<L>(m_e.template cxrbegin<L>(), &m_functor);
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctorview<F, CT>::cxrend() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return const_reverse_broadcast_iterator<L>(m_e.template cxrend<L>(), &m_functor);
-    }
-
     /**
      * Returns an iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
@@ -979,9 +888,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xrbegin(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_shaped_xiterator<S, L>(m_e.template xrbegin<S, L>(shape), &m_functor);
+        return reverse_broadcast_iterator<S, L>(m_e.template xrbegin<S, L>(shape), &m_functor);
     }
 
     /**
@@ -993,9 +902,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xrend(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_shaped_xiterator<S, L>(m_e.template xrend<S, L>(shape), &m_functor);
+        return reverse_broadcast_iterator<S, L>(m_e.template xrend<S, L>(shape), &m_functor);
     }
 
     /**
@@ -1007,9 +916,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return cxrbegin<S, L>(shape);
+        return crbegin<S, L>(shape);
     }
 
     /**
@@ -1021,9 +930,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::xrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return cxrend<S, L>();
+        return crend<S, L>();
     }
 
     /**
@@ -1035,9 +944,9 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::cxrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_shaped_xiterator<S, L>(m_e.template cxrbegin<S, L>(), &m_functor);
+        return const_reverse_broadcast_iterator<S, L>(m_e.template crbegin<S, L>(), &m_functor);
     }
 
     /**
@@ -1049,11 +958,95 @@ namespace xt
      */
     template <class F, class CT>
     template <class S, layout_type L>
-    inline auto xfunctorview<F, CT>::cxrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xfunctorview<F, CT>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_shaped_xiterator<S, L>(m_e.template cxrend<S, L>(shape), &m_functor);
+        return const_reverse_broadcast_iterator<S, L>(m_e.template crend<S, L>(shape), &m_functor);
     }
     //@}
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_begin() noexcept -> storage_iterator
+    {
+        return storage_iterator(m_e.template storage_begin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_end() noexcept -> storage_iterator
+    {
+        return storage_iterator(m_e.template storage_end<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_begin() const noexcept -> const_storage_iterator
+    {
+        return const_storage_iterator(m_e.template storage_begin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_end() const noexcept -> const_storage_iterator
+    {
+        return const_storage_iterator(m_e.template storage_end<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_cbegin() const noexcept -> const_storage_iterator
+    {
+        return const_storage_iterator(m_e.template storage_cbegin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_cend() const noexcept -> const_storage_iterator
+    {
+        return const_storage_iterator(m_e.template storage_cend<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_rbegin() noexcept -> reverse_storage_iterator
+    {
+        return reverse_storage_iterator(m_e.template storage_rbegin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_rend() noexcept -> reverse_storage_iterator
+    {
+        return reverse_storage_iterator(m_e.template storage_rend<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
+    {
+        return const_reverse_storage_iterator(m_e.template storage_rbegin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_rend() const noexcept -> const_reverse_storage_iterator
+    {
+        return const_reverse_storage_iterator(m_e.template storage_rend<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
+    {
+        return const_reverse_storage_iterator(m_e.template storage_crbegin<L>(), &m_functor);
+    }
+
+    template <class F, class CT>
+    template <layout_type L>
+    inline auto xfunctorview<F, CT>::storage_crend() const noexcept -> const_reverse_storage_iterator
+    {
+        return const_reverse_storage_iterator(m_e.template storage_crend<L>(), &m_functor);
+    }
 
     /***************
      * stepper api *

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -37,10 +37,6 @@ namespace xt
         using inner_shape_type = S;
         using const_stepper = xindexed_stepper<xgenerator<C, R, S>>;
         using stepper = const_stepper;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using iterator = const_iterator;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /**
@@ -56,7 +52,7 @@ namespace xt
      */
     template <class F, class R, class S>
     class xgenerator : public xexpression<xgenerator<F, R, S>>,
-                       public xexpression_const_iterable<xgenerator<F, R, S>>
+                       public xconst_iterable<xgenerator<F, R, S>>
     {
     public:
 
@@ -71,7 +67,7 @@ namespace xt
         using size_type = std::size_t;
         using difference_type = std::ptrdiff_t;
 
-        using iterable_base = xexpression_const_iterable<self_type>;
+        using iterable_base = xconst_iterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
         using strides_type = S;

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -39,10 +39,6 @@ namespace xt
         using inner_shape_type = std::array<std::size_t, 1>;
         using const_stepper = xindexed_stepper<xindexview<CT, I>>;
         using stepper = xindexed_stepper<xindexview<CT, I>, false>;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /**************
@@ -65,7 +61,7 @@ namespace xt
      */
     template <class CT, class I>
     class xindexview : public xview_semantic<xindexview<CT, I>>,
-                       public xexpression_iterable<xindexview<CT, I>>
+                       public xiterable<xindexview<CT, I>>
     {
     public:
 
@@ -81,7 +77,7 @@ namespace xt
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
-        using iterable_base = xexpression_iterable<self_type>;
+        using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
         using strides_type = shape_type;
@@ -262,7 +258,7 @@ namespace xt
     template <class CT, class I>
     inline void xindexview<CT, I>::assign_temporary_impl(temporary_type&& tmp)
     {
-        std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
     }
 
     /**

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -46,67 +46,87 @@ namespace xt
         using stepper = typename iterable_types::stepper;
         using const_stepper = typename iterable_types::const_stepper;
 
-        using iterator = typename iterable_types::iterator;
-        using const_iterator = typename iterable_types::const_iterator;
-
         template <layout_type L>
-        using broadcast_iterator = xiterator<stepper, inner_shape_type*, L>;
+        using layout_iterator = xiterator<stepper, inner_shape_type*, L>;
         template <layout_type L>
-        using const_broadcast_iterator = xiterator<const_stepper, inner_shape_type*, L>;
+        using const_layout_iterator = xiterator<const_stepper, inner_shape_type*, L>;
+        template <layout_type L>
+        using reverse_layout_iterator = std::reverse_iterator<layout_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = std::reverse_iterator<const_layout_iterator<L>>;
 
         template <class S, layout_type L>
-        using shaped_xiterator = xiterator<stepper, S, L>;
+        using broadcast_iterator = xiterator<stepper, S, L>;
         template <class S, layout_type L>
-        using const_shaped_xiterator = xiterator<const_stepper, S, L>;
-
-        using reverse_iterator = typename iterable_types::reverse_iterator;
-        using const_reverse_iterator = typename iterable_types::const_reverse_iterator;
-
-        template <layout_type L>
-        using reverse_broadcast_iterator = std::reverse_iterator<broadcast_iterator<L>>;
-        template <layout_type L>
-        using const_reverse_broadcast_iterator = std::reverse_iterator<const_broadcast_iterator<L>>;
-
+        using const_broadcast_iterator = xiterator<const_stepper, S, L>;
         template <class S, layout_type L>
-        using reverse_shaped_xiterator = std::reverse_iterator<shaped_xiterator<S, L>>;
+        using reverse_broadcast_iterator = std::reverse_iterator<broadcast_iterator<S, L>>;
         template <class S, layout_type L>
-        using const_reverse_shaped_xiterator = std::reverse_iterator<const_shaped_xiterator<S, L>>;
+        using const_reverse_broadcast_iterator = std::reverse_iterator<const_broadcast_iterator<S, L>>;
+
+        using storage_iterator = layout_iterator<DL>;
+        using const_storage_iterator = const_layout_iterator<DL>;
+        using reverse_storage_iterator = reverse_layout_iterator<DL>;
+        using const_reverse_storage_iterator = const_reverse_layout_iterator<DL>;
+
+        using iterator = layout_iterator<DL>;
+        using const_iterator = const_layout_iterator<DL>;
+        using reverse_iterator = reverse_layout_iterator<DL>;
+        using const_reverse_iterator = const_reverse_layout_iterator<DL>;
 
         template <layout_type L = DL>
-        const_broadcast_iterator<L> xbegin() const noexcept;
+        const_layout_iterator<L> begin() const noexcept;
         template <layout_type L = DL>
-        const_broadcast_iterator<L> xend() const noexcept;
+        const_layout_iterator<L> end() const noexcept;
         template <layout_type L = DL>
-        const_broadcast_iterator<L> cxbegin() const noexcept;
+        const_layout_iterator<L> cbegin() const noexcept;
         template <layout_type L = DL>
-        const_broadcast_iterator<L> cxend() const noexcept;
-
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> xbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> xend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> cxbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_shaped_xiterator<S, L> cxend(const S& shape) const noexcept;
+        const_layout_iterator<L> cend() const noexcept;
 
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> xrbegin() const noexcept;
+        const_reverse_layout_iterator<L> rbegin() const noexcept;
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> xrend() const noexcept;
+        const_reverse_layout_iterator<L> rend() const noexcept;
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> cxrbegin() const noexcept;
+        const_reverse_layout_iterator<L> crbegin() const noexcept;
         template <layout_type L = DL>
-        const_reverse_broadcast_iterator<L> cxrend() const noexcept;
+        const_reverse_layout_iterator<L> crend() const noexcept;
 
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> xrbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> xrend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> cxrbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
         template <class S, layout_type L = DL>
-        const_reverse_shaped_xiterator<S, L> cxrend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+        template <layout_type L = DL>
+        const_layout_iterator<L> storage_begin() const noexcept;
+        template <layout_type L = DL>
+        const_layout_iterator<L> storage_end() const noexcept;
+        template <layout_type L = DL>
+        const_layout_iterator<L> storage_cbegin() const noexcept;
+        template <layout_type L = DL>
+        const_layout_iterator<L> storage_cend() const noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_layout_iterator<L> storage_rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_layout_iterator<L> storage_rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_layout_iterator<L> storage_crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_layout_iterator<L> storage_crend() const noexcept;
 
     protected:
 
@@ -115,14 +135,14 @@ namespace xt
     private:
 
         template <layout_type L>
-        const_broadcast_iterator<L> get_cxbegin(bool reverse) const noexcept;
+        const_layout_iterator<L> get_cbegin(bool reverse) const noexcept;
         template <layout_type L>
-        const_broadcast_iterator<L> get_cxend(bool reverse) const noexcept;
+        const_layout_iterator<L> get_cend(bool reverse) const noexcept;
 
         template <class S, layout_type L>
-        const_shaped_xiterator<S, L> get_cxbegin(const S& shape, bool reverse) const noexcept;
+        const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool reverse) const noexcept;
         template <class S, layout_type L>
-        const_shaped_xiterator<S, L> get_cxend(const S& shape, bool reverse) const noexcept;
+        const_broadcast_iterator<S, L> get_cend(const S& shape, bool reverse) const noexcept;
 
         template <class S>
         const_stepper get_stepper_begin(const S& shape) const noexcept;
@@ -159,69 +179,77 @@ namespace xt
         using stepper = typename base_type::stepper;
         using const_stepper = typename base_type::const_stepper;
 
+        template <layout_type L>
+        using layout_iterator = typename base_type::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename base_type::template const_layout_iterator<L>;
+        template <layout_type L>
+        using reverse_layout_iterator = typename base_type::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename base_type::template const_reverse_layout_iterator<L>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename base_type::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<S, L>;
+
         using iterator = typename base_type::iterator;
         using const_iterator = typename base_type::const_iterator;
-
-        template <layout_type L>
-        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
-        template <layout_type L>
-        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
-
         using reverse_iterator = typename base_type::reverse_iterator;
         using const_reverse_iterator = typename base_type::const_reverse_iterator;
 
-        template <layout_type L>
-        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
-        template <layout_type L>
-        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
+        using base_type::begin;
+        using base_type::end;
+        using base_type::rbegin;
+        using base_type::rend;
+        using base_type::storage_begin;
+        using base_type::storage_end;
 
         template <layout_type L = DL>
-        broadcast_iterator<L> xbegin() noexcept;
+        layout_iterator<L> begin() noexcept;
         template <layout_type L = DL>
-        broadcast_iterator<L> xend() noexcept;
-
-        using base_type::xbegin;
-        using base_type::xend;
-
-        template <class S, layout_type L = DL>
-        shaped_xiterator<S, L> xbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        shaped_xiterator<S, L> xend(const S& shape) noexcept;
+        layout_iterator<L> end() noexcept;
 
         template <layout_type L = DL>
-        reverse_broadcast_iterator<L> xrbegin() noexcept;
+        reverse_layout_iterator<L> rbegin() noexcept;
         template <layout_type L = DL>
-        reverse_broadcast_iterator<L> xrend() noexcept;
-
-        using base_type::xrbegin;
-        using base_type::xrend;
+        reverse_layout_iterator<L> rend() noexcept;
 
         template <class S, layout_type L = DL>
-        reverse_shaped_xiterator<S, L> xrbegin(const S& shape) noexcept;
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
         template <class S, layout_type L = DL>
-        reverse_shaped_xiterator<S, L> xrend(const S& shape) noexcept;
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <layout_type L = DL>
+        layout_iterator<L> storage_begin() noexcept;
+        template <layout_type L = DL>
+        layout_iterator<L> storage_end() noexcept;
+
+        template <layout_type L = DL>
+        reverse_layout_iterator<L> storage_rbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_layout_iterator<L> storage_rend() noexcept;
 
     private:
 
         template <layout_type L>
-        broadcast_iterator<L> get_xbegin(bool reverse) noexcept;
+        layout_iterator<L> get_begin(bool reverse) noexcept;
         template <layout_type L>
-        broadcast_iterator<L> get_xend(bool reverse) noexcept;
+        layout_iterator<L> get_end(bool reverse) noexcept;
 
         template <class S, layout_type L>
-        shaped_xiterator<S, L> get_xbegin(const S& shape, bool reverse) noexcept;
+        broadcast_iterator<S, L> get_begin(const S& shape, bool reverse) noexcept;
         template <class S, layout_type L>
-        shaped_xiterator<S, L> get_xend(const S& shape, bool reverse) noexcept;
+        broadcast_iterator<S, L> get_end(const S& shape, bool reverse) noexcept;
 
         template <class S>
         stepper get_stepper_begin(const S& shape) noexcept;
@@ -233,144 +261,12 @@ namespace xt
 
 #undef DL
 
-    /******************************
-     * xexpression_const_iterable *
-     ******************************/
-
-    /**
-     * @class xexpression_const_iterable
-     * @brief Base class for multidimensional iterable constant expressions
-     *        that don't store any data
-     *
-     * The xexpression_const_iterable class defines the interface for multidimensional
-     * constant expressions that don't store any data and that can be iterated.
-     *
-     * @tparam D The derived type, i.e. the inheriting class for which xexpression_const_iterable
-     *           provides the interface.
-     */
-    template <class D>
-    class xexpression_const_iterable : public xconst_iterable<D>
-    {
-    public:
-
-        using base_type = xconst_iterable<D>;
-        using inner_shape_type = typename base_type::inner_shape_type;
-
-        using stepper = typename base_type::stepper;
-        using const_stepper = typename base_type::const_stepper;
-
-        using iterator = typename base_type::iterator;
-        using const_iterator = typename base_type::const_iterator;
-
-        template <layout_type L>
-        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
-        template <layout_type L>
-        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
-
-        using reverse_iterator = typename base_type::reverse_iterator;
-        using const_reverse_iterator = typename base_type::const_reverse_iterator;
-
-        template <layout_type L>
-        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
-        template <layout_type L>
-        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
-
-        const_iterator begin() const noexcept;
-        const_iterator end() const noexcept;
-        const_iterator cbegin() const noexcept;
-        const_iterator cend() const noexcept;
-
-        const_reverse_iterator rbegin() const noexcept;
-        const_reverse_iterator rend() const noexcept;
-        const_reverse_iterator crbegin() const noexcept;
-        const_reverse_iterator crend() const noexcept;
-    };
-
-    /************************
-     * xexpression_iterable *
-     ************************/
-
-    /**
-     * @class xexpression_iterable
-     * @brief Base class for multidimensional iterable expressions
-     *        that don't store any data
-     *
-     * The xexpression_iterable class defines the interface for multidimensional
-     * expressions that don't store any data and that can be iterated.
-     *
-     * @tparam D The derived type, i.e.the inheriting class for which xexpression_iterable
-     *           provides the interface.
-     */
-    template <class D>
-    class xexpression_iterable : public xiterable<D>
-    {
-    public:
-
-        using base_type = xiterable<D>;
-        using inner_shape_type = typename base_type::inner_shape_type;
-
-        using stepper = typename base_type::stepper;
-        using const_stepper = typename base_type::const_stepper;
-
-        using iterator = typename base_type::iterator;
-        using const_iterator = typename base_type::const_iterator;
-
-        template <layout_type L>
-        using broadcast_iterator = typename base_type::template broadcast_iterator<L>;
-        template <layout_type L>
-        using const_broadcast_iterator = typename base_type::template const_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using shaped_xiterator = typename base_type::template shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_shaped_xiterator = typename base_type::template const_shaped_xiterator<S, L>;
-
-        using reverse_iterator = typename base_type::reverse_iterator;
-        using const_reverse_iterator = typename base_type::const_reverse_iterator;
-
-        template <layout_type L>
-        using reverse_broadcast_iterator = typename base_type::template reverse_broadcast_iterator<L>;
-        template <layout_type L>
-        using const_reverse_broadcast_iterator = typename base_type::template const_reverse_broadcast_iterator<L>;
-
-        template <class S, layout_type L>
-        using reverse_shaped_xiterator = typename base_type::template reverse_shaped_xiterator<S, L>;
-        template <class S, layout_type L>
-        using const_reverse_shaped_xiterator = typename base_type::template const_reverse_shaped_xiterator<S, L>;
-
-        iterator begin() noexcept;
-        iterator end() noexcept;
-
-        const_iterator begin() const noexcept;
-        const_iterator end() const noexcept;
-        const_iterator cbegin() const noexcept;
-        const_iterator cend() const noexcept;
-
-        reverse_iterator rbegin() noexcept;
-        reverse_iterator rend() noexcept;
-
-        const_reverse_iterator rbegin() const noexcept;
-        const_reverse_iterator rend() const noexcept;
-        const_reverse_iterator crbegin() const noexcept;
-        const_reverse_iterator crend() const noexcept;
-    };
-
     /**********************************
      * xconst_iterable implementation *
      **********************************/
 
     /**
-     * @name Constant broadcast iterators
+     * @name Constant iterators
      */
     //@{
     /**
@@ -379,9 +275,9 @@ namespace xt
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::xbegin() const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::begin() const noexcept -> const_layout_iterator<L>
     {
-        return cxbegin<L>();
+        return cbegin<L>();
     }
 
     /**
@@ -391,9 +287,9 @@ namespace xt
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::xend() const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::end() const noexcept -> const_layout_iterator<L>
     {
-        return cxend<L>();
+        return cend<L>();
     }
 
     /**
@@ -402,9 +298,9 @@ namespace xt
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::cxbegin() const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::cbegin() const noexcept -> const_layout_iterator<L>
     {
-        return get_cxbegin<L>(false);
+        return get_cbegin<L>(false);
     }
 
     /**
@@ -414,11 +310,67 @@ namespace xt
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::cxend() const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::cend() const noexcept -> const_layout_iterator<L>
     {
-        return get_cxend<L>(false);
+        return get_cend<L>(false);
+    }
+    //@}
+
+    /**
+     * @name Constant reverse iterators
+     */
+    //@{
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::rbegin() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crbegin<L>();
     }
 
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::rend() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::crbegin() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return const_reverse_layout_iterator<L>(get_cend<L>(true));
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::crend() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return const_reverse_layout_iterator<L>(get_cbegin<L>(true));
+    }
+    //@}
+
+    /**
+     * @name Constant broadcast iterators
+     */
+    //@{
     /**
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
@@ -428,37 +380,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::xbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cxbegin<S, L>(shape);
-    }
-
-    /**
-    * Returns a constant iterator to the element following the last element of the
-    * expression. The iteration is broadcasted to the specified shape.
-    * @param shape the shape used for broadcasting
-    * @tparam S type of the \c shape parameter.
-    * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-    */
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xconst_iterable<D>::xend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
-    {
-        return cxend<S, L>(shape);
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the expression. The
-     * iteration is broadcasted to the specified shape.
-     * @param shape the shape used for broadcasting
-     * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xconst_iterable<D>::cxbegin(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
-    {
-        return get_cxbegin<S, L>(shape, false);
+        return cbegin<S, L>(shape);
     }
 
     /**
@@ -470,64 +394,46 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::cxend(const S& shape) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cxend<S, L>(shape, false);
+        return cend<S, L>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return get_cbegin<S, L>(shape, false);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <class S, layout_type L>
+    inline auto xconst_iterable<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return get_cend<S, L>(shape, false);
     }
     //@}
 
     /**
-     * @name Constant reverse broadcast iterators
+     * Constant reverse broadcast iterators
      */
     //@{
     /**
      * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::xrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return cxrbegin<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::xrend() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return cxrend<L>();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::cxrbegin() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return const_reverse_broadcast_iterator<L>(get_cxend<L>(true));
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::cxrend() const noexcept -> const_reverse_broadcast_iterator<L>
-    {
-        return const_reverse_broadcast_iterator<L>(get_cxbegin<L>(true));
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
@@ -535,9 +441,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::xrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return cxrbegin<S, L>(shape);
+        return crbegin<S, L>(shape);
     }
 
     /**
@@ -549,9 +455,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::xrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return cxrend<S, L>(shape);
+        return crend<S, L>(shape);
     }
 
     /**
@@ -563,9 +469,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::cxrbegin(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_shaped_xiterator<S, L>(get_cxend<S, L>(shape, true));
+        return const_reverse_broadcast_iterator<S, L>(get_cend<S, L>(shape, true));
     }
 
     /**
@@ -577,38 +483,94 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::cxrend(const S& shape) const noexcept -> const_reverse_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_shaped_xiterator<S, L>(get_cxbegin<S, L>(shape, true));
+        return const_reverse_broadcast_iterator<S, L>(get_cbegin<S, L>(shape, true));
     }
     //@}
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cxbegin(bool reverse) const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::storage_begin() const noexcept -> const_layout_iterator<L>
     {
-        return const_broadcast_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), reverse);
+        return cbegin<L>();
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cxend(bool reverse) const noexcept -> const_broadcast_iterator<L>
+    inline auto xconst_iterable<D>::storage_end() const noexcept -> const_layout_iterator<L>
     {
-        return const_broadcast_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), reverse);
+        return cend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_cbegin() const noexcept -> const_layout_iterator<L>
+    {
+        return cbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_cend() const noexcept -> const_layout_iterator<L>
+    {
+        return cend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_rbegin() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_rend() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_crbegin() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::storage_crend() const noexcept -> const_reverse_layout_iterator<L>
+    {
+        return crend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::get_cbegin(bool reverse) const noexcept -> const_layout_iterator<L>
+    {
+        return const_layout_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), reverse);
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xconst_iterable<D>::get_cend(bool reverse) const noexcept -> const_layout_iterator<L>
+    {
+        return const_layout_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), reverse);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::get_cxbegin(const S& shape, bool reverse) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool reverse) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_shaped_xiterator<S, L>(get_stepper_begin(shape), shape, reverse);
+        return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, reverse);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::get_cxend(const S& shape, bool reverse) const noexcept -> const_shaped_xiterator<S, L>
+    inline auto xconst_iterable<D>::get_cend(const S& shape, bool reverse) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_shaped_xiterator<S, L>(get_stepper_end(shape, L), shape, reverse);
+        return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, reverse);
     }
 
     template <class D>
@@ -642,18 +604,18 @@ namespace xt
      ****************************/
 
     /**
-     * @name Broadcast iterators
+     * @name Iterators
      */
-    //@{
+     //@{
     /**
      * Returns an iterator to the first element of the expression.
      * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::xbegin() noexcept -> broadcast_iterator<L>
+    inline auto xiterable<D>::begin() noexcept -> layout_iterator<L>
     {
-        return get_xbegin<L>(false);
+        return get_begin<L>(false);
     }
 
     /**
@@ -663,11 +625,44 @@ namespace xt
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::xend() noexcept -> broadcast_iterator<L>
+    inline auto xiterable<D>::end() noexcept -> layout_iterator<L>
     {
-        return get_xend<L>(false);
+        return get_end<L>(false);
+    }
+    //@}
+
+    /**
+     * @name Reverse iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::rbegin() noexcept -> reverse_layout_iterator<L>
+    {
+        return reverse_layout_iterator<L>(get_end<L>(true));
     }
 
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::rend() noexcept -> reverse_layout_iterator<L>
+    {
+        return reverse_layout_iterator<L>(get_begin<L>(true));
+    }
+    //@}
+
+    /**
+     * @name Broadcast iterators
+     */
+    //@{
     /**
      * Returns an iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
@@ -677,9 +672,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::xbegin(const S& shape) noexcept -> shaped_xiterator<S, L>
+    inline auto xiterable<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return get_xbegin<S, L>(shape, false);
+        return get_begin<S, L>(shape, false);
     }
 
     /**
@@ -691,9 +686,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::xend(const S& shape) noexcept -> shaped_xiterator<S, L>
+    inline auto xiterable<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return get_xend<S, L>(shape, false);
+        return get_end<S, L>(shape, false);
     }
     //@}
 
@@ -701,29 +696,6 @@ namespace xt
      * @name Reverse broadcast iterators
      */
     //@{
-    /**
-     * Returns an iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::xrbegin() noexcept -> reverse_broadcast_iterator<L>
-    {
-        return reverse_broadcast_iterator<L>(get_xend<L>(true));
-    }
-
-    /**
-     * Returns an iterator to the element following the last element
-     * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c DEFAULT_LAYOUT.
-     */
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::xrend() noexcept -> reverse_broadcast_iterator<L>
-    {
-        return reverse_broadcast_iterator<L>(get_xbegin<L>(true));
-    }
-
     /**
      * Returns an iterator to the first element of the reversed expression. The
      * iteration is broadcasted to the specified shape.
@@ -733,9 +705,9 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::xrbegin(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    inline auto xiterable<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_shaped_xiterator<S, L>(get_xend<S, L>(shape, true));
+        return reverse_broadcast_iterator<S, L>(get_end<S, L>(shape, true));
     }
 
     /**
@@ -747,38 +719,66 @@ namespace xt
      */
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::xrend(const S& shape) noexcept -> reverse_shaped_xiterator<S, L>
+    inline auto xiterable<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_shaped_xiterator<S, L>(get_xbegin<S, L>(shape, true));
+        return reverse_broadcast_iterator<S, L>(get_begin<S, L>(shape, true));
     }
     //@}
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_xbegin(bool reverse) noexcept -> broadcast_iterator<L>
+    inline auto xiterable<D>::storage_begin() noexcept -> layout_iterator<L>
     {
-        return broadcast_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), reverse);
+        return begin<L>();
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_xend(bool reverse) noexcept -> broadcast_iterator<L>
+    inline auto xiterable<D>::storage_end() noexcept -> layout_iterator<L>
     {
-        return broadcast_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), reverse);
+        return end<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::storage_rbegin() noexcept -> reverse_layout_iterator<L>
+    {
+        return rbegin<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::storage_rend() noexcept -> reverse_layout_iterator<L>
+    {
+        return rend<L>();
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::get_begin(bool reverse) noexcept -> layout_iterator<L>
+    {
+        return layout_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), reverse);
+    }
+
+    template <class D>
+    template <layout_type L>
+    inline auto xiterable<D>::get_end(bool reverse) noexcept -> layout_iterator<L>
+    {
+        return layout_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), reverse);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::get_xbegin(const S& shape, bool reverse) noexcept -> shaped_xiterator<S, L>
+    inline auto xiterable<D>::get_begin(const S& shape, bool reverse) noexcept -> broadcast_iterator<S, L>
     {
-        return shaped_xiterator<S, L>(get_stepper_begin(shape), shape, reverse);
+        return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, reverse);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::get_xend(const S& shape, bool reverse) noexcept -> shaped_xiterator<S, L>
+    inline auto xiterable<D>::get_end(const S& shape, bool reverse) noexcept -> broadcast_iterator<S, L>
     {
-        return shaped_xiterator<S, L>(get_stepper_end(shape, L), shape, reverse);
+        return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, reverse);
     }
 
     template <class D>
@@ -801,232 +801,6 @@ namespace xt
         return *static_cast<derived_type*>(this);
     }
 
-    /*********************************************
-     * xexpression_const_iterable implementation *
-     *********************************************/
-
-    /**
-     * @name Constant Iterators
-     */
-    //@{
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::begin() const noexcept -> const_iterator
-    {
-        return this->cxbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::end() const noexcept -> const_iterator
-    {
-        return this->cxend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::cbegin() const noexcept -> const_iterator
-    {
-        return this->cxbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::cend() const noexcept -> const_iterator
-    {
-        return this->cxend();
-    }
-    //@}
-
-    /**
-     * @name Constant Reverse Iterators
-     */
-    //@{
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::rbegin() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::rend() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::crbegin() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_const_iterable<D>::crend() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrend();
-    }
-    //@}
-
-    /***************************************
-     * xexpression_iterable implementation *
-     ***************************************/
-
-    /**
-     * @name Iterators
-     */
-    //@{
-    /**
-     * Returns an iterator to the first element of the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::begin() noexcept -> iterator
-    {
-        return this->xbegin();
-    }
-
-    /**
-     * Returns an iterator to the element following the last element of
-     * the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::end() noexcept -> iterator
-    {
-        return this->xend();
-    }
-    //@}
-
-    /**
-     * @name Constant Iterators
-     */
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::begin() const noexcept -> const_iterator
-    {
-        return this->cxbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::end() const noexcept -> const_iterator
-    {
-        return this->cxend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::cbegin() const noexcept -> const_iterator
-    {
-        return this->cxbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::cend() const noexcept -> const_iterator
-    {
-        return this->cxend();
-    }
-    //@}
-
-    /**
-     * @name Reverse Iterators
-     */
-    //@{
-    /**
-     * Returns an iterator to the first element of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::rbegin() noexcept -> reverse_iterator
-    {
-        return this->xrbegin();
-    }
-
-    /**
-     * Returns an iterator to the element following the last element
-     * of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::rend() noexcept -> reverse_iterator
-    {
-        return this->xrend();
-    }
-    //@}
-
-    /**
-     * @name Constant Reverse Iterators
-     */
-    //@{
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::rbegin() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::rend() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrend();
-    }
-
-    /**
-     * Returns a constant iterator to the first element of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::crbegin() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrbegin();
-    }
-
-    /**
-     * Returns a constant iterator to the element following the last element
-     * of the reversed expression.
-     */
-    template <class D>
-    inline auto xexpression_iterable<D>::crend() const noexcept -> const_reverse_iterator
-    {
-        return this->cxrend();
-    }
-    //@}
 }
 
 #endif

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -296,27 +296,27 @@ namespace xt
     namespace detail
     {
         template <class C>
-        constexpr auto trivial_begin(C& c) -> decltype(c.begin())
+        constexpr auto trivial_begin(C& c) noexcept
         {
-            return c.begin();
+            return c.storage_begin();
         }
 
         template <class C>
-        constexpr auto trivial_end(C& c) -> decltype(c.end())
+        constexpr auto trivial_end(C& c) noexcept
         {
-            return c.end();
+            return c.storage_end();
         }
 
         template <class C>
-        constexpr auto trivial_begin(const C& c) -> decltype(c.begin())
+        constexpr auto trivial_begin(const C& c) noexcept
         {
-            return c.begin();
+            return c.storage_begin();
         }
 
         template <class C>
-        constexpr auto trivial_end(const C& c) -> decltype(c.end())
+        constexpr auto trivial_end(const C& c) noexcept
         {
-            return c.end();
+            return c.storage_end();
         }
     }
 

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -326,9 +326,9 @@ namespace xt
         const E1& de1 = e1.derived_cast();
         const E2& de2 = e2.derived_cast();
         bool res = de1.dimension() == de2.dimension() && std::equal(de1.shape().begin(), de1.shape().end(), de2.shape().begin());
-        auto iter1 = de1.xbegin();
-        auto iter2 = de2.xbegin();
-        auto iter_end = de1.xend();
+        auto iter1 = de1.begin();
+        auto iter2 = de2.begin();
+        auto iter_end = de1.end();
         while (res && iter1 != iter_end)
         {
             res = (*iter1++ == *iter2++);
@@ -488,7 +488,7 @@ namespace xt
         }
         else
         {
-            return std::any_of(e.xbegin(), e.xend(),
+            return std::any_of(e.begin(), e.end(),
                                [](const typename std::decay_t<E>::value_type& el) { return el; });
         }
     }
@@ -513,7 +513,7 @@ namespace xt
         }
         else
         {
-            return std::all_of(e.xbegin(), e.xend(),
+            return std::all_of(e.begin(), e.end(),
                                [](const typename std::decay_t<E>::value_type& el) { return el; });
         }
     }

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -68,10 +68,6 @@ namespace xt
         using inner_shape_type = typename xreducer_shape_type<typename xexpression_type::shape_type, X>::type;
         using const_stepper = xreducer_stepper<F, CT, X>;
         using stepper = const_stepper;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using iterator = const_iterator;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /**
@@ -90,7 +86,7 @@ namespace xt
      */
     template <class F, class CT, class X>
     class xreducer : public xexpression<xreducer<F, CT, X>>,
-                     public xexpression_const_iterable<xreducer<F, CT, X>>
+                     public xconst_iterable<xreducer<F, CT, X>>
     {
     public:
 
@@ -108,7 +104,7 @@ namespace xt
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
-        using iterable_base = xexpression_const_iterable<self_type>;
+        using iterable_base = xconst_iterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -40,17 +40,14 @@ namespace xt
     {
         using value_type = std::decay_t<CT>;
         using inner_shape_type = std::array<std::size_t, 0>;
-        using iterator = value_type*;
-        using const_iterator = const value_type*;
         using const_stepper = xscalar_stepper<true, CT>;
         using stepper = xscalar_stepper<false, CT>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     };
 
+#define DL DEFAULT_LAYOUT
     template <class CT>
     class xscalar : public xexpression<xscalar<CT>>,
-                    public xiterable<xscalar<CT>>
+                    private xiterable<xscalar<CT>>
     {
     public:
 
@@ -71,8 +68,30 @@ namespace xt
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
 
-        using iterator = typename iterable_base::iterator;
-        using const_iterator = typename iterable_base::const_iterator;
+        template <layout_type L>
+        using layout_iterator = typename iterable_base::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
+
+        template <layout_type L>
+        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
+
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
+
+        using iterator = value_type*;
+        using const_iterator = const value_type*;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
         using dummy_iterator = xdummy_iterator<false, CT>;
         using const_dummy_iterator = xdummy_iterator<true, CT>;
@@ -109,13 +128,90 @@ namespace xt
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
 
+        template <layout_type L = DL>
         iterator begin() noexcept;
+        template <layout_type L = DL>
         iterator end() noexcept;
 
+        template <layout_type L = DL>
         const_iterator begin() const noexcept;
+        template <layout_type L = DL>
         const_iterator end() const noexcept;
+        template <layout_type L = DL>
         const_iterator cbegin() const noexcept;
+        template <layout_type L = DL>
         const_iterator cend() const noexcept;
+
+        template <layout_type L = DL>
+        reverse_iterator rbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_iterator rend() noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_iterator rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator crend() const noexcept;
+
+        template <class S, layout_type L = DL>
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <class S, layout_type L = DL>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = DL>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+        template <layout_type L = DL>
+        iterator storage_begin() noexcept;
+        template <layout_type L = DL>
+        iterator storage_end() noexcept;
+
+        template <layout_type L = DL>
+        const_iterator storage_begin() const noexcept;
+        template <layout_type L = DL>
+        const_iterator storage_end() const noexcept;
+        template <layout_type L = DL>
+        const_iterator storage_cbegin() const noexcept;
+        template <layout_type L = DL>
+        const_iterator storage_cend() const noexcept;
+
+        template <layout_type L = DL>
+        reverse_iterator storage_rbegin() noexcept;
+        template <layout_type L = DL>
+        reverse_iterator storage_rend() noexcept;
+
+        template <layout_type L = DL>
+        const_reverse_iterator storage_rbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator storage_rend() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator storage_crbegin() const noexcept;
+        template <layout_type L = DL>
+        const_reverse_iterator storage_crend() const noexcept;
 
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
@@ -139,7 +235,11 @@ namespace xt
     private:
 
         CT m_value;
+
+        friend class xconst_iterable<self_type>;
+        friend class xiterable<self_type>;
     };
+#undef DL
 
     template <class T>
     xscalar<T&> xref(T& t);
@@ -251,25 +351,25 @@ namespace xt
     namespace detail
     {
         template <class CT>
-        constexpr auto trivial_begin(xscalar<CT>& c) -> decltype(c.dummy_begin())
+        constexpr auto trivial_begin(xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
         {
             return c.dummy_begin();
         }
 
         template <class CT>
-        constexpr auto trivial_end(xscalar<CT>& c) -> decltype(c.dummy_end())
+        constexpr auto trivial_end(xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
         {
             return c.dummy_end();
         }
 
         template <class CT>
-        constexpr auto trivial_begin(const xscalar<CT>& c) -> decltype(c.dummy_begin())
+        constexpr auto trivial_begin(const xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
         {
             return c.dummy_begin();
         }
 
         template <class CT>
-        constexpr auto trivial_end(const xscalar<CT>& c) -> decltype(c.dummy_end())
+        constexpr auto trivial_end(const xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
         {
             return c.dummy_end();
         }
@@ -377,39 +477,259 @@ namespace xt
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::begin() noexcept -> iterator
     {
         return &m_value;
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::end() noexcept -> iterator
     {
         return &m_value + 1;
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::begin() const noexcept -> const_iterator
     {
         return &m_value;
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::end() const noexcept -> const_iterator
     {
         return &m_value + 1;
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::cbegin() const noexcept -> const_iterator
     {
         return &m_value;
     }
 
     template <class CT>
+    template <layout_type L>
     inline auto xscalar<CT>::cend() const noexcept -> const_iterator
     {
         return &m_value + 1;
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::rbegin() noexcept -> reverse_iterator
+    {
+        return reverse_storage_iterator(end());
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_storage_iterator(begin());
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return crbegin();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::rend() const noexcept -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_storage_iterator(cend());
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::crend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_storage_iterator(cbegin());
+    }
+
+    /*****************************
+    * Broadcasting iterator api *
+    *****************************/
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cbegin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cend<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crbegin<S, L>(shape);
+    }
+
+    template <class CT>
+    template <class S, layout_type L>
+    inline auto xscalar<CT>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crend<S, L>(shape);
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_begin() noexcept -> iterator
+    {
+        return begin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_end() noexcept -> iterator
+    {
+        return end<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_begin() const noexcept -> const_iterator
+    {
+        return begin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_end() const noexcept -> const_iterator
+    {
+        return end<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_cbegin() const noexcept -> const_iterator
+    {
+        return cbegin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_cend() const noexcept -> const_iterator
+    {
+        return cend<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_rbegin() noexcept -> reverse_iterator
+    {
+        return rbegin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_rend() noexcept -> reverse_iterator
+    {
+        return rend<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_rbegin() const noexcept -> const_reverse_iterator
+    {
+        return rbegin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_rend() const noexcept -> const_reverse_iterator
+    {
+        return rend<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_crbegin() const noexcept -> const_reverse_iterator
+    {
+        return crbegin<L>();
+    }
+
+    template <class CT>
+    template <layout_type L>
+    inline auto xscalar<CT>::storage_crend() const noexcept -> const_reverse_iterator
+    {
+        return crend<L>();
     }
 
     template <class CT>

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -547,7 +547,7 @@ namespace xt
     inline auto xview_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
     {
         D& d = this->derived_cast();
-        std::transform(d.xbegin(), d.xend(), d.xbegin(),
+        std::transform(d.begin(), d.end(), d.begin(),
                        [e, &f](const auto& v) { return f(v, e); });
         return this->derived_cast();
     }

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -41,10 +41,6 @@ namespace xt
         using inner_backstrides_type_type = inner_shape_type;
         using const_stepper = xstepper<const xstrided_view<CT, S, CD>>;
         using stepper = xstepper<xstrided_view<CT, S, CD>>;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
     };
 
     /*****************
@@ -65,7 +61,7 @@ namespace xt
      */
     template <class CT, class S, class CD>
     class xstrided_view : public xview_semantic<xstrided_view<CT, S, CD>>,
-                          public xexpression_iterable<xstrided_view<CT, S, CD>>
+                          public xiterable<xstrided_view<CT, S, CD>>
     {
     public:
 
@@ -83,7 +79,7 @@ namespace xt
 
         using underlying_container_type = CD;
 
-        using iterable_base = xexpression_iterable<self_type>;
+        using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
         using strides_type = shape_type;

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -37,6 +37,7 @@ namespace xt
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = xtensor_container<EC, N, L>;
+        static constexpr layout_type layout = L;
     };
 
     template <class EC, std::size_t N, layout_type L>
@@ -59,13 +60,13 @@ namespace xt
      * @sa xtensor
      */
     template <class EC, size_t N, layout_type L>
-    class xtensor_container : public xstrided_container<xtensor_container<EC, N, L>, L>,
+    class xtensor_container : public xstrided_container<xtensor_container<EC, N, L>>,
                               public xcontainer_semantic<xtensor_container<EC, N, L>>
     {
     public:
 
         using self_type = xtensor_container<EC, N, L>;
-        using base_type = xstrided_container<self_type, L>;
+        using base_type = xstrided_container<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
         using container_type = typename base_type::container_type;
         using value_type = typename base_type::value_type;
@@ -132,6 +133,7 @@ namespace xt
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = xtensor_container<EC, N, L>;
+        static constexpr layout_type layout = L;
     };
 
     template <class EC, std::size_t N, layout_type L>
@@ -155,13 +157,13 @@ namespace xt
      * @tparam L The layout_type of the adaptor.
      */
     template <class EC, std::size_t N, layout_type L>
-    class xtensor_adaptor : public xstrided_container<xtensor_adaptor<EC, N, L>, L>,
+    class xtensor_adaptor : public xstrided_container<xtensor_adaptor<EC, N, L>>,
                             public xadaptor_semantic<xtensor_adaptor<EC, N, L>>
     {
     public:
 
         using self_type = xtensor_adaptor<EC, N, L>;
-        using base_type = xstrided_container<self_type, L>;
+        using base_type = xstrided_container<self_type>;
         using semantic_base = xadaptor_semantic<self_type>;
         using container_type = typename base_type::container_type;
         using shape_type = typename base_type::shape_type;
@@ -224,7 +226,7 @@ namespace xt
         : base_type()
     {
         base_type::reshape(xt::shape<shape_type>(t), true);
-        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template xbegin<layout_type::row_major>(), t);
+        L == layout_type::row_major ? nested_copy(m_data.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
     }
 
     /**

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -916,6 +916,16 @@ namespace xt
         constexpr static bool value = decltype(test<T>(std::size_t(0)))::value == true;
     };
 
+    /******************
+     * enable_if_type *
+     ******************/
+
+    template <class T>
+    struct enable_if_type
+    {
+        using type = void;
+    };
+
     /*****************************
      * is_complete implemenation * 
      *****************************/
@@ -934,6 +944,40 @@ namespace xt
 
     template <typename T>
     struct is_complete : detail::is_complete_impl<T>::type {};
+
+    /*************
+     * static_if *
+     *************/
+
+    namespace static_if_detail
+    {
+        struct identity
+        {
+            template <class T>
+            T&& operator()(T&& x) const
+            {
+                return std::forward<T>(x);
+            }
+        };
+    }
+
+    template <class TF, class FF>
+    auto static_if(std::true_type, const TF& tf, const FF&)
+    {
+        return tf(static_if_detail::identity());
+    }
+
+    template <class TF, class FF>
+    auto static_if(std::false_type, const TF&, const FF& ff)
+    {
+        return ff(static_if_detail::identity());
+    }
+
+    template <bool cond, class TF, class FF>
+    auto static_if(const TF& tf, const FF& ff)
+    {
+        return static_if(std::integral_constant<bool, cond>(), tf, ff);
+    }
 
     /********************************************
      * xtrivial_default_construct implemenation * 

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -50,10 +50,6 @@ namespace xt
         using inner_shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
         using stepper = xview_stepper<false, CT, S...>;
         using const_stepper = xview_stepper<true, CT, S...>;
-        using iterator = xiterator<stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using const_iterator = xiterator<const_stepper, inner_shape_type*, DEFAULT_LAYOUT>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     };
 
     /**
@@ -72,7 +68,7 @@ namespace xt
      */
     template <class CT, class... S>
     class xview : public xview_semantic<xview<CT, S...>>,
-                  public xexpression_iterable<xview<CT, S...>>
+                  public xiterable<xview<CT, S...>>
     {
     public:
 
@@ -88,7 +84,7 @@ namespace xt
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
-        using iterable_base = xexpression_iterable<self_type>;
+        using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
         using strides_type = shape_type;
@@ -712,7 +708,7 @@ namespace xt
     template <class CT, class... S>
     inline void xview<CT, S...>::assign_temporary_impl(temporary_type&& tmp)
     {
-        std::copy(tmp.cbegin(), tmp.cend(), this->xbegin());
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
     }
 
     namespace detail

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -567,43 +567,25 @@ namespace xt
         }
     }
 
-    template <class V, class C = std::vector<std::size_t>>
-    void test_iterator(V& vec)
+    template <class VRM, class VCM, class C = std::vector<std::size_t>>
+    void test_iterator(VRM& vecrm, VCM& veccm)
     {
         {
             SCOPED_TRACE("row_major storage iterator");
             row_major_result<C> rm;
-            vec.reshape(rm.m_shape, layout_type::row_major);
-            std::copy(rm.data().cbegin(), rm.data().cend(), vec.begin());
-            EXPECT_EQ(rm.data(), vec.data());
-            EXPECT_EQ(vec.end(), vec.data().end());
+            vecrm.reshape(rm.m_shape, layout_type::row_major);
+            std::copy(rm.data().cbegin(), rm.data().cend(), vecrm.template begin<layout_type::row_major>());
+            EXPECT_EQ(rm.data(), vecrm.data());
+            EXPECT_EQ(vecrm.template end<layout_type::row_major>(), vecrm.data().end());
         }
 
         {
             SCOPED_TRACE("column_major storage iterator");
             column_major_result<C> cm;
-            vec.reshape(cm.m_shape, layout_type::column_major);
-            std::copy(cm.data().cbegin(), cm.data().cend(), vec.begin());
-            EXPECT_EQ(cm.data(), vec.data());
-            EXPECT_EQ(vec.end(), vec.data().end());
-        }
-
-        {
-            SCOPED_TRACE("central_major storage iterator");
-            central_major_result<C> cem;
-            vec.reshape(cem.m_shape, cem.m_strides);
-            std::copy(cem.data().cbegin(), cem.data().cend(), vec.begin());
-            EXPECT_EQ(cem.data(), vec.data());
-            EXPECT_EQ(vec.end(), vec.data().end());
-        }
-
-        {
-            SCOPED_TRACE("unit_shape storage iterator");
-            unit_shape_result<C> usr;
-            vec.reshape(usr.m_shape, layout_type::row_major);
-            std::copy(usr.data().cbegin(), usr.data().cend(), vec.begin());
-            EXPECT_EQ(usr.data(), vec.data());
-            EXPECT_EQ(vec.end(), vec.data().end());
+            veccm.reshape(cm.m_shape, layout_type::column_major);
+            std::copy(cm.data().cbegin(), cm.data().cend(), veccm.template begin<layout_type::column_major>());
+            EXPECT_EQ(cm.data(), veccm.data());
+            EXPECT_EQ(veccm.template end<layout_type::column_major>(), veccm.data().end());
         }
     }
 
@@ -618,8 +600,8 @@ namespace xt
 
         // broadcast_iterator
         {
-            auto iter = vec.template xbegin<layout_type::row_major>();
-            auto iter_end = vec.template xend<layout_type::row_major>();
+            auto iter = vec.template begin<layout_type::row_major>();
+            auto iter_end = vec.template end<layout_type::row_major>();
             for (size_t i = 0; i < nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec.data()[nb_iter], *iter);
@@ -633,8 +615,8 @@ namespace xt
             shape_type shape(rm.m_shape.size() + 1);
             std::copy(rm.m_shape.begin(), rm.m_shape.end(), shape.begin() + 1);
             shape[0] = 2;
-            auto iter = vec.template xbegin<shape_type, layout_type::row_major>(shape);
-            auto iter_end = vec.template xend<shape_type, layout_type::row_major>(shape);
+            auto iter = vec.template begin<shape_type, layout_type::row_major>(shape);
+            auto iter_end = vec.template end<shape_type, layout_type::row_major>(shape);
             for (size_t i = 0; i < 2 * nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec.data()[0], *iter);
@@ -645,8 +627,8 @@ namespace xt
 
         // column broadcast_iterator
         {
-            auto iter = vec.template xbegin<layout_type::column_major>();
-            auto iter_end = vec.template xend<layout_type::column_major>();
+            auto iter = vec.template begin<layout_type::column_major>();
+            auto iter_end = vec.template end<layout_type::column_major>();
             for (size_t i = 0; i < nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec(0, 0, 2), *iter);
@@ -660,8 +642,8 @@ namespace xt
             shape_type shape(rm.m_shape.size() + 1);
             std::copy(rm.m_shape.begin(), rm.m_shape.end(), shape.begin() + 1);
             shape[0] = 2;
-            auto iter = vec.template xbegin<shape_type, layout_type::column_major>(shape);
-            auto iter_end = vec.template xend<shape_type, layout_type::column_major>(shape);
+            auto iter = vec.template begin<shape_type, layout_type::column_major>(shape);
+            auto iter_end = vec.template end<shape_type, layout_type::column_major>(shape);
             for (size_t i = 0; i < 2 * nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec(0, 0, 2), *iter);
@@ -681,8 +663,8 @@ namespace xt
 
         // broadcast_iterator
         {
-            auto iter = vec.template xrbegin<layout_type::row_major>();
-            auto iter_end = vec.template xrend<layout_type::row_major>();
+            auto iter = vec.template rbegin<layout_type::row_major>();
+            auto iter_end = vec.template rend<layout_type::row_major>();
             for (size_t i = 0; i < nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec.data()[nb_iter - 1], *iter);
@@ -697,8 +679,8 @@ namespace xt
             shape_type shape(rm.m_shape.size() + 1);
             std::copy(rm.m_shape.begin(), rm.m_shape.end(), shape.begin() + 1);
             shape[0] = 2;
-            auto iter = vec.template xrbegin<shape_type, layout_type::row_major>(shape);
-            auto iter_end = vec.template xrend<shape_type, layout_type::row_major>(shape);
+            auto iter = vec.template rbegin<shape_type, layout_type::row_major>(shape);
+            auto iter_end = vec.template rend<shape_type, layout_type::row_major>(shape);
             for (size_t i = 0; i < 2 * nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(vec.data()[2 * nb_iter - 1], *iter);

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -8,6 +8,7 @@
 
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
 #include "test_common.hpp"
 
 namespace xt
@@ -178,8 +179,9 @@ namespace xt
 
     TEST(xarray, iterator)
     {
-        xarray_dynamic a;
-        test_iterator(a);
+        xarray<int, layout_type::row_major> arm;
+        xarray<int, layout_type::column_major> acm;
+        test_iterator(arm, acm);
     }
 
     TEST(xarray, initializer_list)
@@ -228,9 +230,9 @@ namespace xt
         EXPECT_EQ(a, rb);
     }
 
-    TEST(xarray, xend_optimized_stride)
+    TEST(xarray, end_optimized_stride)
     {
         xarray_dynamic a = {1};
-        EXPECT_FALSE((a.xbegin() == a.xend()));
+        EXPECT_FALSE((a.begin() == a.end()));
     }
 }

--- a/test/test_xarray_adaptor.cpp
+++ b/test/test_xarray_adaptor.cpp
@@ -128,8 +128,11 @@ namespace xt
     TEST(xarray_adaptor, iterator)
     {
         vec_type v;
-        adaptor_type a(v);
-        test_iterator(a);
+        using adaptor_rm = xarray_adaptor<vec_type, layout_type::row_major>;
+        using adaptor_cm = xarray_adaptor<vec_type, layout_type::column_major>;
+        adaptor_rm arm(v);
+        adaptor_cm acm(v);
+        test_iterator(arm, acm);
     }
 
     TEST(xarray_adaptor, xiterator)

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -30,7 +30,7 @@ namespace xt
         ASSERT_EQ(4.0, m1_broadcast2(0, 1, 0));
         ASSERT_EQ(5.0, m1_broadcast2(0, 1, 1));
 
-        double f = *(m1_broadcast.xbegin());
+        double f = *(m1_broadcast.begin());
         xarray<double> m1_assigned = m1_broadcast;
         ASSERT_EQ(5.0, m1_assigned(0, 1, 1));
     }
@@ -66,8 +66,8 @@ namespace xt
 
         // broadcast_iterator
         {
-            auto iter = m1_broadcast.template xbegin<layout_type::row_major>();
-            auto iter_end = m1_broadcast.template xend<layout_type::row_major>();
+            auto iter = m1_broadcast.template begin<layout_type::row_major>();
+            auto iter_end = m1_broadcast.template end<layout_type::row_major>();
             for (size_t i = 0; i < nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(1, *iter);
@@ -79,8 +79,8 @@ namespace xt
         // shaped_xiterator
         {
             shape_type shape = {2, 2, 3};
-            auto iter = m1_broadcast.template xbegin<shape_type, layout_type::row_major>(shape);
-            auto iter_end = m1_broadcast.template xend<shape_type, layout_type::row_major>(shape);
+            auto iter = m1_broadcast.template begin<shape_type, layout_type::row_major>(shape);
+            auto iter_end = m1_broadcast.template end<shape_type, layout_type::row_major>(shape);
             for (size_t i = 0; i < 2 * nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(1, *iter);
@@ -99,8 +99,8 @@ namespace xt
 
         // reverse_broadcast_iterator
         {
-            auto iter = m1_broadcast.template xrbegin<layout_type::row_major>();
-            auto iter_end = m1_broadcast.template xrend<layout_type::row_major>();
+            auto iter = m1_broadcast.template rbegin<layout_type::row_major>();
+            auto iter_end = m1_broadcast.template rend<layout_type::row_major>();
             for (size_t i = 0; i < nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(3, *iter);
@@ -112,8 +112,8 @@ namespace xt
         // reverse_shaped_xiterator
         {
             shape_type shape = {2, 2, 3};
-            auto iter = m1_broadcast.template xrbegin<shape_type, layout_type::row_major>(shape);
-            auto iter_end = m1_broadcast.template xrend<shape_type, layout_type::row_major>(shape);
+            auto iter = m1_broadcast.template rbegin<shape_type, layout_type::row_major>(shape);
+            auto iter_end = m1_broadcast.template rend<shape_type, layout_type::row_major>(shape);
             for (size_t i = 0; i < 2 * nb_iter; ++i)
                 ++iter;
             EXPECT_EQ(3, *iter);

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -350,7 +350,7 @@ namespace xt
         std::vector<double> d2 = {6, 7, 8, 9, 10, 11};
         xarray<double> expected_2;
         expected_2.reshape({2, 3, 1});
-        std::copy(d2.begin(), d2.end(), expected_2.template xbegin<layout_type::row_major>());
+        std::copy(d2.begin(), d2.end(), expected_2.template begin<layout_type::row_major>());
 
         xarray<double> t2 = xt::diagonal(e, 1);
         ASSERT_EQ(expected_2, t2);
@@ -358,7 +358,7 @@ namespace xt
         std::vector<double> d3 = {3, 9, 15, 21};
         xarray<double> expected_3;
         expected_3.reshape({2, 2, 1});
-        std::copy(d3.begin(), d3.end(), expected_3.template xbegin<layout_type::row_major>());
+        std::copy(d3.begin(), d3.end(), expected_3.template begin<layout_type::row_major>());
         xarray<double> t3 = xt::diagonal(e, -1, 2, 3);
         ASSERT_EQ(expected_3, t3);
     }

--- a/test/test_xdynamicview.cpp
+++ b/test/test_xdynamicview.cpp
@@ -22,7 +22,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, 1, range(1, 4)));
         EXPECT_EQ(a(1, 1), view1(0));
@@ -81,7 +81,7 @@ namespace xt
             211, 212
         };
         xarray<double> a(shape);
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, 1));
         EXPECT_EQ(2, view1.dimension());
@@ -102,7 +102,7 @@ namespace xt
         xarray<double> a(shape);
         std::vector<double> data {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                                   13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, range(0, 2), 1, range(1, 4)));
         auto iter = view1.begin();
@@ -142,12 +142,12 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<int> a(shape);
         std::vector<int> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         view_shape_type shape2 = {3};
         xarray<int> b(shape2);
         std::vector<int> data2 = {1, 2, 3};
-        std::copy(data2.cbegin(), data2.cend(), b.template xbegin<layout_type::row_major>());
+        std::copy(data2.cbegin(), data2.cend(), b.template begin<layout_type::row_major>());
 
         auto func = dynamic_view(a, slice_vector(a, 1, range(1, 4))) + b;
         auto iter = func.begin();
@@ -166,7 +166,7 @@ namespace xt
     {
         xtensor<int, 2> a({3, 4});
         std::vector<int> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, 1, range(1, 4)));
         EXPECT_EQ(a(1, 1), view1(0));
@@ -203,7 +203,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, all(), newaxis(), all()));
         EXPECT_EQ(a(1, 1), view1(1, 0, 1));
@@ -253,7 +253,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = dynamic_view(a, slice_vector(a, all(), all(), newaxis()));
         auto iter1 = view1.begin();
@@ -321,19 +321,19 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         xarray<double> b(view_shape_type(1, 4));
         auto data_end = data.cbegin();
         data_end += 4;
-        std::copy(data.cbegin(), data_end, b.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data_end, b.template begin<layout_type::row_major>());
 
         auto v = dynamic_view(b, slice_vector(b, newaxis(), all()));
         xarray<double> res = a + v;
 
         std::vector<double> data2{2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16};
         xarray<double> expected(shape);
-        std::copy(data2.cbegin(), data2.cend(), expected.template xbegin<layout_type::row_major>());
+        std::copy(data2.cbegin(), data2.cend(), expected.template begin<layout_type::row_major>());
 
         EXPECT_EQ(expected, res);
     }

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -187,9 +187,9 @@ namespace xt
     void test_xfunction_iterator(const xarray<int>& a, const xarray<int>& b)
     {
         auto func = (a + b);
-        auto iter = func.xbegin();
-        auto itera = a.xbegin();
-        auto iterb = b.xbegin(a.shape());
+        auto iter = func.begin();
+        auto itera = a.begin();
+        auto iterb = b.begin(a.shape());
         auto nb_iter = a.shape().back() * 2 + 1;
         for (size_t i = 0; i < nb_iter; ++i)
         {
@@ -204,25 +204,31 @@ namespace xt
 
         {
             SCOPED_TRACE("same shape");
+            std::cout << "before same shape" << std::endl;
             test_xfunction_iterator(f.m_a, f.m_a);
+            std::cout << "after same shape" << std::endl;
         }
 
         {
             SCOPED_TRACE("different shape");
+            std::cout << "before different shape" << std::endl;
             test_xfunction_iterator(f.m_a, f.m_b);
+            std::cout << "after different shape" << std::endl;
         }
 
         {
             SCOPED_TRACE("different dimensions");
+            std::cout << "before different dimensions" << std::endl;
             test_xfunction_iterator(f.m_c, f.m_a);
+            std::cout << "after different dimensions" << std::endl;
         }
     }
 
     void test_xfunction_iterator_end(const xarray<int>& a, const xarray<int>& b)
     {
         auto func = (a + b);
-        auto iter = func.xbegin();
-        auto iter_end = func.xend();
+        auto iter = func.begin();
+        auto iter_end = func.end();
         auto size = a.size();
         for (size_t i = 0; i < size; ++i)
         {

--- a/test/test_xindexview.cpp
+++ b/test/test_xindexview.cpp
@@ -84,12 +84,12 @@ namespace xt
         std::vector<size_t> idx = {2};
         EXPECT_EQ(fn(2, 2), v.element(idx.begin(), idx.end()));
 
-        auto it = v.xbegin();
+        auto it = v.begin();
         EXPECT_EQ(fn(1, 1), *it);
 
         EXPECT_EQ(fn(1, 2), *(++it));
         EXPECT_EQ(fn(2, 2), *(++it));
-        EXPECT_EQ(++it, v.xend());
+        EXPECT_EQ(++it, v.end());
     }
 
     TEST(xindexview, view_on_view)

--- a/test/test_xiterator.cpp
+++ b/test/test_xiterator.cpp
@@ -25,8 +25,8 @@ namespace xt
         size_type nb_inc = shape.back() * shape[shape.size() - 2] + 1;
         int expected = a(1, 0, 1);
 
-        auto iter = a.template xbegin<layout_type::row_major>();
-        auto iter2 = a.template xbegin<layout_type::row_major>();
+        auto iter = a.template begin<layout_type::row_major>();
+        auto iter2 = a.template begin<layout_type::row_major>();
         for (size_type i = 0; i < nb_inc; ++i)
         {
             ++iter;
@@ -115,8 +115,8 @@ namespace xt
         xarray_adaptor<typename R::vector_type, layout_type::dynamic> a(data, result.shape(), result.strides());
 
         size_type size = a.size();
-        auto iter = a.xbegin();
-        auto last = a.xend();
+        auto iter = a.begin();
+        auto last = a.end();
         for (size_type i = 0; i < size; ++i)
         {
             ++iter;
@@ -204,8 +204,8 @@ namespace xt
         size_type nb_inc = shape.back() * shape[shape.size() - 2] + 1;
         int expected = a(1, 1, 2);
 
-        auto iter = a.template xrbegin<layout_type::row_major>();
-        auto iter2 = a.template xrbegin<layout_type::row_major>();
+        auto iter = a.template rbegin<layout_type::row_major>();
+        auto iter2 = a.template rbegin<layout_type::row_major>();
         for (size_type i = 0; i < nb_inc; ++i)
         {
             ++iter;
@@ -293,8 +293,8 @@ namespace xt
         xarray_adaptor<typename R::vector_type, layout_type::dynamic> a(data, result.shape(), result.strides());
 
         size_type size = a.size();
-        auto iter = a.xrbegin();
-        auto last = a.xrend();
+        auto iter = a.rbegin();
+        auto last = a.rend();
         for (size_type i = 0; i < size; ++i)
         {
             ++iter;
@@ -382,7 +382,20 @@ namespace xt
     TEST(xiterator, pointer)
     {
         xarray<double> m {{3, 4}, {6, 5}};
-        auto it = m.xbegin();
+        constexpr layout_type l = xarray<double>::static_layout == layout_type::column_major ?
+            layout_type::row_major : layout_type::column_major;
+        auto it = m.begin<l>();
         EXPECT_EQ(*(it.operator->()), 3);
+    }
+
+    TEST(xiterator, cross_layout)
+    {
+        xarray<int, layout_type::row_major> a = { { 1, 2, 3, 4}, { 5, 6, 7, 8}, {9, 10, 11, 12} };
+        xarray<int, layout_type::column_major> b = { { 1, 2, 3, 4 }, { 5, 6, 7, 8 }, { 9, 10, 11, 12 } };
+
+        // Performs an element-wise comparison via iterators and ensures the default traversal
+        // of a container is consistent for any layout.
+        bool res = (a == b);
+        EXPECT_TRUE(res);
     }
 }

--- a/test/test_xlayout.cpp
+++ b/test/test_xlayout.cpp
@@ -82,7 +82,7 @@ namespace xt
         EXPECT_TRUE(e(0, 1));
         EXPECT_TRUE(e(1, 1));
 
-        for (auto it = e.xbegin(); it != e.xend(); it++)
+        for (auto it = e.begin(); it != e.end(); it++)
         {
             EXPECT_TRUE(*it);
         }
@@ -149,8 +149,8 @@ namespace xt
         xarray<double, layout_type::column_major> cm = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
         xarray<double, layout_type::row_major> rm = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
         auto e = equal(cm, rm);
-        auto iter_end = e.xend();
-        for (auto iter = e.xbegin(); iter != e.xend(); ++iter)
+        auto iter_end = e.end();
+        for (auto iter = e.begin(); iter != e.end(); ++iter)
         {
             EXPECT_TRUE(*iter);
         }

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -346,7 +346,7 @@ namespace xt
 
         shape_type s = {3, 3, 3};
         bool_container d(s);
-        std::fill(d.xbegin(), d.xend(), true);
+        std::fill(d.begin(), d.end(), true);
 
         auto d_nz = nonzero(d);
         EXPECT_EQ(3 * 3 * 3, d_nz.size());

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -40,10 +40,10 @@ namespace xt
     TEST(xscalar, iterator)
     {
         xscalar<int> x(2);
-        auto xiter = x.xbegin();
+        auto xiter = x.begin();
         *xiter = 4;
         EXPECT_EQ(4, x());
-        auto xiter_end = x.xend();
+        auto xiter_end = x.end();
         ++xiter;
         EXPECT_EQ(xiter, xiter_end);
         auto iter = x.begin();

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -192,8 +192,11 @@ namespace xt
 
     TEST(xtensor, iterator)
     {
-        xtensor_dynamic a;
-        test_iterator<xtensor_dynamic, container_type>(a);
+        using xtensor_rm = xtensor<int, 3, layout_type::row_major>;
+        using xtensor_cm = xtensor<int, 3, layout_type::column_major>;
+        xtensor_rm arm;
+        xtensor_cm acm;
+        test_iterator<xtensor_rm, xtensor_cm, container_type>(arm, acm);
     }
 
     TEST(xtensor, zerod)

--- a/test/test_xtensor_adaptor.cpp
+++ b/test/test_xtensor_adaptor.cpp
@@ -128,8 +128,11 @@ namespace xt
     TEST(xtensor_adaptor, iterator)
     {
         vec_type v;
-        adaptor_type a(v);
-        test_iterator<adaptor_type, container_type>(a);
+        using adaptor_rm = xtensor_adaptor<vec_type, 3, layout_type::row_major>;
+        using adaptor_cm = xtensor_adaptor<vec_type, 3, layout_type::column_major>;
+        adaptor_rm arm(v);
+        adaptor_cm acm(v);
+        test_iterator<adaptor_rm, adaptor_cm, container_type>(arm, acm);
     }
 
     TEST(xtensor_adaptor, xiterator)

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -45,7 +45,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
@@ -105,7 +105,7 @@ namespace xt
             211, 212
         };
         xarray<double> a(shape);
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, 1);
         EXPECT_EQ(2, view1.dimension());
@@ -172,11 +172,11 @@ namespace xt
         xarray<double, layout_type::row_major> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
                                     13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, range(0, 2), 1, range(1, 4));
-        auto iter = view1.template xbegin<layout_type::row_major>();
-        auto iter_end = view1.template xend<layout_type::row_major>();
+        auto iter = view1.template begin<layout_type::row_major>();
+        auto iter_end = view1.template end<layout_type::row_major>();
 
         EXPECT_EQ(6, *iter);
         ++iter;
@@ -193,8 +193,8 @@ namespace xt
         EXPECT_EQ(iter, iter_end);
 
         auto view2 = view(view1, range(0, 2), range(1, 3));
-        auto iter2 = view2.template xbegin<layout_type::row_major>();
-        auto iter_end2 = view2.template xend<layout_type::row_major>();
+        auto iter2 = view2.template begin<layout_type::row_major>();
+        auto iter_end2 = view2.template end<layout_type::row_major>();
 
         EXPECT_EQ(7, *iter2);
         ++iter2;
@@ -213,11 +213,11 @@ namespace xt
         xarray<double, layout_type::row_major> a(shape);
         std::vector<double> data = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
             13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, range(0, 2), 1, range(1, 4));
-        auto iter = view1.template xrbegin<layout_type::row_major>();
-        auto iter_end = view1.template xrend<layout_type::row_major>();
+        auto iter = view1.template rbegin<layout_type::row_major>();
+        auto iter_end = view1.template rend<layout_type::row_major>();
 
         EXPECT_EQ(20, *iter);
         ++iter;
@@ -234,8 +234,8 @@ namespace xt
         EXPECT_EQ(iter, iter_end);
 
         auto view2 = view(view1, range(0, 2), range(1, 3));
-        auto iter2 = view2.template xrbegin<layout_type::row_major>();
-        auto iter_end2 = view2.template xrend<layout_type::row_major>();
+        auto iter2 = view2.template rbegin<layout_type::row_major>();
+        auto iter_end2 = view2.template rend<layout_type::row_major>();
 
         EXPECT_EQ(20, *iter2);
         ++iter2;
@@ -253,16 +253,16 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<int> a(shape);
         std::vector<int> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         view_shape_type shape2 = {4};
         xarray<int> b(shape2);
         std::vector<int> data2 = {1, 2, 3, 4};
-        std::copy(data2.cbegin(), data2.cend(), b.template xbegin<layout_type::row_major>());
+        std::copy(data2.cbegin(), data2.cend(), b.template begin<layout_type::row_major>());
 
         auto v = view(a + b, 1, range(1, 4));
-        auto iter = v.xbegin();
-        auto iter_end = v.xend();
+        auto iter = v.begin();
+        auto iter_end = v.end();
 
         EXPECT_EQ(8, *iter);
         ++iter;
@@ -277,15 +277,15 @@ namespace xt
     {
         xtensor<int, 2> a({3, 4});
         std::vector<int> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, 1, range(1, 4));
         EXPECT_EQ(a(1, 1), view1(0));
         EXPECT_EQ(a(1, 2), view1(1));
         EXPECT_EQ(1, view1.dimension());
 
-        auto iter = view1.template xbegin<layout_type::row_major>();
-        auto iter_end = view1.template xend<layout_type::row_major>();
+        auto iter = view1.template begin<layout_type::row_major>();
+        auto iter_end = view1.template end<layout_type::row_major>();
 
         EXPECT_EQ(6, *iter);
         ++iter;
@@ -303,10 +303,10 @@ namespace xt
     TEST(xview, trivial_iterating)
     {
         xtensor<double, 1> arr1{{2}};
-        std::fill(arr1.xbegin(), arr1.xend(), 6);
+        std::fill(arr1.begin(), arr1.end(), 6);
         auto view = xt::view(arr1, 0);
-        auto iter = view.xbegin();
-        auto iter_end = view.xend();
+        auto iter = view.begin();
+        auto iter_end = view.end();
         ++iter;
         EXPECT_EQ(iter, iter_end);
     }
@@ -339,7 +339,7 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, all(), newaxis(), all());
         EXPECT_EQ(a(1, 1), view1(1, 0, 1));
@@ -392,11 +392,11 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         auto view1 = view(a, all(), all(), newaxis());
-        auto iter1 = view1.template xbegin<layout_type::row_major>();
-        auto iter1_end = view1.template xend<layout_type::row_major>();
+        auto iter1 = view1.template begin<layout_type::row_major>();
+        auto iter1_end = view1.template end<layout_type::row_major>();
 
         EXPECT_EQ(a(0, 0), *iter1);
         ++iter1;
@@ -425,8 +425,8 @@ namespace xt
         EXPECT_EQ(iter1_end, iter1);
 
         auto view2 = view(a, all(), newaxis(), all());
-        auto iter2 = view2.template xbegin<layout_type::row_major>();
-        auto iter2_end = view2.template xend<layout_type::row_major>();
+        auto iter2 = view2.template begin<layout_type::row_major>();
+        auto iter2_end = view2.template end<layout_type::row_major>();
 
         EXPECT_EQ(a(0, 0), *iter2);
         ++iter2;
@@ -460,17 +460,17 @@ namespace xt
         view_shape_type shape = {3, 4};
         xarray<double> a(shape);
         std::vector<double> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-        std::copy(data.cbegin(), data.cend(), a.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cend(), a.template begin<layout_type::row_major>());
 
         xarray<double> b(view_shape_type(1, 4));
-        std::copy(data.cbegin(), data.cbegin() + 4, b.template xbegin<layout_type::row_major>());
+        std::copy(data.cbegin(), data.cbegin() + 4, b.template begin<layout_type::row_major>());
 
         auto v = view(b, newaxis(), all());
         xarray<double> res = a + v;
 
         std::vector<double> data2{2, 4, 6, 8, 6, 8, 10, 12, 10, 12, 14, 16};
         xarray<double> expected(shape);
-        std::copy(data2.cbegin(), data2.cend(), expected.template xbegin<layout_type::row_major>());
+        std::copy(data2.cbegin(), data2.cend(), expected.template begin<layout_type::row_major>());
 
         EXPECT_EQ(expected, res);
     }


### PR DESCRIPTION
Major changes are:

- old `begin` / `end` methods replaced by `storage_begin` / `storage_end` methods. These methods are mainly for internal use and should not be called by client code (except for one corner case).
- `xbegin` and `xend` methods (and their reverse counterpart) replaced by `begin` / `end` methods.
- `begin` / `end` methods return the most optimal iterator depending on the layout of the iteration and the layout of the container in case of container expression.
- `begin` / `end` can take an additional shape parameter, in that case they will perform a broadcasting iteration, just as old methods `xbegin` / `xend` did.

These changes imply that the following code
```cpp
xarray<double> a = {.... };
std::for_each(a.begin(), a.end(), .....);
```
will give the same performance as an iteration on the underlying data container.

Besides, the following code now works as expected
```cpp
xarray<double, layout_type::row_major> a = {{1, 2, 3}, {4, 5, 6}};
xarray<double, layout_type::column_major> b = {{1, 2, 3}, {4, 5, 6}};
bool res = std::equal(a.begin(), a.end(), b.begin()); // res is true
```

Also #289 is fixed by this PR.