### PR TITLE
Enable casting to xoptional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make install
 
 ## Usage
 
-### Basic Usage
+### Basic usage
 
 **Initialize a 2-D array and compute the sum of one of its rows and a 1-D array.**
 
@@ -95,11 +95,11 @@ Outputs:
  {7, 8, 9}}
 ```
 
-## The Numpy to xtensor cheat sheet
+## The numpy to xtensor cheat sheet
 
 If you are familiar with numpy APIs, and you are interested in xtensor, you can check out the [numpy to xtensor cheat sheet](https://xtensor.readthedocs.io/en/latest/numpy.html) provided in the documentation.
 
-## Lazy Broadcasting with `xtensor`
+## Lazy broadcasting with `xtensor`
 
 We can operate on arrays of different shapes of dimensions in an elementwise fashion. Broadcasting rules of xtensor are similar to those of [numpy](http://www.numpy.org) and [libdynd](http://libdynd.org).
 
@@ -134,7 +134,7 @@ If matched up dimensions of two input arrays are different, and one of them has 
 (4, 2, 3) # Result
 ```
 
-### Universal functions, Laziness and Vectorization
+### Universal functions, laziness and vectorization
 
 With `xtensor`, if `x`, `y` and `z` are arrays of *broadcastable shapes*, the return type of an expression such as `x + y * sin(z)` is **not an array**. It is an `xexpression` object offering the same interface as an N-dimensional array, which does not hold the result. **Values are only computed upon access or when the expression is assigned to an xarray object**. This allows to operate symbolically on very large arrays and only compute the result for the indices of interest.
 
@@ -142,14 +142,14 @@ We provide utilities to **vectorize any scalar function** (taking multiple scala
 
 In `xtensor`, arithmetic operations (`+`, `-`, `*`, `/`) and all special functions are *xfunction*s.
 
-### Iterating over `xexpression`s and Broadcasting Iterators
+### Iterating over `xexpression`s and broadcasting Iterators
 
 All `xexpression`s offer two sets of functions to retrieve iterator pairs (and their `const` counterpart).
 
  - `begin()` and `end()` provide instances of `xiterator`s which can be used to iterate over all the elements of the expression. The order in which elements are listed is `row-major` in that the index of last dimension is incremented first.
  - `xbegin(shape)` and `xend(shape)` are similar but take a *broadcasting shape* as an argument. Elements are iterated upon in a row-major way, but certain dimensions are repeated to match the provided shape as per the rules described above. For an expression `e`, `e.xbegin(e.shape())` and `e.begin()` are equivalent.
 
-### Runtime vs Compile-time dimensionality
+### Runtime vs compile-time dimensionality
 
 Two container classes implementing multi-dimensional arrays are provided: `xarray` and `xtensor`.
 
@@ -182,7 +182,7 @@ Therefore, when building an application with xtensor, we recommend using statica
 The [xtensor-python](https://github.com/QuantStack/xtensor-python) project provides the implementation of two `xtensor` containers, `pyarray` and `pytensor` which
 effectively wrap numpy arrays, allowing inplace modification, including reshapes.
 
-## Building and Running the Tests
+## Building and running the tests
 
 Building the tests requires the [GTest](https://github.com/google/googletest) testing framework and [cmake](https://cmake.org).
 
@@ -221,7 +221,7 @@ cmake -DBUILD_TESTS=ON .
 make xtest
 ```
 
-## Building the HTML Documentation
+## Building the HTML documentation
 
 xtensor's documentation is built with three tools
 

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "xtensor/xutils.hpp"
+#include "xtensor/xmath.hpp"
 
 namespace xt
 {
@@ -107,6 +108,8 @@ namespace xt
 
         xoptional(const value_type&);
         xoptional(value_type&&);
+        template <class T>
+        xoptional(const T&);
 
         xoptional(value_type&&, flag_type&&);
         xoptional(std::add_lvalue_reference_t<CT>, std::add_lvalue_reference_t<CB>);
@@ -124,6 +127,9 @@ namespace xt
 
         xoptional& operator=(const value_type&);
         xoptional& operator=(value_type&&);
+
+        template <class T>
+        xoptional& operator=(const T&);
 
         // Operators
         template <class CTO, class CBO>
@@ -243,6 +249,13 @@ namespace xt
     }
 
     template <class CT, class CB>
+    template <class T>
+    xoptional<CT, CB>::xoptional(const T& value)
+        : m_value(value), m_flag(true)
+    {
+    }
+
+    template <class CT, class CB>
     xoptional<CT, CB>::xoptional(value_type&& value, flag_type&& flag)
         : m_value(std::move(value)), m_flag(std::move(flag))
     {
@@ -298,6 +311,15 @@ namespace xt
     {
         m_flag = true;
         m_value = std::move(value);
+        return *this;
+    }
+
+    template <class CT, class CB>
+    template <class T>
+    auto xoptional<CT, CB>::operator=(const T& value) -> xoptional&
+    {
+        m_flag = true;
+        m_value = value;
         return *this;
     }
 

--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -46,6 +46,16 @@ namespace xt
         ASSERT_EQ(value2, 2.0);
     }
 
+    TEST(xoptional, string)
+    {
+        xoptional<std::string, bool> opt1;
+        opt1 = "foo";
+        ASSERT_TRUE(opt1.has_value());
+
+        xoptional<std::string, bool> opt2 = "bar";
+        ASSERT_TRUE(opt2.has_value());
+    }
+
     TEST(xoptional, vector)
     {
         xoptional_vector<double> v(3, 2.0);


### PR DESCRIPTION
This enables conversions such as

`const char* -> xoptional<std::string>`