### PR TITLE
at method added to xscalar

### DIFF
--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -108,11 +108,15 @@ namespace xt
 
         template <class... Args>
         reference operator()(Args...) noexcept;
+        template <class... Args>
+        reference at(Args...);
         reference operator[](const xindex&) noexcept;
         reference operator[](size_type) noexcept;
 
         template <class... Args>
         const_reference operator()(Args...) const noexcept;
+        template <class... Args>
+        const_reference at(Args...) const;
         const_reference operator[](const xindex&) const noexcept;
         const_reference operator[](size_type) const noexcept;
 
@@ -454,6 +458,14 @@ namespace xt
     }
 
     template <class CT>
+    template <class... Args>
+    inline auto xscalar<CT>::at(Args... args) -> reference
+    {
+        check_dimension(shape(), args...);
+        return this->operator()(args...);
+    }
+
+    template <class CT>
     inline auto xscalar<CT>::operator[](const xindex&) noexcept -> reference
     {
         return m_value;
@@ -470,6 +482,14 @@ namespace xt
     inline auto xscalar<CT>::operator()(Args...) const noexcept -> const_reference
     {
         return m_value;
+    }
+
+    template <class CT>
+    template <class... Args>
+    inline auto xscalar<CT>::at(Args... args) const -> const_reference
+    {
+        check_dimension(shape(), args...);
+        return this->operator()(args...);
     }
 
     template <class CT>

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -29,6 +29,12 @@ namespace xt
         EXPECT_EQ(4, x());
     }
 
+    TEST(xscalar, at)
+    {
+        xscalar<int> x(2);
+        EXPECT_ANY_THROW(x.at(0));
+    }
+
     TEST(xscalar, dimension)
     {
         // The dimension of a xscalar is 0


### PR DESCRIPTION
``xscalar::at`` is missing in #420 .