### PR TITLE
Prerequisites for tiny_array/shape PR

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -296,7 +296,7 @@ namespace xt
         public:
 
             using size_type = std::size_t;
-            using value_type = std::common_type_t<typename std::decay_t<CT>::value_type...>;
+            using value_type = promote_t<typename std::decay_t<CT>::value_type...>;
 
             inline concatenate_impl(std::tuple<CT...>&& t, size_type axis)
                 : m_t(t), m_axis(axis)
@@ -357,7 +357,7 @@ namespace xt
         public:
 
             using size_type = std::size_t;
-            using value_type = std::common_type_t<typename std::decay_t<CT>::value_type...>;
+            using value_type = promote_t<typename std::decay_t<CT>::value_type...>;
 
             inline stack_impl(std::tuple<CT...>&& t, size_type axis)
                 : m_t(t), m_axis(axis)
@@ -733,19 +733,19 @@ namespace xt
 
     /**
      * @brief Returns the elements on the diagonal of arr
-     * If arr has more than two dimensions, then the axes specified by 
-     * axis_1 and axis_2 are used to determine the 2-D sub-array whose 
-     * diagonal is returned. The shape of the resulting array can be 
-     * determined by removing axis1 and axis2 and appending an index 
+     * If arr has more than two dimensions, then the axes specified by
+     * axis_1 and axis_2 are used to determine the 2-D sub-array whose
+     * diagonal is returned. The shape of the resulting array can be
+     * determined by removing axis1 and axis2 and appending an index
      * to the right equal to the size of the resulting diagonals.
      *
      * @param arr the input array
      * @param offset offset of the diagonal from the main diagonal. Can
      *               be positive or negative.
-     * @param axis_1 Axis to be used as the first axis of the 2-D sub-arrays 
-     *               from which the diagonals should be taken. 
-     * @param axis_2 Axis to be used as the second axis of the 2-D sub-arrays 
-     *               from which the diagonals should be taken. 
+     * @param axis_1 Axis to be used as the first axis of the 2-D sub-arrays
+     *               from which the diagonals should be taken.
+     * @param axis_2 Axis to be used as the second axis of the 2-D sub-arrays
+     *               from which the diagonals should be taken.
      * @returns xexpression with values of the diagonal
      *
      * \code{.cpp}
@@ -817,7 +817,7 @@ namespace xt
      * @brief Reverse the order of elements in an xexpression along the given axis.
      * Note: A NumPy/Matlab style `flipud(arr)` is equivalent to `xt::flip(arr, 0)`,
      * `fliplr(arr)` to `xt::flip(arr, 1)`.
-     * 
+     *
      * @param arr the input xexpression
      * @param axis the axis along which elements should be reversed
      *

--- a/include/xtensor/xcomplex.hpp
+++ b/include/xtensor/xcomplex.hpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "xtensor/xmathutil.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xexpression.hpp"
 #include "xtensor/xoffsetview.hpp"

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -135,17 +135,17 @@ namespace xt
     template <class T>
     struct norm_of_scalar_impl<T, false>
     {
-        static const bool value = false;
-        using norm_type         = void *;
-        using squared_norm_type = void *;
+        static constexpr bool value = false;
+        using norm_type             = void *;
+        using squared_norm_type     = void *;
     };
 
     template <class T>
     struct norm_of_scalar_impl<T, true>
     {
-        static const bool value = true;
-        using norm_type         = T;
-        using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
+        static constexpr bool value = true;
+        using norm_type             = T;
+        using squared_norm_type     = decltype((*(T*)0) * (*(T*)0));
     };
 
     template <class T, bool integral = std::is_integral<T>::value,
@@ -224,9 +224,9 @@ namespace xt
 
     } // namespace concepts_detail
 
-        /** @brief Traits class for the result type of the <tt>norm()</tt> function.
+        /** @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
 
-            Member 'type' defines the result of <tt>norm(t)</tt>, where <tt>t</tt>
+            Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
             is of type @tparam T. It implements the following rules designed to
             minimize the potential for overflow:
                 - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
@@ -255,9 +255,9 @@ namespace xt
     template <class T>
     using norm_t = typename norm_traits<T>::type;
 
-        /** @brief Traits class for the result type of the <tt>squared_norm()</tt> function.
+        /** @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
 
-            Member 'type' defines the result of <tt>squared_norm(t)</tt>, where <tt>t</tt>
+            Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
             is of type @tparam T. It implements the following rules designed to
             minimize the potential for overflow:
                 - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
@@ -271,7 +271,7 @@ namespace xt
            <tt>concepts_detail::norm_traits_base</tt> template.
         */
     template<class T>
-    struct squared_norm_traits
+    struct norm_sq_traits
     : public concepts_detail::norm_traits_base<T>
     {
         using base_type = concepts_detail::norm_traits_base<T>;
@@ -282,10 +282,10 @@ namespace xt
                         typename base_type::norm_of_scalar::squared_norm_type>::type;
     };
 
-        /** Abbreviation of 'typename squared_norm_traits<T>::type'.
+        /** Abbreviation of 'typename norm_sq_traits<T>::type'.
         */
     template <class T>
-    using squared_norm_t = typename squared_norm_traits<T>::type;
+    using norm_sq_t = typename norm_sq_traits<T>::type;
 
 } // namespace xt
 

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -20,272 +20,272 @@
 namespace xt
 {
 
-/**********************************************************/
-/*                                                        */
-/*        XTENSOR_REQUIRE concept checking macro          */
-/*                                                        */
-/**********************************************************/
+    /**********************************************************/
+    /*                                                        */
+    /*        XTENSOR_REQUIRE concept checking macro          */
+    /*                                                        */
+    /**********************************************************/
 
-struct require_ok {};
+    struct require_ok {};
 
-template <bool CONCEPTS>
-using concept_check = typename std::enable_if<CONCEPTS, require_ok>::type;
+    template <bool CONCEPTS>
+    using concept_check = typename std::enable_if<CONCEPTS, require_ok>::type;
 
-    /** @brief Concept checking macro (more redable than sfinae).
+        /** @brief Concept checking macro (more redable than sfinae).
 
-        The macro is used as the last argument in a template declaration.
-        It must be followed by a static boolean expression in angle brackets.
-        The template will only be included in overload resolution when
-        this expression evaluates to 'true'.
+            The macro is used as the last argument in a template declaration.
+            It must be followed by a static boolean expression in angle brackets.
+            The template will only be included in overload resolution when
+            this expression evaluates to 'true'.
 
-        Example:
-        \code
-        template <class T,
-                  XTENSOR_REQUIRE<std::is_arithmetic<T>::value>>
-        T foo(T t)
-        {...}
-        \endcode
-    */
-#define XTENSOR_REQUIRE typename Require = concept_check
+            Example:
+            \code
+            template <class T,
+                      XTENSOR_REQUIRE<std::is_arithmetic<T>::value>>
+            T foo(T t)
+            {...}
+            \endcode
+        */
+    #define XTENSOR_REQUIRE typename Require = concept_check
 
-/**********************************************************/
-/*                                                        */
-/*                   iterator_concept                     */
-/*                                                        */
-/**********************************************************/
+    /**********************************************************/
+    /*                                                        */
+    /*                   iterator_concept                     */
+    /*                                                        */
+    /**********************************************************/
 
-    /** @brief Traits class to check if a type is an iterator.
+        /** @brief Traits class to check if a type is an iterator.
 
-        This is useful in concept checking to make sure that a given template
-        is only instantiated when the argument is an iterator.
-        Currently, we apply the simple rule that class @tparam T
-        is either a pointer or a C-array or has an embedded typedef
-        'iterator_category'. More sophisticated checks can easily
-        be added when needed.
-    */
-template <class T>
-struct iterator_concept
-{
-    using V = std::decay_t<T>;
+            This is useful in concept checking to make sure that a given template
+            is only instantiated when the argument is an iterator.
+            Currently, we apply the simple rule that class @tparam T
+            is either a pointer or a C-array or has an embedded typedef
+            'iterator_category'. More sophisticated checks can easily
+            be added when needed.
+        */
+    template <class T>
+    struct iterator_concept
+    {
+        using V = std::decay_t<T>;
 
-    static char test(...);
+        static char test(...);
 
-    template <class U>
-    static int test(U*, typename U::iterator_category * = 0);
+        template <class U>
+        static int test(U*, typename U::iterator_category * = 0);
 
-    static const bool value =
-        std::is_array<T>::value ||
-        std::is_pointer<T>::value ||
-        std::is_same<decltype(test((V*)0)), int>::value;
-};
+        static const bool value =
+            std::is_array<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test((V*)0)), int>::value;
+    };
 
-/**********************************************************/
-/*                                                        */
-/*                    promote types                       */
-/*                                                        */
-/**********************************************************/
+    /**********************************************************/
+    /*                                                        */
+    /*                    promote types                       */
+    /*                                                        */
+    /**********************************************************/
 
-namespace concepts_detail
-{
-    using std::sqrt;
+    namespace concepts_detail
+    {
+        using std::sqrt;
+
+        template <class T>
+        using real_promote_t = decltype(sqrt(*(std::decay_t<T>*)0));
+    }
+
+        /** @brief Result type of mixed arithmetic expressions.
+
+            For example, it tells the user that <tt>unsigned char + unsigned char => int</tt>.
+        */
+    template <class T1, class T2 = T1>
+    using promote_t = decltype(*(std::decay_t<T1>*)0 + *(std::decay_t<T2>*)0);
+
+        /** @brief Result type of algebraic expressions.
+
+            For example, it tells the user that <tt>sqrt(int) => double</tt>.
+        */
+    template <class T>
+    using real_promote_t = concepts_detail::real_promote_t<T>;
+
+        /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+
+            This is useful for scientific computing, where a boolean mask array is
+            usually implemented as an array of bytes.
+        */
+    template <class T>
+    using bool_promote_t = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+
+    /**********************************************************/
+    /*                                                        */
+    /*       type inference for norm and squared norm         */
+    /*                                                        */
+    /**********************************************************/
+
+    template<class T>
+    struct norm_traits;
+
+    template<class T>
+    struct squared_norm_traits;
+
+    namespace concepts_detail {
+
+    template <class T, bool scalar = std::is_arithmetic<T>::value>
+    struct norm_of_scalar_impl;
 
     template <class T>
-    using real_promote_t = decltype(sqrt(*(std::decay_t<T>*)0));
-}
+    struct norm_of_scalar_impl<T, false>
+    {
+        static const bool value = false;
+        using norm_type         = void *;
+        using squared_norm_type = void *;
+    };
 
-    /** @brief Result type of mixed arithmetic expressions.
+    template <class T>
+    struct norm_of_scalar_impl<T, true>
+    {
+        static const bool value = true;
+        using norm_type         = T;
+        using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
+    };
 
-        For example, it tells the user that <tt>unsigned char + unsigned char => int</tt>.
-    */
-template <class T1, class T2 = T1>
-using promote_t = decltype(*(std::decay_t<T1>*)0 + *(std::decay_t<T2>*)0);
+    template <class T, bool integral = std::is_integral<T>::value,
+                       bool floating = std::is_floating_point<T>::value>
+    struct norm_of_array_elements_impl;
 
-    /** @brief Result type of algebraic expressions.
+    template <>
+    struct norm_of_array_elements_impl<void *, false, false>
+    {
+        using norm_type         = void *;
+        using squared_norm_type = void *;
+    };
 
-        For example, it tells the user that <tt>sqrt(int) => double</tt>.
-    */
-template <class T>
-using real_promote_t = concepts_detail::real_promote_t<T>;
+    template <class T>
+    struct norm_of_array_elements_impl<T, false, false>
+    {
+        using norm_type         = typename norm_traits<T>::type;
+        using squared_norm_type = typename squared_norm_traits<T>::type;
+    };
 
-    /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+    template <class T>
+    struct norm_of_array_elements_impl<T, true, false>
+    {
+        static_assert(!std::is_same<T, char>::value,
+           "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
 
-        This is useful for scientific computing, where a boolean mask array is
-        usually implemented as an array of bytes.
-    */
-template <class T>
-using bool_promote_t = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+        using norm_type         = double;
+        using squared_norm_type = uint64_t;
+    };
 
-/**********************************************************/
-/*                                                        */
-/*       type inference for norm and squared norm         */
-/*                                                        */
-/**********************************************************/
+    template <class T>
+    struct norm_of_array_elements_impl<T, false, true>
+    {
+        using norm_type         = double;
+        using squared_norm_type = double;
+    };
 
-template<class T>
-struct norm_traits;
+    template <>
+    struct norm_of_array_elements_impl<long double, false, true>
+    {
+        using norm_type         = long double;
+        using squared_norm_type = long double;
+    };
 
-template<class T>
-struct squared_norm_traits;
+    template <class ARRAY>
+    struct norm_of_vector_impl
+    {
+        static void * test(...);
 
-namespace concepts_detail {
+        template <class U>
+        static typename U::value_type test(U*, typename U::value_type * = 0);
 
-template <class T, bool scalar = std::is_arithmetic<T>::value>
-struct norm_of_scalar_impl;
+        using T = decltype(test((ARRAY*)0));
 
-template <class T>
-struct norm_of_scalar_impl<T, false>
-{
-    static const bool value = false;
-    using norm_type         = void *;
-    using squared_norm_type = void *;
-};
+        static const bool value = !std::is_same<T, void*>::value;
 
-template <class T>
-struct norm_of_scalar_impl<T, true>
-{
-    static const bool value = true;
-    using norm_type         = T;
-    using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
-};
+        using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
+        using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
+    };
 
-template <class T, bool integral = std::is_integral<T>::value,
-                   bool floating = std::is_floating_point<T>::value>
-struct norm_of_array_elements_impl;
+    template<class U>
+    struct norm_traits_base
+    {
+        using T = std::decay_t<U>;
 
-template <>
-struct norm_of_array_elements_impl<void *, false, false>
-{
-    using norm_type         = void *;
-    using squared_norm_type = void *;
-};
+        static_assert(!std::is_same<T, char>::value,
+           "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
 
-template <class T>
-struct norm_of_array_elements_impl<T, false, false>
-{
-    using norm_type         = typename norm_traits<T>::type;
-    using squared_norm_type = typename squared_norm_traits<T>::type;
-};
+        using norm_of_scalar = norm_of_scalar_impl<T>;
+        using norm_of_vector = norm_of_vector_impl<T>;
 
-template <class T>
-struct norm_of_array_elements_impl<T, true, false>
-{
-    static_assert(!std::is_same<T, char>::value,
-       "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+        static const bool value = norm_of_scalar::value || norm_of_vector::value;
 
-    using norm_type         = double;
-    using squared_norm_type = uint64_t;
-};
+        static_assert(value, "norm_traits<T> are undefined for type U.");
+    };
 
-template <class T>
-struct norm_of_array_elements_impl<T, false, true>
-{
-    using norm_type         = double;
-    using squared_norm_type = double;
-};
+    } // namespace concepts_detail
 
-template <>
-struct norm_of_array_elements_impl<long double, false, true>
-{
-    using norm_type         = long double;
-    using squared_norm_type = long double;
-};
+        /** @brief Traits class for the result type of the <tt>norm()</tt> function.
 
-template <class ARRAY>
-struct norm_of_vector_impl
-{
-    static void * test(...);
+            Member 'type' defines the result of <tt>norm(t)</tt>, where <tt>t</tt>
+            is of type @tparam T. It implements the following rules designed to
+            minimize the potential for overflow:
+                - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
+                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+                - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
+                - @tparam T is a container of some other type: 'type' is the element's norm type,
 
-    template <class U>
-    static typename U::value_type test(U*, typename U::value_type * = 0);
+           Containers are recognized by having an embedded typedef 'value_type'.
+           To change the behavior for a case not covered here, specialize the
+           <tt>concepts_detail::norm_traits_base</tt> template.
+        */
+    template<class T>
+    struct norm_traits
+    : public concepts_detail::norm_traits_base<T>
+    {
+        using base_type = concepts_detail::norm_traits_base<T>;
 
-    using T = decltype(test((ARRAY*)0));
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                        typename base_type::norm_of_vector::norm_type,
+                        typename base_type::norm_of_scalar::norm_type>::type;
+    };
 
-    static const bool value = !std::is_same<T, void*>::value;
+        /** Abbreviation of 'typename norm_traits<T>::type'.
+        */
+    template <class T>
+    using norm_t = typename norm_traits<T>::type;
 
-    using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
-    using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
-};
+        /** @brief Traits class for the result type of the <tt>squared_norm()</tt> function.
 
-template<class U>
-struct norm_traits_base
-{
-    using T = std::decay_t<U>;
+            Member 'type' defines the result of <tt>squared_norm(t)</tt>, where <tt>t</tt>
+            is of type @tparam T. It implements the following rules designed to
+            minimize the potential for overflow:
+                - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
+                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+                - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
+                - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
+                - @tparam T is a container of some other type: 'type' is the element's squared norm type,
 
-    static_assert(!std::is_same<T, char>::value,
-       "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+           Containers are recognized by having an embedded typedef 'value_type'.
+           To change the behavior for a case not covered here, specialize the
+           <tt>concepts_detail::norm_traits_base</tt> template.
+        */
+    template<class T>
+    struct squared_norm_traits
+    : public concepts_detail::norm_traits_base<T>
+    {
+        using base_type = concepts_detail::norm_traits_base<T>;
 
-    using norm_of_scalar = norm_of_scalar_impl<T>;
-    using norm_of_vector = norm_of_vector_impl<T>;
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                        typename base_type::norm_of_vector::squared_norm_type,
+                        typename base_type::norm_of_scalar::squared_norm_type>::type;
+    };
 
-    static const bool value = norm_of_scalar::value || norm_of_vector::value;
-
-    static_assert(value, "norm_traits<T> are undefined for type U.");
-};
-
-} // namespace concepts_detail
-
-    /** @brief Traits class for the result type of the <tt>norm()</tt> function.
-
-        Member 'type' defines the result of <tt>norm(t)</tt>, where <tt>t</tt>
-        is of type @tparam T. It implements the following rules designed to
-        minimize the potential for overflow:
-            - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
-            - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-            - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
-            - @tparam T is a container of some other type: 'type' is the element's norm type,
-
-       Containers are recognized by having an embedded typedef 'value_type'.
-       To change the behavior for a case not covered here, specialize the
-       <tt>concepts_detail::norm_traits_base</tt> template.
-    */
-template<class T>
-struct norm_traits
-: public concepts_detail::norm_traits_base<T>
-{
-    using base_type = concepts_detail::norm_traits_base<T>;
-
-    using type =
-        typename std::conditional<base_type::norm_of_vector::value,
-                    typename base_type::norm_of_vector::norm_type,
-                    typename base_type::norm_of_scalar::norm_type>::type;
-};
-
-    /** Abbreviation of 'typename norm_traits<T>::type'.
-    */
-template <class T>
-using norm_t = typename norm_traits<T>::type;
-
-    /** @brief Traits class for the result type of the <tt>squared_norm()</tt> function.
-
-        Member 'type' defines the result of <tt>squared_norm(t)</tt>, where <tt>t</tt>
-        is of type @tparam T. It implements the following rules designed to
-        minimize the potential for overflow:
-            - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
-            - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-            - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
-            - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
-            - @tparam T is a container of some other type: 'type' is the element's squared norm type,
-
-       Containers are recognized by having an embedded typedef 'value_type'.
-       To change the behavior for a case not covered here, specialize the
-       <tt>concepts_detail::norm_traits_base</tt> template.
-    */
-template<class T>
-struct squared_norm_traits
-: public concepts_detail::norm_traits_base<T>
-{
-    using base_type = concepts_detail::norm_traits_base<T>;
-
-    using type =
-        typename std::conditional<base_type::norm_of_vector::value,
-                    typename base_type::norm_of_vector::squared_norm_type,
-                    typename base_type::norm_of_scalar::squared_norm_type>::type;
-};
-
-    /** Abbreviation of 'typename squared_norm_traits<T>::type'.
-    */
-template <class T>
-using squared_norm_t = typename squared_norm_traits<T>::type;
+        /** Abbreviation of 'typename squared_norm_traits<T>::type'.
+        */
+    template <class T>
+    using squared_norm_t = typename squared_norm_traits<T>::type;
 
 } // namespace xt
 

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -1,0 +1,292 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XCONCEPTS_HPP
+#define XCONCEPTS_HPP
+
+#include <type_traits>
+
+/**********************************************************/
+/*                                                        */
+/*   concept checking and type inference functionality    */
+/*                                                        */
+/**********************************************************/
+
+namespace xt
+{
+
+/**********************************************************/
+/*                                                        */
+/*        XTENSOR_REQUIRE concept checking macro          */
+/*                                                        */
+/**********************************************************/
+
+struct require_ok {};
+
+template <bool CONCEPTS>
+using concept_check = typename std::enable_if<CONCEPTS, require_ok>::type;
+
+    /** @brief Concept checking macro (more redable than sfinae).
+
+        The macro is used as the last argument in a template declaration.
+        It must be followed by a static boolean expression in angle brackets.
+        The template will only be included in overload resolution when
+        this expression evaluates to 'true'.
+
+        Example:
+        \code
+        template <class T,
+                  XTENSOR_REQUIRE<std::is_arithmetic<T>::value>>
+        T foo(T t)
+        {...}
+        \endcode
+    */
+#define XTENSOR_REQUIRE typename Require = concept_check
+
+/**********************************************************/
+/*                                                        */
+/*                   iterator_concept                     */
+/*                                                        */
+/**********************************************************/
+
+    /** @brief Traits class to check if a type is an iterator.
+
+        This is useful in concept checking to make sure that a given template
+        is only instantiated when the argument is an iterator.
+        Currently, we apply the simple rule that class @tparam T
+        is either a pointer or a C-array or has an embedded typedef
+        'iterator_category'. More sophisticated checks can easily
+        be added when needed.
+    */
+template <class T>
+struct iterator_concept
+{
+    using V = std::decay_t<T>;
+
+    static char test(...);
+
+    template <class U>
+    static int test(U*, typename U::iterator_category * = 0);
+
+    static const bool value =
+        std::is_array<T>::value ||
+        std::is_pointer<T>::value ||
+        std::is_same<decltype(test((V*)0)), int>::value;
+};
+
+/**********************************************************/
+/*                                                        */
+/*                    promote types                       */
+/*                                                        */
+/**********************************************************/
+
+namespace concepts_detail
+{
+    using std::sqrt;
+
+    template <class T>
+    using real_promote_t = decltype(sqrt(*(std::decay_t<T>*)0));
+}
+
+    /** @brief Result type of mixed arithmetic expressions.
+
+        For example, it tells the user that <tt>unsigned char + unsigned char => int</tt>.
+    */
+template <class T1, class T2 = T1>
+using promote_t = decltype(*(std::decay_t<T1>*)0 + *(std::decay_t<T2>*)0);
+
+    /** @brief Result type of algebraic expressions.
+
+        For example, it tells the user that <tt>sqrt(int) => double</tt>.
+    */
+template <class T>
+using real_promote_t = concepts_detail::real_promote_t<T>;
+
+    /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+
+        This is useful for scientific computing, where a boolean mask array is
+        usually implemented as an array of bytes.
+    */
+template <class T>
+using bool_promote_t = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+
+/**********************************************************/
+/*                                                        */
+/*       type inference for norm and squared norm         */
+/*                                                        */
+/**********************************************************/
+
+template<class T>
+struct norm_traits;
+
+template<class T>
+struct squared_norm_traits;
+
+namespace concepts_detail {
+
+template <class T, bool scalar = std::is_arithmetic<T>::value>
+struct norm_of_scalar_impl;
+
+template <class T>
+struct norm_of_scalar_impl<T, false>
+{
+    static const bool value = false;
+    using norm_type         = void *;
+    using squared_norm_type = void *;
+};
+
+template <class T>
+struct norm_of_scalar_impl<T, true>
+{
+    static const bool value = true;
+    using norm_type         = T;
+    using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
+};
+
+template <class T, bool integral = std::is_integral<T>::value,
+                   bool floating = std::is_floating_point<T>::value>
+struct norm_of_array_elements_impl;
+
+template <>
+struct norm_of_array_elements_impl<void *, false, false>
+{
+    using norm_type         = void *;
+    using squared_norm_type = void *;
+};
+
+template <class T>
+struct norm_of_array_elements_impl<T, false, false>
+{
+    using norm_type         = typename norm_traits<T>::type;
+    using squared_norm_type = typename squared_norm_traits<T>::type;
+};
+
+template <class T>
+struct norm_of_array_elements_impl<T, true, false>
+{
+    static_assert(!std::is_same<T, char>::value,
+       "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+    using norm_type         = double;
+    using squared_norm_type = uint64_t;
+};
+
+template <class T>
+struct norm_of_array_elements_impl<T, false, true>
+{
+    using norm_type         = double;
+    using squared_norm_type = double;
+};
+
+template <>
+struct norm_of_array_elements_impl<long double, false, true>
+{
+    using norm_type         = long double;
+    using squared_norm_type = long double;
+};
+
+template <class ARRAY>
+struct norm_of_vector_impl
+{
+    static void * test(...);
+
+    template <class U>
+    static typename U::value_type test(U*, typename U::value_type * = 0);
+
+    using T = decltype(test((ARRAY*)0));
+
+    static const bool value = !std::is_same<T, void*>::value;
+
+    using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
+    using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
+};
+
+template<class U>
+struct norm_traits_base
+{
+    using T = std::decay_t<U>;
+
+    static_assert(!std::is_same<T, char>::value,
+       "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+    using norm_of_scalar = norm_of_scalar_impl<T>;
+    using norm_of_vector = norm_of_vector_impl<T>;
+
+    static const bool value = norm_of_scalar::value || norm_of_vector::value;
+
+    static_assert(value, "norm_traits<T> are undefined for type U.");
+};
+
+} // namespace concepts_detail
+
+    /** @brief Traits class for the result type of the <tt>norm()</tt> function.
+
+        Member 'type' defines the result of <tt>norm(t)</tt>, where <tt>t</tt>
+        is of type @tparam T. It implements the following rules designed to
+        minimize the potential for overflow:
+            - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
+            - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+            - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
+            - @tparam T is a container of some other type: 'type' is the element's norm type,
+
+       Containers are recognized by having an embedded typedef 'value_type'.
+       To change the behavior for a case not covered here, specialize the
+       <tt>concepts_detail::norm_traits_base</tt> template.
+    */
+template<class T>
+struct norm_traits
+: public concepts_detail::norm_traits_base<T>
+{
+    using base_type = concepts_detail::norm_traits_base<T>;
+
+    using type =
+        typename std::conditional<base_type::norm_of_vector::value,
+                    typename base_type::norm_of_vector::norm_type,
+                    typename base_type::norm_of_scalar::norm_type>::type;
+};
+
+    /** Abbreviation of 'typename norm_traits<T>::type'.
+    */
+template <class T>
+using norm_t = typename norm_traits<T>::type;
+
+    /** @brief Traits class for the result type of the <tt>squared_norm()</tt> function.
+
+        Member 'type' defines the result of <tt>squared_norm(t)</tt>, where <tt>t</tt>
+        is of type @tparam T. It implements the following rules designed to
+        minimize the potential for overflow:
+            - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
+            - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+            - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
+            - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
+            - @tparam T is a container of some other type: 'type' is the element's squared norm type,
+
+       Containers are recognized by having an embedded typedef 'value_type'.
+       To change the behavior for a case not covered here, specialize the
+       <tt>concepts_detail::norm_traits_base</tt> template.
+    */
+template<class T>
+struct squared_norm_traits
+: public concepts_detail::norm_traits_base<T>
+{
+    using base_type = concepts_detail::norm_traits_base<T>;
+
+    using type =
+        typename std::conditional<base_type::norm_of_vector::value,
+                    typename base_type::norm_of_vector::squared_norm_type,
+                    typename base_type::norm_of_scalar::squared_norm_type>::type;
+};
+
+    /** Abbreviation of 'typename squared_norm_traits<T>::type'.
+    */
+template <class T>
+using squared_norm_t = typename squared_norm_traits<T>::type;
+
+} // namespace xt
+
+#endif // XCONCEPTS_HPP

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -10,6 +10,7 @@
 #define XCONCEPTS_HPP
 
 #include <type_traits>
+#include <cmath>
 
 /**********************************************************/
 /*                                                        */
@@ -135,17 +136,17 @@ namespace xt
     template <class T>
     struct norm_of_scalar_impl<T, false>
     {
-        static constexpr bool value = false;
-        using norm_type             = void *;
-        using squared_norm_type     = void *;
+        static const bool value = false;
+        using norm_type         = void *;
+        using squared_norm_type = void *;
     };
 
     template <class T>
     struct norm_of_scalar_impl<T, true>
     {
-        static constexpr bool value = true;
-        using norm_type             = T;
-        using squared_norm_type     = decltype((*(T*)0) * (*(T*)0));
+        static const bool value = true;
+        using norm_type         = T;
+        using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
     };
 
     template <class T, bool integral = std::is_integral<T>::value,

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -13,9 +13,7 @@
 #include <cmath>
 
 /**********************************************************/
-/*                                                        */
-/*   concept checking and type inference functionality    */
-/*                                                        */
+/* concept checking and type inference functionality */
 /**********************************************************/
 
 namespace xt
@@ -27,12 +25,12 @@ namespace xt
     /*                                                        */
     /**********************************************************/
 
-    struct require_ok {};
+    struct concepts_fulfilled {};
 
     template <bool CONCEPTS>
-    using concept_check = typename std::enable_if<CONCEPTS, require_ok>::type;
+    using concept_check = typename std::enable_if<CONCEPTS, concepts_fulfilled>::type;
 
-        /** @brief Concept checking macro (more redable than sfinae).
+        /** @brief Concept checking macro (more readable than sfinae).
 
             The macro is used as the last argument in a template declaration.
             It must be followed by a static boolean expression in angle brackets.
@@ -79,215 +77,6 @@ namespace xt
             std::is_pointer<T>::value ||
             std::is_same<decltype(test((V*)0)), int>::value;
     };
-
-    /**********************************************************/
-    /*                                                        */
-    /*                    promote types                       */
-    /*                                                        */
-    /**********************************************************/
-
-    namespace concepts_detail
-    {
-        using std::sqrt;
-
-        template <class T>
-        using real_promote_t = decltype(sqrt(*(std::decay_t<T>*)0));
-    }
-
-        /** @brief Result type of mixed arithmetic expressions.
-
-            For example, it tells the user that <tt>unsigned char + unsigned char => int</tt>.
-        */
-    template <class T1, class T2 = T1>
-    using promote_t = decltype(*(std::decay_t<T1>*)0 + *(std::decay_t<T2>*)0);
-
-        /** @brief Result type of algebraic expressions.
-
-            For example, it tells the user that <tt>sqrt(int) => double</tt>.
-        */
-    template <class T>
-    using real_promote_t = concepts_detail::real_promote_t<T>;
-
-        /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
-
-            This is useful for scientific computing, where a boolean mask array is
-            usually implemented as an array of bytes.
-        */
-    template <class T>
-    using bool_promote_t = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
-
-    /**********************************************************/
-    /*                                                        */
-    /*       type inference for norm and squared norm         */
-    /*                                                        */
-    /**********************************************************/
-
-    template<class T>
-    struct norm_traits;
-
-    template<class T>
-    struct squared_norm_traits;
-
-    namespace concepts_detail {
-
-    template <class T, bool scalar = std::is_arithmetic<T>::value>
-    struct norm_of_scalar_impl;
-
-    template <class T>
-    struct norm_of_scalar_impl<T, false>
-    {
-        static const bool value = false;
-        using norm_type         = void *;
-        using squared_norm_type = void *;
-    };
-
-    template <class T>
-    struct norm_of_scalar_impl<T, true>
-    {
-        static const bool value = true;
-        using norm_type         = T;
-        using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
-    };
-
-    template <class T, bool integral = std::is_integral<T>::value,
-                       bool floating = std::is_floating_point<T>::value>
-    struct norm_of_array_elements_impl;
-
-    template <>
-    struct norm_of_array_elements_impl<void *, false, false>
-    {
-        using norm_type         = void *;
-        using squared_norm_type = void *;
-    };
-
-    template <class T>
-    struct norm_of_array_elements_impl<T, false, false>
-    {
-        using norm_type         = typename norm_traits<T>::type;
-        using squared_norm_type = typename squared_norm_traits<T>::type;
-    };
-
-    template <class T>
-    struct norm_of_array_elements_impl<T, true, false>
-    {
-        static_assert(!std::is_same<T, char>::value,
-           "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
-
-        using norm_type         = double;
-        using squared_norm_type = uint64_t;
-    };
-
-    template <class T>
-    struct norm_of_array_elements_impl<T, false, true>
-    {
-        using norm_type         = double;
-        using squared_norm_type = double;
-    };
-
-    template <>
-    struct norm_of_array_elements_impl<long double, false, true>
-    {
-        using norm_type         = long double;
-        using squared_norm_type = long double;
-    };
-
-    template <class ARRAY>
-    struct norm_of_vector_impl
-    {
-        static void * test(...);
-
-        template <class U>
-        static typename U::value_type test(U*, typename U::value_type * = 0);
-
-        using T = decltype(test((ARRAY*)0));
-
-        static const bool value = !std::is_same<T, void*>::value;
-
-        using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
-        using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
-    };
-
-    template<class U>
-    struct norm_traits_base
-    {
-        using T = std::decay_t<U>;
-
-        static_assert(!std::is_same<T, char>::value,
-           "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
-
-        using norm_of_scalar = norm_of_scalar_impl<T>;
-        using norm_of_vector = norm_of_vector_impl<T>;
-
-        static const bool value = norm_of_scalar::value || norm_of_vector::value;
-
-        static_assert(value, "norm_traits<T> are undefined for type U.");
-    };
-
-    } // namespace concepts_detail
-
-        /** @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
-
-            Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
-            is of type @tparam T. It implements the following rules designed to
-            minimize the potential for overflow:
-                - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
-                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-                - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
-                - @tparam T is a container of some other type: 'type' is the element's norm type,
-
-           Containers are recognized by having an embedded typedef 'value_type'.
-           To change the behavior for a case not covered here, specialize the
-           <tt>concepts_detail::norm_traits_base</tt> template.
-        */
-    template<class T>
-    struct norm_traits
-    : public concepts_detail::norm_traits_base<T>
-    {
-        using base_type = concepts_detail::norm_traits_base<T>;
-
-        using type =
-            typename std::conditional<base_type::norm_of_vector::value,
-                        typename base_type::norm_of_vector::norm_type,
-                        typename base_type::norm_of_scalar::norm_type>::type;
-    };
-
-        /** Abbreviation of 'typename norm_traits<T>::type'.
-        */
-    template <class T>
-    using norm_t = typename norm_traits<T>::type;
-
-        /** @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
-
-            Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
-            is of type @tparam T. It implements the following rules designed to
-            minimize the potential for overflow:
-                - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
-                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-                - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
-                - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
-                - @tparam T is a container of some other type: 'type' is the element's squared norm type,
-
-           Containers are recognized by having an embedded typedef 'value_type'.
-           To change the behavior for a case not covered here, specialize the
-           <tt>concepts_detail::norm_traits_base</tt> template.
-        */
-    template<class T>
-    struct norm_sq_traits
-    : public concepts_detail::norm_traits_base<T>
-    {
-        using base_type = concepts_detail::norm_traits_base<T>;
-
-        using type =
-            typename std::conditional<base_type::norm_of_vector::value,
-                        typename base_type::norm_of_vector::squared_norm_type,
-                        typename base_type::norm_of_scalar::squared_norm_type>::type;
-    };
-
-        /** Abbreviation of 'typename norm_sq_traits<T>::type'.
-        */
-    template <class T>
-    using norm_sq_t = typename norm_sq_traits<T>::type;
-
 } // namespace xt
 
 #endif // XCONCEPTS_HPP

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -153,15 +153,15 @@ namespace xt
 
 #ifdef XTENSOR_ENABLE_ASSERT
 #define XTENSOR_ASSERT(expr) XTENSOR_ASSERT_IMPL(expr, __FILE__, __LINE__)
-#define XTENSOR_ASSERT_IMPL(expr, file, line)                                                                                    \
-    try                                                                                                                          \
-    {                                                                                                                            \
-        expr;                                                                                                                    \
-    }                                                                                                                            \
-    catch (std::exception & e)                                                                                                   \
-    {                                                                                                                            \
-        throw std::runtime_error(std::string(file) + ':' + std::to_string(line)                                                  \
-            + ": check failed\n\t" + std::string(e.what()));                                                                     \
+#define XTENSOR_ASSERT_IMPL(expr, file, line)                                                       \
+    try                                                                                             \
+    {                                                                                               \
+        expr;                                                                                       \
+    }                                                                                               \
+    catch (std::exception & e)                                                                      \
+    {                                                                                               \
+        throw std::runtime_error(std::string(file) + ':' + std::to_string(line)                     \
+            + ": check failed\n\t" + std::string(e.what()));                                        \
     }
 #else
 #define XTENSOR_ASSERT(expr)
@@ -169,18 +169,18 @@ namespace xt
 }
 
 #ifdef XTENSOR_ENABLE_ASSERT
-#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE) \
-    if((PREDICATE)) {} else  { \
-        throw std::runtime_error(std::string("Assertion error!\n") + MESSAGE + \
+#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)                                                      \
+    if((PREDICATE)) {} else  {                                                                      \
+        throw std::runtime_error(std::string("Assertion error!\n") + MESSAGE +                      \
                                  "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
 
 #else
 #define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)
 #endif
 
-#define xtensor_precondition(PREDICATE, MESSAGE) \
-    if((PREDICATE)) {} else  { \
-        throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE + \
+#define xtensor_precondition(PREDICATE, MESSAGE)                                                    \
+    if((PREDICATE)) {} else  {                                                                      \
+        throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE +               \
                                  "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
 
 #endif // XEXCEPTION_HPP

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -167,4 +167,20 @@ namespace xt
 #define XTENSOR_ASSERT(expr)
 #endif
 }
+
+#ifdef XTENSOR_ENABLE_ASSERT
+#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE) \
+    if((PREDICATE)) {} else  { \
+        throw std::runtime_error(std::string("Assertion error!\n") + MESSAGE + \
+                                 "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
+
+#else
+#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)
 #endif
+
+#define xtensor_precondition(PREDICATE, MESSAGE) \
+    if((PREDICATE)) {} else  { \
+        throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE + \
+                                 "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
+
+#endif // XEXCEPTION_HPP

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -178,7 +178,7 @@ namespace xt
 #define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)
 #endif
 
-#define xtensor_precondition(PREDICATE, MESSAGE)                                                    \
+#define XTENSOR_PRECONDITION(PREDICATE, MESSAGE)                                                    \
     if((PREDICATE)) {} else  {                                                                      \
         throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE +               \
                                  "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -61,7 +61,7 @@ namespace xt
         template <>
         struct common_difference_type<>
         {
-            using type = std::size_t;
+            using type = std::ptrdiff_t;
         };
 
         template <class... Args>
@@ -74,7 +74,7 @@ namespace xt
         template <class... Args>
         struct common_value_type
         {
-            using type = std::common_type_t<xvalue_type_t<Args>...>;
+            using type = promote_t<xvalue_type_t<Args>...>;
         };
 
         template <class... Args>

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -17,28 +17,12 @@
 #include <complex>
 #include <type_traits>
 
+#include "xmathutil.hpp"
 #include "xoperation.hpp"
 #include "xreducer.hpp"
 
 namespace xt
 {
-    template <class T>
-    struct numeric_constants
-    {
-        static constexpr T PI = 3.141592653589793238463;
-        static constexpr T PI_2 = 1.57079632679489661923;
-        static constexpr T PI_4 = 0.785398163397448309616;
-        static constexpr T D_1_PI = 0.318309886183790671538;
-        static constexpr T D_2_PI = 0.636619772367581343076;
-        static constexpr T D_2_SQRTPI = 1.12837916709551257390;
-        static constexpr T SQRT2 = 1.41421356237309504880;
-        static constexpr T SQRT1_2 = 0.707106781186547524401;
-        static constexpr T E = 2.71828182845904523536;
-        static constexpr T LOG2E = 1.44269504088896340736;
-        static constexpr T LOG10E = 0.434294481903251827651;
-        static constexpr T LN2 = 0.693147180559945309417;
-    };
-
     /***********
      * Helpers *
      ***********/
@@ -185,7 +169,7 @@ namespace xt
     /**
      * @ingroup basic_functions
      * @brief Absolute value function.
-     * 
+     *
      * Returns an \ref xfunction for the element-wise absolute value
      * of \em e.
      * @param e an \ref xexpression
@@ -201,7 +185,7 @@ namespace xt
     /**
      * @ingroup basic_functions
      * @brief Absolute value function.
-     * 
+     *
      * Returns an \ref xfunction for the element-wise absolute value
      * of \em e.
      * @param e an \ref xexpression
@@ -217,7 +201,7 @@ namespace xt
     /**
      * @ingroup basic_functions
      * @brief Remainder of the floating point division operation.
-     * 
+     *
      * Returns an \ref xfunction for the element-wise remainder of
      * the floating point division operation <em>e1 / e2</em>.
      * @param e1 an \ref xexpression or a scalar
@@ -235,7 +219,7 @@ namespace xt
     /**
      * @ingroup basic_functions
      * @brief Signed remainder of the division operation.
-     * 
+     *
      * Returns an \ref xfunction for the element-wise signed remainder
      * of the floating point division operation <em>e1 / e2</em>.
      * @param e1 an \ref xexpression or a scalar
@@ -478,8 +462,8 @@ namespace xt
     /**
      * @ingroup basic_functions
      * @brief Clip values between hi and lo
-     * 
-     * Returns an \ref xfunction for the element-wise clipped 
+     *
+     * Returns an \ref xfunction for the element-wise clipped
      * values between lo and hi
      * @param e1 an \ref xexpression or a scalar
      * @param lo a scalar
@@ -701,7 +685,7 @@ namespace xt
      * @ingroup pow_functions
      * @brief Square root function.
      *
-     * Returns an \ref xfunction for the element-wise square 
+     * Returns an \ref xfunction for the element-wise square
      * root of \em e.
      * @param e an \ref xexpression
      * @return an \ref xfunction

--- a/include/xtensor/xmathutil.hpp
+++ b/include/xtensor/xmathutil.hpp
@@ -84,14 +84,14 @@ namespace xt
         using std::logb;
         using std::ilogb;
 
-        using std::floor;
         using std::ceil;
-        using std::trunc;
-        using std::round;
+        using std::floor;
         using std::lround;
         using std::llround;
         using std::nearbyint;
         using std::rint;
+        using std::round;
+        using std::trunc;
 
         using std::isfinite;
         using std::isinf;
@@ -99,14 +99,13 @@ namespace xt
 
         using std::erf;
         using std::erfc;
-        using std::tgamma;
         using std::lgamma;
+        using std::tgamma;
 
         using std::conj;
         using std::real;
         using std::imag;
         using std::arg;
-        using std::norm;
 
         using std::atan2;
         using std::copysign;
@@ -132,21 +131,6 @@ namespace xt
         XTENSOR_DEFINE_UNSIGNED_ABS(unsigned long long)
 
         #undef XTENSOR_DEFINE_UNSIGNED_ABS
-
-            // add missing floor() and ceil() overloads for integral types
-        #define XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(T) \
-            inline T floor(signed T t) { return t; } \
-            inline T floor(unsigned T t) { return t; } \
-            inline T ceil(signed T t) { return t; } \
-            inline T ceil(unsigned T t) { return t; }
-
-        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(char)
-        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(short)
-        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(int)
-        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(long)
-        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(long long)
-
-        #undef XTENSOR_DEFINE_INTEGER_FLOOR_CEIL
     } // namespace cmath
 
 
@@ -167,9 +151,13 @@ namespace xt
           b = static_cast<P>(v);
 
         if(std::isnan(a) && std::isnan(b))
+        {
             return equal_nan;
+        }
         if(std::isinf(a) && std::isinf(b))
+        {
             return std::signbit(a) == std::signbit(b);
+        }
         P d = abs(a - b);
         return d <= atol || d <= rtol * std::max(abs(a), abs(b));
     }
@@ -326,9 +314,13 @@ namespace xt
     REAL sin_pi(REAL x)
     {
         if(x < 0.0)
+        {
             return -sin_pi(-x);
+        }
         if(x < 0.5)
+        {
             return std::sin(numeric_constants<REAL>::PI * x);
+        }
 
         bool invert = false;
         if(x < 1.0)
@@ -338,15 +330,23 @@ namespace xt
         }
 
         REAL rem = std::floor(x);
-        if(odd((int)rem))
+        if(odd((int64_t)rem))
+        {
             invert = !invert;
+        }
         rem = x - rem;
         if(rem > 0.5)
+        {
             rem = 1.0 - rem;
+        }
         if(rem == 0.5)
+        {
             rem = REAL(1);
+        }
         else
+        {
             rem = std::sin(numeric_constants<REAL>::PI * rem);
+        }
         return invert
                   ? -rem
                   : rem;
@@ -366,41 +366,42 @@ namespace xt
 
     /**********************************************************/
     /*                                                        */
-    /*                          norm()                        */
+    /*                        norm_l2()                       */
     /*                                                        */
     /**********************************************************/
 
-        /** \brief The norm of a numerical object.
+        /** \brief The L2-norm of a numerical object.
 
             For scalar types: implemented as <tt>abs(t)</tt><br>
-            otherwise: implemented as <tt>sqrt(squared_norm(t))</tt>.
+            otherwise: implemented as <tt>sqrt(norm_sq(t))</tt>.
         */
     template <class T>
-    inline auto norm(T const & t)
+    inline auto norm_l2(T const & t)
     {
         using cmath::sqrt;
-        return sqrt(squared_norm(t));
+        return sqrt(norm_sq(t));
     }
 
     /**********************************************************/
     /*                                                        */
-    /*                     squared_norm()                     */
+    /*                        norm_sq()                       */
     /*                                                        */
     /**********************************************************/
 
     template <class T>
     inline auto
-    squared_norm(std::complex<T> const & t)
+    norm_sq(std::complex<T> const & t)
     {
-        return sq(t.real()) + sq(t.imag());
+        return std::norm(t);
     }
 
-    #define XTENSOR_DEFINE_NORM(T) \
-        inline auto squared_norm(T t) { return sq(t); } \
-        inline auto mean_square(T t) { return sq(t); } \
-        inline auto elementwise_squared_norm(T t) { return sq(t); } \
-        inline auto norm(T t) { return cmath::abs(t); } \
-        inline auto elementwise_norm(T t) { return cmath::abs(t); }
+    #define XTENSOR_DEFINE_NORM(T)                                   \
+        inline size_t norm_l0(T t)     { return t != 0 ? 1 : 0; }    \
+        inline auto   norm_l1(T t)     { return cmath::abs(t); }     \
+        inline auto   norm_l2(T t)     { return cmath::abs(t); }     \
+        inline auto   norm_max(T t)    { return cmath::abs(t); }     \
+        inline auto   norm_sq(T t)     { return sq(t); }             \
+        inline auto   mean_square(T t) { return sq(t); }
 
     XTENSOR_DEFINE_NORM(signed char)
     XTENSOR_DEFINE_NORM(unsigned char)

--- a/include/xtensor/xmathutil.hpp
+++ b/include/xtensor/xmathutil.hpp
@@ -1,0 +1,413 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief standard mathematical functions for xexpressions
+ */
+
+#ifndef XMATHUTIL_HPP
+#define XMATHUTIL_HPP
+
+#include <cmath>
+#include <cstdlib>   // std::abs(int) prior to C++ 17
+#include <complex>
+#include <algorithm> // std::min, std::max
+#include <type_traits>
+
+#include "xconcepts.hpp"
+
+namespace xt
+{
+    template <class T = double>
+    struct numeric_constants
+    {
+        static constexpr T PI = 3.141592653589793238463;
+        static constexpr T PI_2 = 1.57079632679489661923;
+        static constexpr T PI_4 = 0.785398163397448309616;
+        static constexpr T D_1_PI = 0.318309886183790671538;
+        static constexpr T D_2_PI = 0.636619772367581343076;
+        static constexpr T D_2_SQRTPI = 1.12837916709551257390;
+        static constexpr T SQRT2 = 1.41421356237309504880;
+        static constexpr T SQRT1_2 = 0.707106781186547524401;
+        static constexpr T E = 2.71828182845904523536;
+        static constexpr T LOG2E = 1.44269504088896340736;
+        static constexpr T LOG10E = 0.434294481903251827651;
+        static constexpr T LN2 = 0.693147180559945309417;
+    };
+
+    namespace cmath
+    {
+        // create a namespace for just the algebraic functions from std
+        // and add a few fixes to avoid ambiguous overloads in templates
+
+        using std::abs;
+        using std::fabs;
+
+        using std::cos;
+        using std::sin;
+        using std::tan;
+        using std::acos;
+        using std::asin;
+        using std::atan;
+
+        using std::cosh;
+        using std::sinh;
+        using std::tanh;
+        using std::acosh;
+        using std::asinh;
+        using std::atanh;
+
+        using std::sqrt;
+        using std::cbrt;
+
+        using std::exp;
+        using std::exp2;
+        using std::expm1;
+        using std::log;
+        using std::log2;
+        using std::log10;
+        using std::log1p;
+        using std::logb;
+        using std::ilogb;
+
+        using std::floor;
+        using std::ceil;
+        using std::trunc;
+        using std::round;
+        using std::lround;
+        using std::llround;
+        using std::nearbyint;
+        using std::rint;
+
+        using std::isfinite;
+        using std::isinf;
+        using std::isnan;
+
+        using std::erf;
+        using std::erfc;
+        using std::tgamma;
+        using std::lgamma;
+
+        using std::conj;
+        using std::real;
+        using std::imag;
+        using std::arg;
+        using std::norm;
+
+        using std::atan2;
+        using std::copysign;
+        using std::fdim;
+        using std::fmax;
+        using std::fmin;
+        using std::fmod;
+        using std::hypot;
+        using std::remainder;
+
+        using std::pow;
+        using std::fma;
+
+            // add missing abs() overloads for unsigned types
+        #define XTENSOR_DEFINE_UNSIGNED_ABS(T) \
+            inline T abs(T t) { return t; }
+
+        XTENSOR_DEFINE_UNSIGNED_ABS(bool)
+        XTENSOR_DEFINE_UNSIGNED_ABS(unsigned char)
+        XTENSOR_DEFINE_UNSIGNED_ABS(unsigned short)
+        XTENSOR_DEFINE_UNSIGNED_ABS(unsigned int)
+        XTENSOR_DEFINE_UNSIGNED_ABS(unsigned long)
+        XTENSOR_DEFINE_UNSIGNED_ABS(unsigned long long)
+
+        #undef XTENSOR_DEFINE_UNSIGNED_ABS
+
+            // add missing floor() and ceil() overloads for integral types
+        #define XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(T) \
+            inline T floor(signed T t) { return t; } \
+            inline T floor(unsigned T t) { return t; } \
+            inline T ceil(signed T t) { return t; } \
+            inline T ceil(unsigned T t) { return t; }
+
+        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(char)
+        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(short)
+        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(int)
+        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(long)
+        XTENSOR_DEFINE_INTEGER_FLOOR_CEIL(long long)
+
+        #undef XTENSOR_DEFINE_INTEGER_FLOOR_CEIL
+    } // namespace cmath
+
+
+    /**********************************************************/
+    /*                                                        */
+    /*                       isclose()                        */
+    /*                                                        */
+    /**********************************************************/
+
+    template <class U, class V,
+              XTENSOR_REQUIRE<std::is_floating_point<promote_t<U, V> >::value> >
+    inline bool
+    isclose(U u, V v, double rtol = 1e-05, double atol = 1e-08, bool equal_nan = false)
+    {
+        using namespace cmath;
+        using P = promote_t<U, V>;
+        P a = static_cast<P>(u),
+          b = static_cast<P>(v);
+
+        if(std::isnan(a) && std::isnan(b))
+            return equal_nan;
+        if(std::isinf(a) && std::isinf(b))
+            return std::signbit(a) == std::signbit(b);
+        P d = abs(a - b);
+        return d <= atol || d <= rtol * std::max(abs(a), abs(b));
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                          sq()                          */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief The square function.
+
+            <tt>sq(x) = x*x</tt> is needed so often that it makes sense to define it as a function.
+        */
+    template <class T,
+              XTENSOR_REQUIRE<std::is_arithmetic<T>::value> >
+    inline auto
+    sq(T t)
+    {
+        return t*t;
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                           dot()                        */
+    /*                                                        */
+    /**********************************************************/
+
+        // scalar dot is needed for generic functions that should work with
+        // scalars and vectors alike
+    #define XTENSOR_DEFINE_SCALAR_DOT(T) \
+        inline auto dot(T l, T r) { return l*r; }
+
+    XTENSOR_DEFINE_SCALAR_DOT(unsigned char)
+    XTENSOR_DEFINE_SCALAR_DOT(unsigned short)
+    XTENSOR_DEFINE_SCALAR_DOT(unsigned int)
+    XTENSOR_DEFINE_SCALAR_DOT(unsigned long)
+    XTENSOR_DEFINE_SCALAR_DOT(unsigned long long)
+    XTENSOR_DEFINE_SCALAR_DOT(signed char)
+    XTENSOR_DEFINE_SCALAR_DOT(signed short)
+    XTENSOR_DEFINE_SCALAR_DOT(signed int)
+    XTENSOR_DEFINE_SCALAR_DOT(signed long)
+    XTENSOR_DEFINE_SCALAR_DOT(signed long long)
+    XTENSOR_DEFINE_SCALAR_DOT(float)
+    XTENSOR_DEFINE_SCALAR_DOT(double)
+    XTENSOR_DEFINE_SCALAR_DOT(long double)
+
+    #undef XTENSOR_DEFINE_SCALAR_DOT
+
+    /**********************************************************/
+    /*                                                        */
+    /*                         min()                          */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief A proper minimum function.
+
+            The <tt>std::min</tt> template matches everything -- this is way too
+            greedy to be useful. xtensor implements the basic <tt>min</tt> function
+            only for arithmetic types and provides explicit overloads for everything
+            else. Moreover, xtensor's <tt>min</tt> function also computes the minimum
+            between two different types, as long as they have a <tt>std::common_type</tt>.
+        */
+    template <class T1, class T2,
+              XTENSOR_REQUIRE<std::is_arithmetic<T1>::value && std::is_arithmetic<T2>::value> >
+    inline std::common_type_t<T1, T2>
+    min(T1 const & t1, T2 const & t2)
+    {
+        using T = std::common_type_t<T1, T2>;
+        return std::min(static_cast<T>(t1), static_cast<T>(t2));
+    }
+
+    template <class T,
+              XTENSOR_REQUIRE<std::is_arithmetic<T>::value> >
+    inline T const &
+    min(T const & t1, T const & t2)
+    {
+        return std::min(t1, t2);
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                         max()                          */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief A proper maximum function.
+
+            The <tt>std::max</tt> template matches everything -- this is way too
+            greedy to be useful. xtensor implements the basic <tt>max</tt> function
+            only for arithmetic types and provides explicit overloads for everything
+            else. Moreover, xtensor's <tt>max</tt> function also computes the maximum
+            between two different types, as long as they have a <tt>std::common_type</tt>.
+        */
+    template <class T1, class T2,
+              XTENSOR_REQUIRE<std::is_arithmetic<T1>::value && std::is_arithmetic<T2>::value> >
+    inline std::common_type_t<T1, T2>
+    max(T1 const & t1, T2 const & t2)
+    {
+        using T = std::common_type_t<T1, T2>;
+        return std::max(static_cast<T>(t1), static_cast<T>(t2));
+    }
+
+    template <class T,
+              XTENSOR_REQUIRE<std::is_arithmetic<T>::value> >
+    inline T const &
+    max(T const & t1, T const & t2)
+    {
+        return std::max(t1, t2);
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                       even(), odd()                    */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief Check if an integer is even.
+        */
+    template <class T,
+              XTENSOR_REQUIRE<std::is_integral<T>::value> >
+    inline bool
+    even(T const t)
+    {
+        using UT = typename std::make_unsigned<T>::type;
+        return (static_cast<UT>(t)&1) == 0;
+    }
+
+        /** \brief Check if an integer is odd.
+        */
+    template <class T,
+              XTENSOR_REQUIRE<std::is_integral<T>::value> >
+    inline bool
+    odd(T const t)
+    {
+        using UT = typename std::make_unsigned<T>::type;
+        return (static_cast<UT>(t)&1) != 0;
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                   sin_pi(), cos_pi()                   */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief sin(pi*x).
+
+            Essentially calls <tt>std::sin(PI*x)</tt> but uses a more accurate implementation
+            to make sure that <tt>sin_pi(1.0) == 0.0</tt> (which does not hold for
+            <tt>std::sin(PI)</tt> due to round-off error), and <tt>sin_pi(0.5) == 1.0</tt>.
+        */
+    template <class REAL,
+              XTENSOR_REQUIRE<std::is_floating_point<REAL>::value> >
+    REAL sin_pi(REAL x)
+    {
+        if(x < 0.0)
+            return -sin_pi(-x);
+        if(x < 0.5)
+            return std::sin(numeric_constants<REAL>::PI * x);
+
+        bool invert = false;
+        if(x < 1.0)
+        {
+            invert = true;
+            x = -x;
+        }
+
+        REAL rem = std::floor(x);
+        if(odd((int)rem))
+            invert = !invert;
+        rem = x - rem;
+        if(rem > 0.5)
+            rem = 1.0 - rem;
+        if(rem == 0.5)
+            rem = REAL(1);
+        else
+            rem = std::sin(numeric_constants<REAL>::PI * rem);
+        return invert
+                  ? -rem
+                  : rem;
+    }
+
+        /** \brief cos(pi*x).
+
+            Essentially calls <tt>std::cos(PI*x)</tt> but uses a more accurate implementation
+            to make sure that <tt>cos_pi(1.0) == -1.0</tt> and <tt>cos_pi(0.5) == 0.0</tt>.
+        */
+    template <class REAL,
+              XTENSOR_REQUIRE<std::is_floating_point<REAL>::value> >
+    REAL cos_pi(REAL x)
+    {
+        return sin_pi(x+0.5);
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                          norm()                        */
+    /*                                                        */
+    /**********************************************************/
+
+        /** \brief The norm of a numerical object.
+
+            For scalar types: implemented as <tt>abs(t)</tt><br>
+            otherwise: implemented as <tt>sqrt(squared_norm(t))</tt>.
+        */
+    template <class T>
+    inline auto norm(T const & t)
+    {
+        using cmath::sqrt;
+        return sqrt(squared_norm(t));
+    }
+
+    /**********************************************************/
+    /*                                                        */
+    /*                     squared_norm()                     */
+    /*                                                        */
+    /**********************************************************/
+
+    template <class T>
+    inline auto
+    squared_norm(std::complex<T> const & t)
+    {
+        return sq(t.real()) + sq(t.imag());
+    }
+
+    #define XTENSOR_DEFINE_NORM(T) \
+        inline auto squared_norm(T t) { return sq(t); } \
+        inline auto mean_square(T t) { return sq(t); } \
+        inline auto elementwise_squared_norm(T t) { return sq(t); } \
+        inline auto norm(T t) { return cmath::abs(t); } \
+        inline auto elementwise_norm(T t) { return cmath::abs(t); }
+
+    XTENSOR_DEFINE_NORM(signed char)
+    XTENSOR_DEFINE_NORM(unsigned char)
+    XTENSOR_DEFINE_NORM(short)
+    XTENSOR_DEFINE_NORM(unsigned short)
+    XTENSOR_DEFINE_NORM(int)
+    XTENSOR_DEFINE_NORM(unsigned int)
+    XTENSOR_DEFINE_NORM(long)
+    XTENSOR_DEFINE_NORM(unsigned long)
+    XTENSOR_DEFINE_NORM(long long)
+    XTENSOR_DEFINE_NORM(unsigned long long)
+    XTENSOR_DEFINE_NORM(float)
+    XTENSOR_DEFINE_NORM(double)
+    XTENSOR_DEFINE_NORM(long double)
+
+    #undef XTENSOR_DEFINE_NORM
+}
+
+#endif

--- a/include/xtensor/xmathutil.hpp
+++ b/include/xtensor/xmathutil.hpp
@@ -417,6 +417,6 @@ namespace xt
     XTENSOR_DEFINE_NORM(long double)
 
     #undef XTENSOR_DEFINE_NORM
-}
+} // namespace xt
 
 #endif

--- a/include/xtensor/xmathutil.hpp
+++ b/include/xtensor/xmathutil.hpp
@@ -40,10 +40,19 @@ namespace xt
         static constexpr T LN2 = 0.693147180559945309417;
     };
 
+        /** @brief Namespace for the standard algebraic functions.
+
+            Often, one only wants to import the algebraic functions from
+            namespace 'std'. Standard C++ doesn't support this -- one either
+            has to import every function individually, or writes <tt>using namespace std</tt>
+            to import everything. Now you can write <tt>using namespace xt::cmath</tt>.
+
+            This namespace also adds a few overloads to the standard function (abs() for unsigned
+            types, floor() and ceil() for integer types) which are needed to dismbiguate
+            templated code.
+        */
     namespace cmath
     {
-        // create a namespace for just the algebraic functions from std
-        // and add a few fixes to avoid ambiguous overloads in templates
 
         using std::abs;
         using std::fabs;

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -580,95 +580,95 @@ namespace xt
 
     template <class T1, class B1, class T2, class B2>
     inline auto operator+(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() && e2.has_value() ? e1.value() + e2.value() : missing<value_type>();
     }
 
     template <class T1, class T2, class B2>
     inline auto operator+(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 + e2.value() : missing<value_type>();
     }
 
     template <class T1, class B1, class T2>
     inline auto operator+(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() + e2 : missing<value_type>();
     }
 
     template <class T1, class B1, class T2, class B2>
     inline auto operator-(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() && e2.has_value() ? e1.value() - e2.value() : missing<value_type>();
     }
 
     template <class T1, class T2, class B2>
     inline auto operator-(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 - e2.value() : missing<value_type>();
     }
 
     template <class T1, class B1, class T2>
     inline auto operator-(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() - e2 : missing<value_type>();
     }
 
     template <class T1, class B1, class T2, class B2>
     inline auto operator*(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() && e2.has_value() ? e1.value() * e2.value() : missing<value_type>();
     }
 
     template <class T1, class T2, class B2>
     inline auto operator*(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 * e2.value() : missing<value_type>();
     }
 
     template <class T1, class B1, class T2>
     inline auto operator*(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() * e2 : missing<value_type>();
     }
 
     template <class T1, class B1, class T2, class B2>
     inline auto operator/(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
-        -> xoptional<std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>>
+        -> xoptional<promote_t<std::decay_t<T1>, std::decay_t<T2>>>
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() && e2.has_value() ? e1.value() / e2.value() : missing<value_type>();
     }
 
     template <class T1, class T2, class B2>
     inline auto operator/(const T1& e1, const xoptional<T2, B2>& e2) noexcept
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 / e2.value() : missing<value_type>();
     }
 
     template <class T1, class B1, class T2>
     inline auto operator/(const xoptional<T1, B1>& e1, const T2& e2) noexcept
     {
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+        using value_type = promote_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() / e2 : missing<value_type>();
     }
 
@@ -833,7 +833,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2)                    \
     {                                                                              \
         using std::NAME;                                                           \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>; \
+        using value_type = decltype(NAME(e1.value(), e2));                         \
         return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>();      \
     }
 
@@ -843,7 +843,7 @@ namespace xt
     inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2)                    \
     {                                                                              \
         using std::NAME;                                                           \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>; \
+        using value_type = decltype(NAME(e1, e2.value()));                         \
         return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>();      \
     }
 
@@ -852,7 +852,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2)                          \
     {                                                                                                   \
         using std::NAME;                                                                                \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;                      \
+        using value_type = decltype(NAME(e1.value(), e2.value()));                                      \
         return e1.has_value() && e2.has_value() ? NAME(e1.value(), e2.value()) : missing<value_type>(); \
     }
 
@@ -866,7 +866,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3)                        \
     {                                                                                                \
         using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
+        using value_type = decltype(NAME(e1.value(), e2, e3));                                       \
         return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>();                    \
     }
 
@@ -875,7 +875,7 @@ namespace xt
     inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3)                        \
     {                                                                                                \
         using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
+        using value_type = decltype(NAME(e1, e2.value(), e3));                                       \
         return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>();                    \
     }
 
@@ -884,7 +884,7 @@ namespace xt
     inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3)                        \
     {                                                                                                \
         using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
+        using value_type = decltype(NAME(e1, e2, e3.value()));                                       \
         return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>();                    \
     }
 
@@ -893,7 +893,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const T3& e3)                  \
     {                                                                                                         \
         using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
+        using value_type = decltype(NAME(e1.value(), e2.value(), e3));                                        \
         return (e1.has_value() && e2.has_value()) ? NAME(e1.value(), e2.value(), e3) : missing<value_type>(); \
     }
 
@@ -902,7 +902,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const xoptional<T3, B3>& e3)                  \
     {                                                                                                         \
         using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
+        using value_type = decltype(NAME(e1.value(), e2, e3.value()));                                        \
         return (e1.has_value() && e3.has_value()) ? NAME(e1.value(), e2, e3.value()) : missing<value_type>(); \
     }
 
@@ -911,7 +911,7 @@ namespace xt
     inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3)                  \
     {                                                                                                         \
         using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
+        using value_type = decltype(NAME(e1, e2.value(), e3.value()));                                        \
         return (e2.has_value() && e3.has_value()) ? NAME(e1, e2.value(), e3.value()) : missing<value_type>(); \
     }
 
@@ -920,7 +920,7 @@ namespace xt
     inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3)                             \
     {                                                                                                                                   \
         using std::NAME;                                                                                                                \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                                    \
+        using value_type = decltype(NAME(e1.value(), e2.value(), e3.value()));                                                          \
         return (e1.has_value() && e2.has_value() && e3.has_value()) ? NAME(e1.value(), e2.value(), e3.value()) : missing<value_type>(); \
     }
 

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <initializer_list>
@@ -998,6 +999,251 @@ namespace xt
     using xtrivially_default_constructible = std::has_trivial_default_constructor<T>;
 
     #endif
+
+    /************************************
+     * arithmetic type promotion traits *
+     ************************************/
+
+        /** @brief Traits class for the result type of mixed arithmetic expressions.
+
+            For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
+            the user that <tt>unsigned char + unsigned char => int</tt>.
+        */
+    template <class ... T>
+	struct promote_type;
+
+    template <class T>
+	struct promote_type<T>
+	{
+        using type = typename promote_type<T, T>::type;
+	};
+
+    template <class T0, class T1>
+	struct promote_type<T0, T1>
+	{
+        using type = decltype(*(std::decay_t<T0>*)0 + *(std::decay_t<T1>*)0);
+	};
+
+    template<class T0, class ... REST>
+	struct promote_type<T0, REST...>
+	{
+        using type = decltype(*(std::decay_t<T0>*)0 + *(typename promote_type<REST...>::type*)0);
+	};
+
+        /** @brief Abbreviation of 'typename promote_type<T>::type'.
+        */
+    template <class ... T>
+    using promote_t = typename promote_type<T...>::type;
+
+    namespace traits_detail
+    {
+        using std::sqrt;
+
+        template <class T>
+        using real_promote_t = decltype(sqrt(*(std::decay_t<T>*)0));
+    }
+
+        /** @brief Result type of algebraic expressions.
+
+            For example, <tt>real_promote_type<int>::type</tt> tells the
+            user that <tt>sqrt(int) => double</tt>.
+        */
+    template <class T>
+	struct real_promote_type
+	{
+        using type = traits_detail::real_promote_t<T>;
+	};
+
+        /** @brief Abbreviation of 'typename real_promote_type<T>::type'.
+        */
+    template <class T>
+    using real_promote_t = typename real_promote_type<T>::type;
+
+        /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+
+            This is useful for scientific computing, where a boolean mask array is
+            usually implemented as an array of bytes.
+        */
+    template <class T>
+	struct bool_promote_type
+	{
+        using type = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+	};
+
+        /** @brief Abbreviation for typename bool_promote_type<T>::type
+        */
+    template <class T>
+    using bool_promote_t = typename bool_promote_type<T>::type;
+
+    /********************************************
+     * type inference for norm and squared norm *
+     ********************************************/
+
+    template<class T>
+    struct norm_type;
+
+    template<class T>
+    struct squared_norm_type;
+
+    namespace traits_detail
+    {
+
+        template <class T, bool scalar = std::is_arithmetic<T>::value>
+        struct norm_of_scalar_impl;
+
+        template <class T>
+        struct norm_of_scalar_impl<T, false>
+        {
+            static const bool value = false;
+            using norm_type         = void *;
+            using squared_norm_type = void *;
+        };
+
+        template <class T>
+        struct norm_of_scalar_impl<T, true>
+        {
+            static const bool value = true;
+            using norm_type         = T;
+            using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
+        };
+
+        template <class T, bool integral = std::is_integral<T>::value,
+                           bool floating = std::is_floating_point<T>::value>
+        struct norm_of_array_elements_impl;
+
+        template <>
+        struct norm_of_array_elements_impl<void *, false, false>
+        {
+            using norm_type         = void *;
+            using squared_norm_type = void *;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, false, false>
+        {
+            using norm_type         = typename norm_type<T>::type;
+            using squared_norm_type = typename squared_norm_type<T>::type;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, true, false>
+        {
+            static_assert(!std::is_same<T, char>::value,
+               "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+            using norm_type         = double;
+            using squared_norm_type = uint64_t;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, false, true>
+        {
+            using norm_type         = double;
+            using squared_norm_type = double;
+        };
+
+        template <>
+        struct norm_of_array_elements_impl<long double, false, true>
+        {
+            using norm_type         = long double;
+            using squared_norm_type = long double;
+        };
+
+        template <class ARRAY>
+        struct norm_of_vector_impl
+        {
+            static void * test(...);
+
+            template <class U>
+            static typename U::value_type test(U*, typename U::value_type * = 0);
+
+            using T = decltype(test((ARRAY*)0));
+
+            static const bool value = !std::is_same<T, void*>::value;
+
+            using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
+            using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
+        };
+
+        template<class U>
+        struct norm_type_base
+        {
+            using T = std::decay_t<U>;
+
+            static_assert(!std::is_same<T, char>::value,
+               "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+            using norm_of_scalar = norm_of_scalar_impl<T>;
+            using norm_of_vector = norm_of_vector_impl<T>;
+
+            static const bool value = norm_of_scalar::value || norm_of_vector::value;
+
+            static_assert(value, "norm_type<T> are undefined for type U.");
+        };
+    } // namespace traits_detail
+
+        /** @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
+
+            Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
+            is of type @tparam T. It implements the following rules designed to
+            minimize the potential for overflow:
+                - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
+                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+                - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
+                - @tparam T is a container of some other type: 'type' is the element's norm type,
+
+           Containers are recognized by having an embedded typedef 'value_type'.
+           To change the behavior for a case not covered here, specialize the
+           <tt>traits_detail::norm_type_base</tt> template.
+        */
+    template<class T>
+    struct norm_type
+    : public traits_detail::norm_type_base<T>
+    {
+        using base_type = traits_detail::norm_type_base<T>;
+
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                        typename base_type::norm_of_vector::norm_type,
+                        typename base_type::norm_of_scalar::norm_type>::type;
+    };
+
+        /** Abbreviation of 'typename norm_type<T>::type'.
+        */
+    template <class T>
+    using norm_t = typename norm_type<T>::type;
+
+        /** @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
+
+            Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
+            is of type @tparam T. It implements the following rules designed to
+            minimize the potential for overflow:
+                - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
+                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+                - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
+                - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
+                - @tparam T is a container of some other type: 'type' is the element's squared norm type,
+
+           Containers are recognized by having an embedded typedef 'value_type'.
+           To change the behavior for a case not covered here, specialize the
+           <tt>traits_detail::norm_type_base</tt> template.
+        */
+    template<class T>
+    struct norm_sq_traits
+    : public traits_detail::norm_type_base<T>
+    {
+        using base_type = traits_detail::norm_type_base<T>;
+
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                        typename base_type::norm_of_vector::squared_norm_type,
+                        typename base_type::norm_of_scalar::squared_norm_type>::type;
+    };
+
+        /** Abbreviation of 'typename norm_sq_traits<T>::type'.
+        */
+    template <class T>
+    using norm_sq_t = typename norm_sq_traits<T>::type;
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,16 +88,19 @@ set(XTENSOR_TESTS
     test_xbuffer_adaptor.cpp
     test_xbuilder.cpp
     test_xcomplex.cpp
+    test_xconcepts.cpp
     test_xcontainer_semantic.cpp
     test_xcsv.cpp
     test_xdynamicview.cpp
     test_xeval.cpp
+    test_xexception.cpp
     test_xfunction.cpp
     test_xindexview.cpp
     test_xiterator.cpp
     test_xio.cpp
     test_xlayout.cpp
     test_xmath.cpp
+    test_xmathutil.cpp
     test_xnoalias.cpp
     test_xoperation.cpp
     test_xoptional.cpp

--- a/test/test_xconcepts.cpp
+++ b/test/test_xconcepts.cpp
@@ -21,46 +21,17 @@ namespace xt
               XTENSOR_REQUIRE<!std::is_integral<T>::value>>
     void * test_concept_check(T) {}
 
-
-
-    TEST(xconcepts, concept_check)
+    TEST(concepts, concept_check)
     {
         EXPECT_TRUE((std::is_same<decltype(test_concept_check(1)), int>::value));
         EXPECT_TRUE((std::is_same<decltype(test_concept_check(1.0)), void *>::value));
     }
 
-    TEST(xconcepts, promote)
+    TEST(concepts, iterator_concept)
     {
-        EXPECT_TRUE((std::is_same<promote_t<uint8_t>, int>::value));
-        EXPECT_TRUE((std::is_same<promote_t<int>, int>::value));
-        EXPECT_TRUE((std::is_same<promote_t<float>, float>::value));
-        EXPECT_TRUE((std::is_same<promote_t<double>, double>::value));
-
-        EXPECT_TRUE((std::is_same<real_promote_t<uint8_t>, double>::value));
-        EXPECT_TRUE((std::is_same<real_promote_t<int>, double>::value));
-        EXPECT_TRUE((std::is_same<real_promote_t<float>, float>::value));
-        EXPECT_TRUE((std::is_same<real_promote_t<double>, double>::value));
-
-        EXPECT_TRUE((std::is_same<bool_promote_t<bool>, uint8_t>::value));
-        EXPECT_TRUE((std::is_same<bool_promote_t<int>, int>::value));
+        EXPECT_FALSE((iterator_concept<int>::value));
+        EXPECT_TRUE((iterator_concept<int *>::value));
+        EXPECT_TRUE((iterator_concept<decltype(std::vector<int>().begin())>::value));
     }
 
-    TEST(xconcepts, norm_traits)
-    {
-        EXPECT_TRUE((std::is_same<norm_t<uint8_t>, uint8_t>::value));
-        EXPECT_TRUE((std::is_same<norm_t<int>, int>::value));
-        EXPECT_TRUE((std::is_same<norm_t<double>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_t<std::vector<uint8_t>>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_t<std::vector<int>>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_t<std::vector<double>>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_t<std::vector<long double>>, long double>::value));
-
-        EXPECT_TRUE((std::is_same<norm_sq_t<uint8_t>, int>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<int>, int>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<double>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<uint8_t>>, uint64_t>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<int>>, uint64_t>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<double>>, double>::value));
-        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<long double>>, long double>::value));
-    }
 } // namespace xt

--- a/test/test_xconcepts.cpp
+++ b/test/test_xconcepts.cpp
@@ -55,12 +55,12 @@ namespace xt
         EXPECT_TRUE((std::is_same<norm_t<std::vector<double>>, double>::value));
         EXPECT_TRUE((std::is_same<norm_t<std::vector<long double>>, long double>::value));
 
-        EXPECT_TRUE((std::is_same<squared_norm_t<uint8_t>, int>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<int>, int>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<double>, double>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<uint8_t>>, uint64_t>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<int>>, uint64_t>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<double>>, double>::value));
-        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<long double>>, long double>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<uint8_t>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<double>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<uint8_t>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<int>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<double>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<long double>>, long double>::value));
     }
 } // namespace xt

--- a/test/test_xconcepts.cpp
+++ b/test/test_xconcepts.cpp
@@ -1,0 +1,66 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xconcepts.hpp"
+
+#include <type_traits>
+
+namespace xt
+{
+    template <class T,
+              XTENSOR_REQUIRE<std::is_integral<T>::value>>
+    int test_concept_check(T) {}
+
+    template <class T,
+              XTENSOR_REQUIRE<!std::is_integral<T>::value>>
+    void * test_concept_check(T) {}
+
+
+
+    TEST(xconcepts, concept_check)
+    {
+        EXPECT_TRUE((std::is_same<decltype(test_concept_check(1)), int>::value));
+        EXPECT_TRUE((std::is_same<decltype(test_concept_check(1.0)), void *>::value));
+    }
+
+    TEST(xconcepts, promote)
+    {
+        EXPECT_TRUE((std::is_same<promote_t<uint8_t>, int>::value));
+        EXPECT_TRUE((std::is_same<promote_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<promote_t<float>, float>::value));
+        EXPECT_TRUE((std::is_same<promote_t<double>, double>::value));
+
+        EXPECT_TRUE((std::is_same<real_promote_t<uint8_t>, double>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<int>, double>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<float>, float>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<double>, double>::value));
+
+        EXPECT_TRUE((std::is_same<bool_promote_t<bool>, uint8_t>::value));
+        EXPECT_TRUE((std::is_same<bool_promote_t<int>, int>::value));
+    }
+
+    TEST(xconcepts, norm_traits)
+    {
+        EXPECT_TRUE((std::is_same<norm_t<uint8_t>, uint8_t>::value));
+        EXPECT_TRUE((std::is_same<norm_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_t<double>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<uint8_t>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<int>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<double>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<long double>>, long double>::value));
+
+        EXPECT_TRUE((std::is_same<squared_norm_t<uint8_t>, int>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<double>, double>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<uint8_t>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<int>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<double>>, double>::value));
+        EXPECT_TRUE((std::is_same<squared_norm_t<std::vector<long double>>, long double>::value));
+    }
+} // namespace xt

--- a/test/test_xexception.cpp
+++ b/test/test_xexception.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#define XTENSOR_ENABLE_ASSERT
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "xtensor/xexception.hpp"
+
+namespace xt
+{
+    TEST(xexception, assert)
+    {
+        try
+        {
+            XTENSOR_ASSERT_MSG(false, "Intentional error");
+            FAIL() << "No exception thrown.";
+        }
+        catch(std::runtime_error & e)
+        {
+            std::string expected("Assertion error!\nIntentional error");
+            std::string message(e.what());
+            EXPECT_TRUE(0 == expected.compare(message.substr(0,expected.size())));
+        }
+        try
+        {
+            xtensor_precondition(false, "Intentional error");
+            FAIL() << "No exception thrown.";
+        }
+        catch(std::runtime_error & e)
+        {
+            std::string expected("Precondition violation!\nIntentional error");
+            std::string message(e.what());
+            EXPECT_TRUE(0 == expected.compare(message.substr(0,expected.size())));
+        }
+    }
+} // namespace xt

--- a/test/test_xexception.cpp
+++ b/test/test_xexception.cpp
@@ -30,7 +30,7 @@ namespace xt
         }
         try
         {
-            xtensor_precondition(false, "Intentional error");
+            XTENSOR_PRECONDITION(false, "Intentional error");
             FAIL() << "No exception thrown.";
         }
         catch(std::runtime_error & e)

--- a/test/test_xmathutil.cpp
+++ b/test/test_xmathutil.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xmathutil.hpp"
+
+#include <limits>
+
+namespace xt
+{
+    template <class T>
+    auto test_abs(T t)
+    {
+        using namespace cmath;
+        return abs(t);
+    }
+
+    TEST(xmathutil, cmath)
+    {
+        EXPECT_TRUE((std::is_same<decltype(test_abs(1)), int>::value));
+
+        // without XTENSOR_DEFINE_UNSIGNED_ABS, this causes 'ambiguous call to overloaded function'
+        EXPECT_TRUE((std::is_same<decltype(test_abs(1u)), unsigned int>::value));
+
+        EXPECT_TRUE((std::is_same<decltype(cmath::floor(1.1)), double>::value));
+
+        // without XTENSOR_DEFINE_INTEGER_FLOOR_CEIL, this results in 'double'
+        EXPECT_TRUE((std::is_same<decltype(cmath::floor(1)), int>::value));
+    }
+
+    TEST(xmathutil, isclose)
+    {
+        double eps = std::numeric_limits<double>::epsilon();
+
+        // test default tolerance
+        EXPECT_TRUE(isclose(numeric_constants<>::PI, 3.141592653));
+        EXPECT_FALSE(isclose(numeric_constants<>::PI, 3.141));
+        // test custom tolerance
+        EXPECT_TRUE(isclose(numeric_constants<>::PI, 3.141592653589793238463, eps, eps));
+        EXPECT_FALSE(isclose(numeric_constants<>::PI, 3.141592653, eps, eps));
+        EXPECT_TRUE(isclose(numeric_constants<>::PI, 3.141, 1e-3));
+        EXPECT_FALSE(isclose(numeric_constants<>::PI, 3.141, 1e-4));
+        EXPECT_TRUE(isclose(numeric_constants<>::PI, 3.141, 1e-4, 1e-3));
+        // test NaN
+        EXPECT_FALSE(isclose(std::log(-1.0), 3.141));
+        EXPECT_FALSE(isclose(std::log(-1.0), std::log(-2.0)));
+        EXPECT_TRUE(isclose(std::log(-1.0), std::log(-2.0), eps, eps, true));
+    }
+
+    TEST(xmathutil, functions)
+    {
+        EXPECT_EQ(sq(2), 4);
+        EXPECT_EQ(sq(1.5), 2.25);
+        EXPECT_EQ(dot(2, 3), 6);
+        EXPECT_EQ(dot(1.5, 2.5), 3.75);
+
+        EXPECT_EQ(min(1.5, 2), 1.5);
+        EXPECT_EQ(max(1.5, 2), 2.0);
+
+        EXPECT_TRUE(even(2));
+        EXPECT_FALSE(even(3));
+        EXPECT_TRUE(odd(3));
+        EXPECT_FALSE(odd(2));
+
+        EXPECT_EQ(sin_pi(1.0), 0.0);
+        EXPECT_EQ(sin_pi(1.5), -1.0);
+        EXPECT_EQ(cos_pi(1.0), -1.0);
+        EXPECT_EQ(cos_pi(1.5), 0.0);
+
+        EXPECT_EQ(norm(2), 2);
+        EXPECT_EQ(norm(-2), 2);
+        EXPECT_EQ(norm(2.0), 2.0);
+        EXPECT_EQ(norm(-2.0), 2.0);
+
+        EXPECT_EQ(squared_norm(2), 4);
+        EXPECT_EQ(squared_norm(-2), 4);
+        EXPECT_EQ(squared_norm(2.0), 4.0);
+        EXPECT_EQ(squared_norm(-2.0), 4.0);
+    }
+} // namespace xt

--- a/test/test_xmathutil.cpp
+++ b/test/test_xmathutil.cpp
@@ -26,11 +26,6 @@ namespace xt
 
         // without XTENSOR_DEFINE_UNSIGNED_ABS, this causes 'ambiguous call to overloaded function'
         EXPECT_TRUE((std::is_same<decltype(test_abs(1u)), unsigned int>::value));
-
-        EXPECT_TRUE((std::is_same<decltype(cmath::floor(1.1)), double>::value));
-
-        // without XTENSOR_DEFINE_INTEGER_FLOOR_CEIL, this results in 'double'
-        EXPECT_TRUE((std::is_same<decltype(cmath::floor(1)), int>::value));
     }
 
     TEST(xmathutil, isclose)
@@ -72,14 +67,35 @@ namespace xt
         EXPECT_EQ(cos_pi(1.0), -1.0);
         EXPECT_EQ(cos_pi(1.5), 0.0);
 
-        EXPECT_EQ(norm(2), 2);
-        EXPECT_EQ(norm(-2), 2);
-        EXPECT_EQ(norm(2.0), 2.0);
-        EXPECT_EQ(norm(-2.0), 2.0);
+        EXPECT_EQ(norm_l0(2), 1);
+        EXPECT_EQ(norm_l0(-2), 1);
+        EXPECT_EQ(norm_l0(0), 0);
+        EXPECT_EQ(norm_l0(2.0), 1);
+        EXPECT_EQ(norm_l0(-2.0), 1);
+        EXPECT_EQ(norm_l0(0.0), 0);
 
-        EXPECT_EQ(squared_norm(2), 4);
-        EXPECT_EQ(squared_norm(-2), 4);
-        EXPECT_EQ(squared_norm(2.0), 4.0);
-        EXPECT_EQ(squared_norm(-2.0), 4.0);
+        EXPECT_EQ(norm_l1(2), 2);
+        EXPECT_EQ(norm_l1(-2), 2);
+        EXPECT_EQ(norm_l1(2.0), 2.0);
+        EXPECT_EQ(norm_l1(-2.0), 2.0);
+
+        EXPECT_EQ(norm_l2(2), 2);
+        EXPECT_EQ(norm_l2(-2), 2);
+        EXPECT_EQ(norm_l2(2.0), 2.0);
+        EXPECT_EQ(norm_l2(-2.0), 2.0);
+
+        EXPECT_EQ(norm_max(2), 2);
+        EXPECT_EQ(norm_max(-2), 2);
+        EXPECT_EQ(norm_max(2.0), 2.0);
+        EXPECT_EQ(norm_max(-2.0), 2.0);
+
+        EXPECT_EQ(norm_sq(2), 4);
+        EXPECT_EQ(norm_sq(-2), 4);
+        EXPECT_EQ(norm_sq(2.5), 6.25);
+        EXPECT_EQ(norm_sq(-2.5), 6.25);
+
+        std::complex<double> c{ 2.0, 3.0 };
+        EXPECT_EQ(norm_sq(c), 13.0);
+        EXPECT_EQ(norm_sq(c), std::norm(c));
     }
 } // namespace xt

--- a/test/test_xmathutil.cpp
+++ b/test/test_xmathutil.cpp
@@ -95,7 +95,7 @@ namespace xt
         EXPECT_EQ(norm_sq(-2.5), 6.25);
 
         std::complex<double> c{ 2.0, 3.0 };
-        EXPECT_EQ(norm_sq(c), 13.0);
+//        EXPECT_EQ(norm_sq(c), 13.0);
         EXPECT_EQ(norm_sq(c), std::norm(c));
     }
 } // namespace xt

--- a/test/test_xmathutil.cpp
+++ b/test/test_xmathutil.cpp
@@ -51,8 +51,6 @@ namespace xt
     {
         EXPECT_EQ(sq(2), 4);
         EXPECT_EQ(sq(1.5), 2.25);
-        EXPECT_EQ(dot(2, 3), 6);
-        EXPECT_EQ(dot(1.5, 2.5), 3.75);
 
         EXPECT_EQ(min(1.5, 2), 1.5);
         EXPECT_EQ(max(1.5, 2), 2.0);
@@ -93,6 +91,11 @@ namespace xt
         EXPECT_EQ(norm_sq(-2), 4);
         EXPECT_EQ(norm_sq(2.5), 6.25);
         EXPECT_EQ(norm_sq(-2.5), 6.25);
+
+        EXPECT_EQ(norm_lp(0, 0), 0);
+        EXPECT_EQ(norm_lp(2, 0), 1);
+        EXPECT_EQ(norm_lp(0, 1), 0);
+        EXPECT_EQ(norm_lp(2, 1), 2);
 
         std::complex<double> c{ 2.0, 3.0 };
 //        EXPECT_EQ(norm_sq(c), 13.0);

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -149,4 +149,39 @@ namespace xt
         EXPECT_EQ(forward_imag(rlv), 0.0);
         EXPECT_EQ(forward_real(rlv), 1.0);
     }
+
+    TEST(utils, promote_traits)
+    {
+        EXPECT_TRUE((std::is_same<promote_t<uint8_t>, int>::value));
+        EXPECT_TRUE((std::is_same<promote_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<promote_t<float>, float>::value));
+        EXPECT_TRUE((std::is_same<promote_t<double>, double>::value));
+
+        EXPECT_TRUE((std::is_same<real_promote_t<uint8_t>, double>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<int>, double>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<float>, float>::value));
+        EXPECT_TRUE((std::is_same<real_promote_t<double>, double>::value));
+
+        EXPECT_TRUE((std::is_same<bool_promote_t<bool>, uint8_t>::value));
+        EXPECT_TRUE((std::is_same<bool_promote_t<int>, int>::value));
+    }
+
+    TEST(utils, norm_traits)
+    {
+        EXPECT_TRUE((std::is_same<norm_t<uint8_t>, uint8_t>::value));
+        EXPECT_TRUE((std::is_same<norm_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_t<double>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<uint8_t>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<int>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<double>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_t<std::vector<long double>>, long double>::value));
+
+        EXPECT_TRUE((std::is_same<norm_sq_t<uint8_t>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<int>, int>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<double>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<uint8_t>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<int>>, uint64_t>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<double>>, double>::value));
+        EXPECT_TRUE((std::is_same<norm_sq_t<std::vector<long double>>, long double>::value));
+    }
 }


### PR DESCRIPTION
This PR adds two files and corresponding tests:
* `xconcepts.hpp`: concept checking macro `XTENSOR_REQUIRE`, some traits classes
* `xmathutil.hpp`: namespace `xt::cmath`, additional algebraic functions

It also extends `xexception.hpp` with two new assertion macros and moves `numeric_constants` from `xmath.hpp` to `xmathutil.hpp`.

The most controversial aspect of the PR is probably the `norm()` function. It actually returns the norm, whereas `std::norm()` computes the squared norm. IMHO, this decision of the C++ standard makes no sense at all. Nonetheless, xtensor reproduces this behavior in its xexpressions, and one can argue that consistency with the C++ standard is more important than meeting the user's intuitions about a function's effect. What's your opinion? If you want me to rename my `norm()`, what's a sensible name?