### PR TITLE
xsimd plugged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(XTENSOR_HEADERS
 
 OPTION(XTENSOR_ENABLE_ASSERT "xtensor bound check" OFF)
 OPTION(XTENSOR_CHECK_DIMENSION "xtensor dimension check" OFF)
+OPTION(XTENSOR_USE_XSIMD "simd acceleration for xtensor" OFF)
 OPTION(BUILD_TESTS "xtensor test suite" OFF)
 OPTION(BUILD_BENCHMARK "xtensor benchmark" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
@@ -92,6 +93,13 @@ endif()
 
 if(XTENSOR_CHECK_DIMENSION)
     add_definitions(-DXTENSOR_ENABLE_CHECK_DIMENSION)
+endif()
+
+if(XTENSOR_USE_XSIMD)
+    MESSAGE(STATUS "compiling with simd acceleration")
+    add_definitions(-DXTENSOR_USE_XSIMD)
+    find_package(xsimd REQUIRED)
+    include_directories(${xsimd_INCLUDE_DIRS})
 endif()
 
 if(DEFAULT_COLUMN_MAJOR)

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -188,8 +188,8 @@ namespace xt
             template <class It>
             inline T operator()(const It& /*begin*/, const It& end) const
             {
-                using value_type = typename std::iterator_traits<It>::value_type;
-                return *(end - 1) == *(end - 2) + value_type(m_k) ? T(1) : T(0);
+                using lvalue_type = typename std::iterator_traits<It>::value_type;
+                return *(end - 1) == *(end - 2) + lvalue_type(m_k) ? T(1) : T(0);
             }
 
         private:

--- a/include/xtensor/xcomplex.hpp
+++ b/include/xtensor/xcomplex.hpp
@@ -170,7 +170,12 @@ namespace xt
         {
             using argument_type = T;
             using result_type = decltype(detail::conj(std::declval<T>()));
+            using simd_value_type = xsimd::simd_type<T>;                            \
             constexpr result_type operator()(const T& t) const
+            {
+                return detail::conj(t);
+            }
+            constexpr simd_value_type simd_apply(const simd_value_type& t) const
             {
                 return detail::conj(t);
             }

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -43,87 +43,105 @@ namespace xt
      * Helpers *
      ***********/
 
-    namespace detail
-    {
-        template <class T>
-        struct bool_functor_return_type
-        {
-            using type = bool;
-        };
+#define UNARY_MATH_FUNCTOR_IMPL(NAME, R)                                        \
+    template <class T>                                                          \
+    struct NAME##_fun                                                           \
+    {                                                                           \
+        using return_type = xt::detail::functor_return_type<T, R>;              \
+        using argument_type = T;                                                \
+        using result_type = typename return_type::type;                         \
+        using simd_value_type = xsimd::simd_type<T>;                            \
+        using simd_result_type = typename return_type::simd_type;               \
+        constexpr result_type operator()(const T& arg) const                    \
+        {                                                                       \
+            using std::NAME;                                                    \
+            return NAME(arg);                                                   \
+        }                                                                       \
+        constexpr simd_result_type simd_apply(const simd_value_type& arg) const \
+        {                                                                       \
+            using std::NAME;                                                    \
+            return NAME(arg);                                                   \
+        }                                                                       \
     }
 
-#define UNARY_MATH_FUNCTOR(NAME)                   \
-    template <class T>                             \
-    struct NAME##_fun                              \
-    {                                              \
-        using argument_type = T;                   \
-        using result_type = T;                     \
-                                                   \
-        constexpr T operator()(const T& arg) const \
-        {                                          \
-            using std::NAME;                       \
-            return NAME(arg);                      \
-        }                                          \
+#define UNARY_MATH_FUNCTOR(NAME) UNARY_MATH_FUNCTOR_IMPL(NAME, T)
+#define UNARY_BOOL_FUNCTOR(NAME) UNARY_MATH_FUNCTOR_IMPL(NAME, bool)
+
+#define UNARY_MATH_FUNCTOR_COMPLEX_REDUCING(NAME)                               \
+    template <class T>                                                          \
+    struct NAME##_fun                                                           \
+    {                                                                           \
+        using argument_type = T;                                                \
+        using result_type = complex_value_type_t<T>;                            \
+        using simd_value_type = argument_type;                                  \
+        using simd_result_type = result_type;                                   \
+        constexpr result_type operator()(const T& arg) const                    \
+        {                                                                       \
+            using std::NAME;                                                    \
+            return NAME(arg);                                                   \
+        }                                                                       \
+        constexpr simd_result_type simd_apply(const simd_value_type& arg) const \
+        {                                                                       \
+            using std::NAME;                                                    \
+            return NAME(arg);                                                   \
+        }                                                                       \
     }
 
-#define UNARY_MATH_FUNCTOR_COMPLEX_REDUCING(NAME)            \
-    template <class T>                                       \
-    struct NAME##_fun                                        \
-    {                                                        \
-        using argument_type = T;                             \
-        using result_type = complex_value_type_t<T>;         \
-                                                             \
-        constexpr result_type operator()(const T& arg) const \
-        {                                                    \
-            using std::NAME;                                 \
-            return NAME(arg);                                \
-        }                                                    \
+#define BINARY_MATH_FUNCTOR_IMPL(NAME, R)                                        \
+    template <class T>                                                           \
+    struct NAME##_fun                                                            \
+    {                                                                            \
+        using return_type = xt::detail::functor_return_type<T, R>;               \
+        using first_argument_type = T;                                           \
+        using second_argument_type = T;                                          \
+        using result_type = typename return_type::type;                          \
+        using simd_value_type = xsimd::simd_type<T>;                             \
+        using simd_result_type = typename return_type::simd_type;                \
+        constexpr result_type operator()(const T& arg1, const T& arg2) const     \
+        {                                                                        \
+            using std::NAME;                                                     \
+            return NAME(arg1, arg2);                                             \
+        }                                                                        \
+        constexpr simd_result_type simd_apply(const simd_value_type& arg1,       \
+                                              const simd_value_type& arg2) const \
+        {                                                                        \
+            using std::NAME;                                                     \
+            return NAME(arg1, arg2);                                             \
+        }                                                                        \
     }
 
-#define BINARY_MATH_FUNCTOR(NAME)                                  \
-    template <class T>                                             \
-    struct NAME##_fun                                              \
-    {                                                              \
-        using first_argument_type = T;                             \
-        using second_argument_type = T;                            \
-        using result_type = T;                                     \
-                                                                   \
-        constexpr T operator()(const T& arg1, const T& arg2) const \
-        {                                                          \
-            using std::NAME;                                       \
-            return NAME(arg1, arg2);                               \
-        }                                                          \
+#define BINARY_MATH_FUNCTOR(NAME) BINARY_MATH_FUNCTOR_IMPL(NAME, T)
+#define BINARY_BOOL_FUNCTOR(NAME) BINARY_MATH_FUNCTOR_IMPL(NAME, bool)
+
+#define TERNARY_MATH_FUNCTOR_IMPL(NAME, R)                                       \
+    template <class T>                                                           \
+    struct NAME##_fun                                                            \
+    {                                                                            \
+        using return_type = xt::detail::functor_return_type<T, R>;               \
+        using first_argument_type = T;                                           \
+        using second_argument_type = T;                                          \
+        using third_argument_type = T;                                           \
+        using result_type = typename return_type::type;                          \
+        using simd_value_type = xsimd::simd_type<T>;                             \
+        using simd_result_type = typename return_type::simd_type;                \
+        constexpr result_type operator()(const T& arg1,                          \
+                                         const T& arg2,                          \
+                                          const T& arg3) const                   \
+        {                                                                        \
+            using std::NAME;                                                     \
+            return NAME(arg1, arg2, arg3);                                       \
+        }                                                                        \
+        constexpr simd_result_type simd_apply(const simd_value_type& arg1,       \
+                                              const simd_value_type& arg2,       \
+                                              const simd_value_type& arg3) const \
+        {                                                                        \
+            using std::NAME;                                                     \
+            return NAME(arg1, arg2, arg3);                                       \
+        }                                                                        \
     }
 
-#define TERNARY_MATH_FUNCTOR(NAME)                                                \
-    template <class T>                                                            \
-    struct NAME##_fun                                                             \
-    {                                                                             \
-        using first_argument_type = T;                                            \
-        using second_argument_type = T;                                           \
-        using third_argument_type = T;                                            \
-        using result_type = T;                                                    \
-                                                                                  \
-        constexpr T operator()(const T& arg1, const T& arg2, const T& arg3) const \
-        {                                                                         \
-            using std::NAME;                                                      \
-            return NAME(arg1, arg2, arg3);                                        \
-        }                                                                         \
-    }
-
-#define UNARY_BOOL_FUNCTOR(NAME)                                                    \
-    template <class T>                                                              \
-    struct NAME##_fun                                                               \
-    {                                                                               \
-        using argument_type = T;                                                    \
-        using result_type = typename xt::detail::bool_functor_return_type<T>::type; \
-                                                                                    \
-        constexpr result_type operator()(const T& arg) const                        \
-        {                                                                           \
-            using std::NAME;                                                        \
-            return NAME(arg);                                                       \
-        }                                                                           \
-    }
+#define TERNARY_MATH_FUNCTOR(NAME) TERNARY_MATH_FUNCTOR_IMPL(NAME, T)
+#define TERNARY_BOOL_FUNCTOR(NAME) TERNARY_MATH_FUNCTOR_IMPL(NAME, bool)
 
     namespace math
     {
@@ -174,10 +192,15 @@ namespace xt
         UNARY_BOOL_FUNCTOR(isnan);
     }
 
-#undef UNARY_BOOL_FUNCTOR
-#undef TERNARY_MATH_FUNCTOR
-#undef BINARY_MATH_FUNCTOR
 #undef UNARY_MATH_FUNCTOR
+#undef UNARY_BOOL_FUNCTOR
+#undef UNARY_MATH_FUNCTOR_IMPL
+#undef BINARY_MATH_FUNCTOR
+#undef BINARY_BOOL_FUNCTOR
+#undef BINARY_MATH_FUNCTOR_IMPL
+#undef TERNARY_MATH_FUNCTOR
+#undef TERNARY_BOOL_FUNCTOR
+#undef TERNARY_MATH_FUNCTOR_IMPL
 #undef UNARY_MATH_FUNCTOR_COMPLEX_REDUCING
 
     /*******************
@@ -335,10 +358,16 @@ namespace xt
         struct minimum
         {
             using result_type = T;
-
+            using simd_value_type = xsimd::simd_type<T>;
+            
             constexpr result_type operator()(const T& t1, const T& t2) const noexcept
             {
                 return (t1 < t2) ? t1 : t2;
+            }
+
+            constexpr simd_value_type simd_apply(const simd_value_type& t1, const simd_value_type& t2) const noexcept
+            {
+                return xsimd::select(t1 < t2, t1, t2);
             }
         };
 
@@ -346,10 +375,16 @@ namespace xt
         struct maximum
         {
             using result_type = T;
+            using simd_value_type = xsimd::simd_type<T>;
 
             constexpr result_type operator()(const T& t1, const T& t2) const noexcept
             {
                 return (t1 > t2) ? t1 : t2;
+            }
+
+            constexpr simd_value_type simd_apply(const simd_value_type& t1, const simd_value_type& t2) const noexcept
+            {
+                return xsimd::select(t1 > t2, t1, t2);
             }
         };
 
@@ -360,9 +395,18 @@ namespace xt
             using second_argument_type = T;
             using third_argument_type = T;
             using result_type = T;
+            using simd_value_type = xsimd::simd_type<T>;
+            
             constexpr T operator()(const T& v, const T& lo, const T& hi) const
             {
                 return v < lo ? lo : hi < v ? hi : v;
+            }
+
+            constexpr simd_value_type simd_apply(const simd_value_type& v,
+                                                 const simd_value_type& lo,
+                                                 const simd_value_type& hi) const
+            {
+                return xsimd::select(v < lo, lo, xsimd::select(hi < v, hi, v));
             }
         };
     }

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -47,9 +47,10 @@ namespace xt
         };
 
         template <class CT, class CB>
-        struct bool_functor_return_type<xoptional<CT, CB>>
+        struct functor_return_type<xoptional<CT, CB>, bool>
         {
             using type = xoptional<bool>;
+            using simd_type = xoptional<bool>;
         };
     }
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -16,6 +16,7 @@
 #include "xexpression.hpp"
 #include "xiterable.hpp"
 #include "xlayout.hpp"
+#include "xtensor_simd.hpp"
 
 namespace xt
 {
@@ -60,6 +61,7 @@ namespace xt
         using const_pointer = const value_type*;
         using size_type = std::size_t;
         using difference_type = std::ptrdiff_t;
+        using simd_value_type = xsimd::simd_type<value_type>;
 
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
@@ -235,6 +237,11 @@ namespace xt
 
         reference data_element(size_type i) noexcept;
         const_reference data_element(size_type i) const noexcept;
+
+        template <class align, class simd = simd_value_type>
+        void store_simd(size_type i, const simd& e);
+        template <class align, class simd = simd_value_type>
+        simd load_simd(size_type i) const;
 
     private:
 
@@ -850,6 +857,20 @@ namespace xt
     inline auto xscalar<CT>::data_element(size_type) const noexcept -> const_reference
     {
         return m_value;
+    }
+
+    template <class CT>
+    template <class align, class simd>
+    inline void xscalar<CT>::store_simd(size_type, const simd& e)
+    {
+        m_value = static_cast<value_type>(e[0]);
+    }
+
+    template <class CT>
+    template <class align, class simd>
+    inline auto xscalar<CT>::load_simd(size_type) const -> simd
+    {
+        return xsimd::set_simd<value_type, typename simd::value_type>(m_value);
     }
 
     template <class T>

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -15,6 +15,7 @@
 #include "xlayout.hpp"
 #include "xstorage.hpp"
 #include "xtensor_config.hpp"
+#include "xtensor_simd.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xtensor_simd.hpp
+++ b/include/xtensor/xtensor_simd.hpp
@@ -1,0 +1,145 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_SIMD_HPP
+#define XTENSOR_SIMD_HPP
+
+#include <vector>
+#include "xstorage.hpp"
+
+#ifdef XTENSOR_USE_XSIMD
+
+#include "xsimd/xsimd.hpp"
+
+#else // XTENSOR_USE_XSIMD
+
+namespace xsimd
+{
+    struct aligned_mode {};
+    struct unaligned_mode {};
+
+    template <class A>
+    struct allocator_alignment
+    {
+        using type = unaligned_mode;
+    };
+
+    template <class A>
+    using allocator_alignment_t = typename allocator_alignment<A>::type;
+
+    template <class C>
+    struct container_alignment
+    {
+        using type = unaligned_mode;
+    };
+
+    template <class C>
+    using container_alignment_t = typename container_alignment<C>::type;
+
+    template <class T>
+    struct simd_traits
+    {
+        using type = T;
+        using bool_type = bool;
+        static constexpr size_t size = 1;
+    };
+
+    template <class T>
+    struct revert_simd_traits
+    {
+        using type = T;
+        static constexpr size_t size = simd_traits<type>::size;
+    };
+
+    template <class T>
+    using simd_type = typename simd_traits<T>::type;
+
+    template <class T>
+    using simd_bool_type = typename simd_traits<T>::bool_type;
+
+    template <class T>
+    using revert_simd_type = typename revert_simd_traits<T>::type;
+
+    template <class T>
+    inline simd_type<T> set_simd(const T& value)
+    {
+        return value;
+    }
+
+    template <class T>
+    inline simd_type<T> load_simd(const T* src, aligned_mode)
+    {
+        return *src;
+    }
+
+    template <class T>
+    inline simd_type<T> load_simd(const T* src, unaligned_mode)
+    {
+        return *src;
+    }
+
+    template <class T>
+    inline void store_simd(T* dst, const simd_type<T>& src, aligned_mode)
+    {
+        *dst = src;
+    }
+
+    template <class T>
+    inline void store_simd(T* dst, const simd_type<T>& src, unaligned_mode)
+    {
+        *dst = src;
+    }
+
+    template <class T>
+    inline T select(bool cond, const T& t1, const T& t2)
+    {
+        return cond ? t1 : t2;
+    }
+
+    template <class T>
+    inline std::size_t get_alignment_offset(const T* /*p*/, std::size_t size, std::size_t /*block_size*/)
+    {
+        return size;
+    }
+}
+
+#endif // XTENSOR_USE_XSIMD
+
+namespace xt
+{
+    using xsimd::aligned_mode;
+    using xsimd::unaligned_mode;
+    struct inner_aligned_mode {};
+
+    namespace detail
+    {
+        template <class A1, class A2>
+        struct driven_align_mode_impl
+        {
+            using type = std::conditional_t<std::is_same<A1, A2>::value, A1, ::xsimd::unaligned_mode>;
+        };
+
+        template <class A>
+        struct driven_align_mode_impl<inner_aligned_mode, A>
+        {
+            using type = A;
+        };
+    }
+
+    template <class A1, class A2>
+    struct driven_align_mode
+    {
+        using type = typename detail::driven_align_mode_impl<A1, A2>::type;
+    };
+
+    template <class A1, class A2>
+    using driven_align_mode_t = typename detail::driven_align_mode_impl<A1, A2>::type;
+
+}
+
+#endif

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -90,6 +90,12 @@ namespace xt
     template <class T, std::size_t N>
     constexpr std::size_t sequence_size(const T (&a)[N]);
 
+    namespace detail
+    {
+        template <class T>
+        using void_t = void;
+    }
+
     /*******************************
      * remove_class implementation *
      *******************************/


### PR DESCRIPTION
simd acceleration is disabled by default. To enable it, one needs to add `-DXTENSOR_USE_XSIMD` to the cmake command line. This requires `xsimd` to be installed.