### PR TITLE
Add `value_type()` cast operator to xfunction when all arguments are of type xscalar

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -14,8 +14,8 @@
 #define XBUILDER_HPP
 
 #include <array>
-#include <cstddef>
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <utility>
 #include <vector>

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -153,7 +153,7 @@ namespace xt
 
         template <layout_type L, class It1, class It2>
         using select_iterator_impl = std::conditional_t<L == static_layout, It1, It2>;
-        
+
         template <layout_type L>
         using select_iterator = select_iterator_impl<L, storage_iterator, layout_iterator<L>>;
         template <layout_type L>
@@ -162,7 +162,7 @@ namespace xt
         using select_reverse_iterator = select_iterator_impl<L, reverse_storage_iterator, reverse_layout_iterator<L>>;
         template <layout_type L>
         using select_const_reverse_iterator = select_iterator_impl<L, const_reverse_storage_iterator, const_reverse_layout_iterator<L>>;
-        
+
         using iterator = select_iterator<DL>;
         using const_iterator = select_const_iterator<DL>;
         using reverse_iterator = select_reverse_iterator<DL>;

--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -55,4 +55,3 @@ namespace xt
 }
 
 #endif
-

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -153,15 +153,14 @@ namespace xt
 
 #ifdef XTENSOR_ENABLE_ASSERT
 #define XTENSOR_ASSERT(expr) XTENSOR_ASSERT_IMPL(expr, __FILE__, __LINE__)
-#define XTENSOR_ASSERT_IMPL(expr, file, line)                                                       \
-    try                                                                                             \
-    {                                                                                               \
-        expr;                                                                                       \
-    }                                                                                               \
-    catch (std::exception & e)                                                                      \
-    {                                                                                               \
-        throw std::runtime_error(std::string(file) + ':' + std::to_string(line)                     \
-            + ": check failed\n\t" + std::string(e.what()));                                        \
+#define XTENSOR_ASSERT_IMPL(expr, file, line)                                                                                    \
+    try                                                                                                                          \
+    {                                                                                                                            \
+        expr;                                                                                                                    \
+    }                                                                                                                            \
+    catch (std::exception & e)                                                                                                   \
+    {                                                                                                                            \
+        throw std::runtime_error(std::string(file) + ':' + std::to_string(line) + ": check failed\n\t" + std::string(e.what())); \
     }
 #else
 #define XTENSOR_ASSERT(expr)
@@ -169,18 +168,28 @@ namespace xt
 }
 
 #ifdef XTENSOR_ENABLE_ASSERT
-#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)                                                      \
-    if((PREDICATE)) {} else  {                                                                      \
-        throw std::runtime_error(std::string("Assertion error!\n") + MESSAGE +                      \
-                                 "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
+#define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)                                                \
+    if ((PREDICATE))                                                                          \
+    {                                                                                         \
+    }                                                                                         \
+    else                                                                                      \
+    {                                                                                         \
+        throw std::runtime_error(std::string("Assertion error!\n") + MESSAGE +                \
+                                 "\n  " + __FILE__ + '(' + std::to_string(__LINE__) + ")\n"); \
+    }
 
 #else
 #define XTENSOR_ASSERT_MSG(PREDICATE, MESSAGE)
 #endif
 
-#define XTENSOR_PRECONDITION(PREDICATE, MESSAGE)                                                    \
-    if((PREDICATE)) {} else  {                                                                      \
-        throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE +               \
-                                 "\n  " + __FILE__ + '(' +  std::to_string(__LINE__) + ")\n"); }
+#define XTENSOR_PRECONDITION(PREDICATE, MESSAGE)                                              \
+    if ((PREDICATE))                                                                          \
+    {                                                                                         \
+    }                                                                                         \
+    else                                                                                      \
+    {                                                                                         \
+        throw std::runtime_error(std::string("Precondition violation!\n") + MESSAGE +         \
+                                 "\n  " + __FILE__ + '(' + std::to_string(__LINE__) + ")\n"); \
+    }
 
-#endif // XEXCEPTION_HPP
+#endif  // XEXCEPTION_HPP

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -44,7 +44,7 @@ namespace xt
         using derived_type = D;
 
         derived_type& derived_cast() & noexcept;
-        const derived_type& derived_cast() const& noexcept;
+        const derived_type& derived_cast() const & noexcept;
         derived_type derived_cast() && noexcept;
 
     protected:

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -122,6 +122,7 @@ namespace xt
     public:
 
         using self_type = xfunction<F, R, CT...>;
+        using only_scalar = all_xscalar<CT...>;
         using functor_type = typename std::remove_reference<F>::type;
 
         using value_type = R;
@@ -226,6 +227,9 @@ namespace xt
         const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
 
         const_reference data_element(size_type i) const;
+
+        template <class UT = self_type, class = typename std::enable_if<UT::only_scalar::value>::type>
+        operator value_type() const;
 
     private:
 
@@ -622,6 +626,13 @@ namespace xt
     inline auto xfunction<F, R, CT...>::data_element(size_type i) const -> const_reference
     {
         return data_element_impl(std::make_index_sequence<sizeof...(CT)>(), i);
+    }
+
+    template <class F, class R, class... CT>
+    template <class UT, class>
+    inline xfunction<F, R, CT...>::operator value_type() const
+    {
+        return operator()();
     }
 
     template <class F, class R, class... CT>

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -647,7 +647,7 @@ namespace xt
 
     template <class F, class R, class... CT>
     template <std::size_t... I>
-    inline auto xfunction<F, R, CT...>::data_element_impl(std::index_sequence<I...>, size_type i) const ->const_reference
+    inline auto xfunction<F, R, CT...>::data_element_impl(std::index_sequence<I...>, size_type i) const -> const_reference
     {
         return m_f((std::get<I>(m_e).data_element(i))...);
     }

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -819,7 +819,6 @@ namespace xt
     {
         return *static_cast<derived_type*>(this);
     }
-
 }
 
 #endif

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -9,8 +9,8 @@
 #ifndef XITERATOR_HPP
 #define XITERATOR_HPP
 
-#include <array>
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <iterator>
 #include <vector>
@@ -458,7 +458,7 @@ namespace xt
                 index[i] = shape[i] - 1;
                 if (i != 0)
                 {
-                     stepper.reset_back(i);
+                    stepper.reset_back(i);
                 }
             }
         }
@@ -673,7 +673,7 @@ namespace xt
     {
         if (reverse)
         {
-            auto iter_begin = (L == layout_type::row_major)  ? m_index.begin() : m_index.begin() + 1;
+            auto iter_begin = (L == layout_type::row_major) ? m_index.begin() : m_index.begin() + 1;
             auto iter_end = (L == layout_type::row_major) ? m_index.end() - 1 : m_index.end();
             std::transform(iter_begin, iter_end, iter_begin, [](const auto& v) { return v - 1; });
         }

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -428,7 +428,7 @@ namespace xt
     }
 #else
     template <class E, class I, std::size_t N>
-    inline auto amax(E&& e, const I(&axes)[N]) noexcept
+    inline auto amax(E&& e, const I (&axes)[N]) noexcept
     {
         using functor_type = math::maximum<typename std::decay_t<E>::value_type>;
         return reduce(functor_type(), std::forward<E>(e), axes);
@@ -468,7 +468,7 @@ namespace xt
     }
 #else
     template <class E, class I, std::size_t N>
-    inline auto amin(E&& e, const I(&axes)[N]) noexcept
+    inline auto amin(E&& e, const I (&axes)[N]) noexcept
     {
         using functor_type = math::minimum<typename std::decay_t<E>::value_type>;
         return reduce(functor_type(), std::forward<E>(e), axes);

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -51,12 +51,14 @@ namespace xt
             using type = bool;
         };
     }
+
 #define UNARY_MATH_FUNCTOR(NAME)                   \
     template <class T>                             \
     struct NAME##_fun                              \
     {                                              \
         using argument_type = T;                   \
         using result_type = T;                     \
+                                                   \
         constexpr T operator()(const T& arg) const \
         {                                          \
             using std::NAME;                       \
@@ -70,6 +72,7 @@ namespace xt
     {                                                        \
         using argument_type = T;                             \
         using result_type = complex_value_type_t<T>;         \
+                                                             \
         constexpr result_type operator()(const T& arg) const \
         {                                                    \
             using std::NAME;                                 \
@@ -84,6 +87,7 @@ namespace xt
         using first_argument_type = T;                             \
         using second_argument_type = T;                            \
         using result_type = T;                                     \
+                                                                   \
         constexpr T operator()(const T& arg1, const T& arg2) const \
         {                                                          \
             using std::NAME;                                       \
@@ -99,6 +103,7 @@ namespace xt
         using second_argument_type = T;                                           \
         using third_argument_type = T;                                            \
         using result_type = T;                                                    \
+                                                                                  \
         constexpr T operator()(const T& arg1, const T& arg2, const T& arg3) const \
         {                                                                         \
             using std::NAME;                                                      \
@@ -112,6 +117,7 @@ namespace xt
     {                                                                               \
         using argument_type = T;                                                    \
         using result_type = typename xt::detail::bool_functor_return_type<T>::type; \
+                                                                                    \
         constexpr result_type operator()(const T& arg) const                        \
         {                                                                           \
             using std::NAME;                                                        \

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -12,8 +12,8 @@
 #include <type_traits>
 #include <utility>
 
-#include "xtensor/xutils.hpp"
 #include "xtensor/xmath.hpp"
+#include "xtensor/xutils.hpp"
 
 namespace xt
 {
@@ -153,20 +153,20 @@ namespace xt
 
         // Access
         std::add_lvalue_reference_t<CT> value() & noexcept;
-        std::add_lvalue_reference_t<std::add_const_t<CT>> value() const& noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<CT>> value() const & noexcept;
         std::conditional_t<std::is_reference<CT>::value, apply_cv_t<CT, value_type>&, value_type> value() && noexcept;
-        std::conditional_t<std::is_reference<CT>::value, const value_type&, value_type> value() const&& noexcept;
+        std::conditional_t<std::is_reference<CT>::value, const value_type&, value_type> value() const && noexcept;
 
         template <class U>
-        value_type value_or(U&&) const& noexcept;
+        value_type value_or(U&&) const & noexcept;
         template <class U>
-        value_type value_or(U&&) const&& noexcept;
+        value_type value_or(U&&) const && noexcept;
 
         // Access
         std::add_lvalue_reference_t<CB> has_value() & noexcept;
-        std::add_lvalue_reference_t<std::add_const_t<CB>> has_value() const& noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<CB>> has_value() const & noexcept;
         std::conditional_t<std::is_reference<CB>::value, apply_cv_t<CB, flag_type>&, flag_type> has_value() && noexcept;
-        std::conditional_t<std::is_reference<CB>::value, const flag_type&, flag_type> has_value() const&& noexcept;
+        std::conditional_t<std::is_reference<CB>::value, const flag_type&, flag_type> has_value() const && noexcept;
 
         // Swap
         void swap(xoptional& other);
@@ -828,23 +828,23 @@ namespace xt
         return e.has_value() ? bool(NAME(e.value())) : missing<bool>(); \
     }
 
-#define BINARY_OPTIONAL_1(NAME)                                                    \
-    template <class T1, class B1, class T2>                                        \
-    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2)                    \
-    {                                                                              \
-        using std::NAME;                                                           \
-        using value_type = decltype(NAME(e1.value(), e2));                         \
-        return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>();      \
+#define BINARY_OPTIONAL_1(NAME)                                               \
+    template <class T1, class B1, class T2>                                   \
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2)               \
+    {                                                                         \
+        using std::NAME;                                                      \
+        using value_type = decltype(NAME(e1.value(), e2));                    \
+        return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>(); \
     }
 
 
-#define BINARY_OPTIONAL_2(NAME)                                                    \
-    template <class T1, class T2, class B2>                                        \
-    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2)                    \
-    {                                                                              \
-        using std::NAME;                                                           \
-        using value_type = decltype(NAME(e1, e2.value()));                         \
-        return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>();      \
+#define BINARY_OPTIONAL_2(NAME)                                               \
+    template <class T1, class T2, class B2>                                   \
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2)               \
+    {                                                                         \
+        using std::NAME;                                                      \
+        using value_type = decltype(NAME(e1, e2.value()));                    \
+        return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>(); \
     }
 
 #define BINARY_OPTIONAL_12(NAME)                                                                        \
@@ -861,31 +861,31 @@ namespace xt
     BINARY_OPTIONAL_2(NAME)   \
     BINARY_OPTIONAL_12(NAME)
 
-#define TERNARY_OPTIONAL_1(NAME)                                                                     \
-    template <class T1, class B1, class T2, class T3>                                                \
-    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3)                        \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = decltype(NAME(e1.value(), e2, e3));                                       \
-        return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_1(NAME)                                                  \
+    template <class T1, class B1, class T2, class T3>                             \
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3)     \
+    {                                                                             \
+        using std::NAME;                                                          \
+        using value_type = decltype(NAME(e1.value(), e2, e3));                    \
+        return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>(); \
     }
 
-#define TERNARY_OPTIONAL_2(NAME)                                                                     \
-    template <class T1, class T2, class B2, class T3>                                                \
-    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3)                        \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = decltype(NAME(e1, e2.value(), e3));                                       \
-        return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_2(NAME)                                                  \
+    template <class T1, class T2, class B2, class T3>                             \
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3)     \
+    {                                                                             \
+        using std::NAME;                                                          \
+        using value_type = decltype(NAME(e1, e2.value(), e3));                    \
+        return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>(); \
     }
 
-#define TERNARY_OPTIONAL_3(NAME)                                                                     \
-    template <class T1, class T2, class T3, class B3>                                                \
-    inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3)                        \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = decltype(NAME(e1, e2, e3.value()));                                       \
-        return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_3(NAME)                                                  \
+    template <class T1, class T2, class T3, class B3>                             \
+    inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3)     \
+    {                                                                             \
+        using std::NAME;                                                          \
+        using value_type = decltype(NAME(e1, e2, e3.value()));                    \
+        return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>(); \
     }
 
 #define TERNARY_OPTIONAL_12(NAME)                                                                             \

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -785,13 +785,13 @@ namespace xt
     }
 
     template <class CT>
-    inline auto xscalar<CT>::data_element(size_type) noexcept->reference
+    inline auto xscalar<CT>::data_element(size_type) noexcept -> reference
     {
         return m_value;
     }
-    
+
     template <class CT>
-    inline auto xscalar<CT>::data_element(size_type) const noexcept->const_reference
+    inline auto xscalar<CT>::data_element(size_type) const noexcept -> const_reference
     {
         return m_value;
     }
@@ -893,7 +893,7 @@ namespace xt
     }
 
     template <bool is_const, class CT>
-    inline auto xdummy_iterator<is_const, CT>::operator++(int) noexcept -> self_type
+    inline auto xdummy_iterator<is_const, CT>::operator++(int)noexcept -> self_type
     {
         self_type tmp(*this);
         ++(*this);

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -257,8 +257,21 @@ namespace xt
     template <class E>
     using is_xscalar = detail::is_xscalar_impl<E>;
 
+    namespace detail
+    {
+        template <class... E>
+        struct all_xscalar
+        {
+            static constexpr bool value = and_<is_xscalar<std::decay_t<E>>...>::value;
+        };
+    }
+
+    // Note: MSVC bug workaround. Cannot just define 
+    // template <class... E>
+    // using all_xscalar = and_<is_xscalar<std::decay_t<E>>...>;
+
     template <class... E>
-    using all_xscalar = and_<is_xscalar<std::decay_t<E>>...>;
+    using all_xscalar = detail::all_xscalar<E...>;
 
     /******************
      * xref and xcref *

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -241,6 +241,29 @@ namespace xt
     };
 #undef DL
 
+    namespace detail
+    {
+        template <class E>
+        struct is_xscalar_impl : std::false_type
+        {
+        };
+
+        template <class E>
+        struct is_xscalar_impl<xscalar<E>> : std::true_type
+        {
+        };
+    }
+
+    template <class E>
+    using is_xscalar = detail::is_xscalar_impl<E>;
+
+    template <class... E>
+    using all_xscalar = and_<is_xscalar<std::decay_t<E>>...>;
+
+    /******************
+     * xref and xcref *
+     ******************/
+
     template <class T>
     xscalar<T&> xref(T& t);
 

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -217,7 +217,7 @@ namespace xt
     }
 
     template <class T, class A>
-    inline uvector< T, A>::uvector(const allocator_type& alloc) noexcept
+    inline uvector<T, A>::uvector(const allocator_type& alloc) noexcept
         : m_allocator(alloc), p_begin(nullptr), p_end(nullptr)
     {
     }

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -652,7 +652,8 @@ namespace xt
             using value_type = typename xexpression_type::value_type;
             using reference = typename xexpression_type::reference;
 
-            expression_adaptor(CT&& e) : m_e(e)
+            expression_adaptor(CT&& e)
+                : m_e(e)
             {
                 resize_container(m_index, m_e.dimension());
                 m_size = compute_size(m_e.shape());
@@ -664,7 +665,7 @@ namespace xt
                 std::div_t dv{};
                 for (size_type i = 0; i < m_strides.size(); ++i)
                 {
-                    dv = std::div((int) idx, (int) m_strides[i]);
+                    dv = std::div((int)idx, (int)m_strides[i]);
                     idx = static_cast<std::size_t>(dv.rem);
                     m_index[i] = dv.quot;
                 }

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -66,7 +66,7 @@ namespace xt
     /********************************************
      * utility functions for strided containers *
      ********************************************/
-    
+
     template <class C, class It>
     It strided_data_end(const C& c, It end, layout_type l)
     {
@@ -83,7 +83,7 @@ namespace xt
             return end + difference_type(leading_stride - 1);
         }
     }
-     
+
     /******************
      * Implementation *
      ******************/

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1004,35 +1004,34 @@ namespace xt
      * arithmetic type promotion traits *
      ************************************/
 
-        /** @brief Traits class for the result type of mixed arithmetic expressions.
-
-            For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
-            the user that <tt>unsigned char + unsigned char => int</tt>.
-        */
-    template <class ... T>
-	struct promote_type;
+    /** @brief Traits class for the result type of mixed arithmetic expressions.
+     *   For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
+     *  the user that <tt>unsigned char + unsigned char => int</tt>.
+     */
+    template <class... T>
+    struct promote_type;
 
     template <class T>
-	struct promote_type<T>
-	{
+    struct promote_type<T>
+    {
         using type = typename promote_type<T, T>::type;
-	};
+    };
 
     template <class T0, class T1>
-	struct promote_type<T0, T1>
-	{
+    struct promote_type<T0, T1>
+    {
         using type = decltype(*(std::decay_t<T0>*)0 + *(std::decay_t<T1>*)0);
-	};
+    };
 
-    template<class T0, class ... REST>
-	struct promote_type<T0, REST...>
-	{
+    template <class T0, class... REST>
+    struct promote_type<T0, REST...>
+    {
         using type = decltype(*(std::decay_t<T0>*)0 + *(typename promote_type<REST...>::type*)0);
-	};
+    };
 
-        /** @brief Abbreviation of 'typename promote_type<T>::type'.
+    /** @brief Abbreviation of 'typename promote_type<T>::type'.
         */
-    template <class ... T>
+    template <class... T>
     using promote_type_t = typename promote_type<T...>::type;
 
     namespace traits_detail
@@ -1043,35 +1042,35 @@ namespace xt
         using real_promote_type_t = decltype(sqrt(*(std::decay_t<T>*)0));
     }
 
-        /** @brief Result type of algebraic expressions.
-
-            For example, <tt>real_promote_type<int>::type</tt> tells the
-            user that <tt>sqrt(int) => double</tt>.
-        */
+    /** @brief Result type of algebraic expressions.
+     *
+     *   For example, <tt>real_promote_type<int>::type</tt> tells the
+     *   user that <tt>sqrt(int) => double</tt>.
+     */
     template <class T>
-	struct real_promote_type
-	{
+    struct real_promote_type
+    {
         using type = traits_detail::real_promote_type_t<T>;
-	};
+    };
 
-        /** @brief Abbreviation of 'typename real_promote_type<T>::type'.
+    /** @brief Abbreviation of 'typename real_promote_type<T>::type'.
         */
     template <class T>
     using real_promote_type_t = typename real_promote_type<T>::type;
 
-        /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
-
-            This is useful for scientific computing, where a boolean mask array is
-            usually implemented as an array of bytes.
-        */
+    /** @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+     *
+     *  This is useful for scientific computing, where a boolean mask array is
+     *  usually implemented as an array of bytes.
+     */
     template <class T>
-	struct bool_promote_type
-	{
+    struct bool_promote_type
+    {
         using type = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
-	};
+    };
 
-        /** @brief Abbreviation for typename bool_promote_type<T>::type
-        */
+    /** @brief Abbreviation for typename bool_promote_type<T>::type
+      */
     template <class T>
     using bool_promote_type_t = typename bool_promote_type<T>::type;
 
@@ -1079,10 +1078,10 @@ namespace xt
      * type inference for norm and squared norm *
      ********************************************/
 
-    template<class T>
+    template <class T>
     struct norm_type;
 
-    template<class T>
+    template <class T>
     struct squared_norm_type;
 
     namespace traits_detail
@@ -1095,33 +1094,33 @@ namespace xt
         struct norm_of_scalar_impl<T, false>
         {
             static const bool value = false;
-            using norm_type         = void *;
-            using squared_norm_type = void *;
+            using norm_type = void*;
+            using squared_norm_type = void*;
         };
 
         template <class T>
         struct norm_of_scalar_impl<T, true>
         {
             static const bool value = true;
-            using norm_type         = T;
+            using norm_type = T;
             using squared_norm_type = decltype((*(T*)0) * (*(T*)0));
         };
 
         template <class T, bool integral = std::is_integral<T>::value,
-                           bool floating = std::is_floating_point<T>::value>
+                  bool floating = std::is_floating_point<T>::value>
         struct norm_of_array_elements_impl;
 
         template <>
-        struct norm_of_array_elements_impl<void *, false, false>
+        struct norm_of_array_elements_impl<void*, false, false>
         {
-            using norm_type         = void *;
-            using squared_norm_type = void *;
+            using norm_type = void*;
+            using squared_norm_type = void*;
         };
 
         template <class T>
         struct norm_of_array_elements_impl<T, false, false>
         {
-            using norm_type         = typename norm_type<T>::type;
+            using norm_type = typename norm_type<T>::type;
             using squared_norm_type = typename squared_norm_type<T>::type;
         };
 
@@ -1129,49 +1128,49 @@ namespace xt
         struct norm_of_array_elements_impl<T, true, false>
         {
             static_assert(!std::is_same<T, char>::value,
-               "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
 
-            using norm_type         = double;
+            using norm_type = double;
             using squared_norm_type = uint64_t;
         };
 
         template <class T>
         struct norm_of_array_elements_impl<T, false, true>
         {
-            using norm_type         = double;
+            using norm_type = double;
             using squared_norm_type = double;
         };
 
         template <>
         struct norm_of_array_elements_impl<long double, false, true>
         {
-            using norm_type         = long double;
+            using norm_type = long double;
             using squared_norm_type = long double;
         };
 
         template <class ARRAY>
         struct norm_of_vector_impl
         {
-            static void * test(...);
+            static void* test(...);
 
             template <class U>
-            static typename U::value_type test(U*, typename U::value_type * = 0);
+            static typename U::value_type test(U*, typename U::value_type* = 0);
 
             using T = decltype(test((ARRAY*)0));
 
             static const bool value = !std::is_same<T, void*>::value;
 
-            using norm_type         = typename norm_of_array_elements_impl<T>::norm_type;
+            using norm_type = typename norm_of_array_elements_impl<T>::norm_type;
             using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
         };
 
-        template<class U>
+        template <class U>
         struct norm_type_base
         {
             using T = std::decay_t<U>;
 
             static_assert(!std::is_same<T, char>::value,
-               "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
 
             using norm_of_scalar = norm_of_scalar_impl<T>;
             using norm_of_vector = norm_of_vector_impl<T>;
@@ -1180,9 +1179,9 @@ namespace xt
 
             static_assert(value, "norm_type<T> are undefined for type U.");
         };
-    } // namespace traits_detail
+    }  // namespace traits_detail
 
-        /** @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
+    /** @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
 
             Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
             is of type @tparam T. It implements the following rules designed to
@@ -1196,52 +1195,52 @@ namespace xt
            To change the behavior for a case not covered here, specialize the
            <tt>traits_detail::norm_type_base</tt> template.
         */
-    template<class T>
+    template <class T>
     struct norm_type
-    : public traits_detail::norm_type_base<T>
+        : public traits_detail::norm_type_base<T>
     {
         using base_type = traits_detail::norm_type_base<T>;
 
         using type =
             typename std::conditional<base_type::norm_of_vector::value,
-                        typename base_type::norm_of_vector::norm_type,
-                        typename base_type::norm_of_scalar::norm_type>::type;
+                                      typename base_type::norm_of_vector::norm_type,
+                                      typename base_type::norm_of_scalar::norm_type>::type;
     };
 
-        /** Abbreviation of 'typename norm_type<T>::type'.
+    /** Abbreviation of 'typename norm_type<T>::type'.
         */
     template <class T>
     using norm_type_t = typename norm_type<T>::type;
 
-        /** @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
-
-            Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
-            is of type @tparam T. It implements the following rules designed to
-            minimize the potential for overflow:
-                - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
-                - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-                - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
-                - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
-                - @tparam T is a container of some other type: 'type' is the element's squared norm type,
-
-           Containers are recognized by having an embedded typedef 'value_type'.
-           To change the behavior for a case not covered here, specialize the
-           <tt>traits_detail::norm_type_base</tt> template.
-        */
-    template<class T>
+    /** @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
+     *
+     * Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
+     * is of type @tparam T. It implements the following rules designed to
+     * minimize the potential for overflow:
+     *   - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
+     *   - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+     *   - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
+     *   - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
+     *   - @tparam T is a container of some other type: 'type' is the element's squared norm type,
+     *
+     *  Containers are recognized by having an embedded typedef 'value_type'.
+     *  To change the behavior for a case not covered here, specialize the
+     *  <tt>traits_detail::norm_type_base</tt> template.
+     */
+    template <class T>
     struct squared_norm_type
-    : public traits_detail::norm_type_base<T>
+        : public traits_detail::norm_type_base<T>
     {
         using base_type = traits_detail::norm_type_base<T>;
 
         using type =
             typename std::conditional<base_type::norm_of_vector::value,
-                        typename base_type::norm_of_vector::squared_norm_type,
-                        typename base_type::norm_of_scalar::squared_norm_type>::type;
+                                      typename base_type::norm_of_vector::squared_norm_type,
+                                      typename base_type::norm_of_scalar::squared_norm_type>::type;
     };
 
-        /** Abbreviation of 'typename squared_norm_type<T>::type'.
-        */
+    /** Abbreviation of 'typename squared_norm_type<T>::type'.
+     */
     template <class T>
     using squared_norm_type_t = typename squared_norm_type<T>::type;
 }

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -487,4 +487,13 @@ namespace xt
         EXPECT_FALSE(isclose(a, b)(0, 0));
         EXPECT_TRUE(isclose(a, b, 1, 1, true)(0, 0));
     }
+
+    TEST(xmath, scalar_cast)
+    {
+        double arg = 1.0;
+        double res = ::xt::atan(xscalar<double>(arg));
+        EXPECT_EQ(res, std::atan(arg));
+        bool close = ::xt::isclose(1.0, 1.0);
+        EXPECT_EQ(close, true);
+    }
 }

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -81,4 +81,12 @@ namespace xt
         xarray<int> b = a + 5;
         EXPECT_EQ(ref, b);
     }
+
+    TEST(xscalar, all_scalar)
+    {
+        auto tr = all_xscalar<xscalar<double>, xscalar<int>>::value;
+        EXPECT_TRUE(tr);
+        auto fa = all_xscalar<xscalar<double>, xarray<int>>::value;
+        EXPECT_FALSE(fa);
+    }
 }


### PR DESCRIPTION
Fixes #412 

- Even when universal functions are only called with scalar arguments, they continue returning a xfunction object.
- This preserves the laziness. 
- When universal functions are called with scalar arguments only, a cast operator to the underlying scalar return type is made available, so that you can assign the value to a scalar.

1. In this example, close is an xfunction, just like when arguments are arrays

```cpp
auto close = xt::isclose(1.0, 1.0);
```

2. However, it is convertible to bool,  triggering the evaluation, so that you can do

```cpp
bool close = xt::isclose(1.0, 1.0);
```