### PR TITLE
WIP Handle trusty transition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 matrix:
   include:
     - os: linux
@@ -41,6 +42,7 @@ matrix:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
+            - gcc-4.9
       env: COMPILER=clang CLANG=3.6
     - os: linux
       addons:
@@ -59,6 +61,7 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
+            - gcc-4.9
       env: COMPILER=clang CLANG=3.8
     - os: linux
       addons:
@@ -68,6 +71,7 @@ matrix:
             - llvm-toolchain-precise-3.9
           packages:
             - clang-3.9
+            - gcc-4.9
       env: COMPILER=clang CLANG=3.9
     - os: osx
       osx_image: xcode8


### PR DESCRIPTION
On ubuntu precise (which was the default travis environment until recently), the default GCC version is 4.6, so when you install the clang package, you would also get a more recent GCC.

On ubuntu trusty, which is slowly being transitioned to, the default GCC is 4.8, and clang does not need to instal a more recent version. Hence the failures on clang when using a trusty VM.

This PR forces the use of trusty and requires a GCC version greater than 4.9 when using clang.