### PR TITLE
Added conditional cast in assigments

### DIFF
--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -81,6 +81,31 @@ namespace xt
             std::is_pointer<T>::value ||
             std::is_same<decltype(test((V*)0)), int>::value;
     };
+
+        /** @brief Check if a conversion may loose information.
+
+            @tparam FROM source type
+            @tparam TO target type
+
+            When data is converted from a big type (e.g. <tt>int64_t</tt> or <tt>double</tt>)
+            to a smaller type (e.g. <tt>int32_t</tt>), most compilers issue a 'possible loss of data'
+            warning. This metafunction allows you to detect these situations and take appropriate
+            actions.
+
+            If loss of data may occur, member <tt>is_narrowing_conversion::value</tt> is true. Currently,
+            the check is only implemented for built-in types, i.e. types where <tt>std::is_arithmetic</tt>
+            is true.
+        */
+    template <class FROM, class TO>
+    struct is_narrowing_conversion
+    {
+        using argument_type = std::decay_t<FROM>;
+        using result_type = std::decay_t<TO>;
+
+        static const bool value = std::is_arithmetic<result_type>::value &&
+            (sizeof(result_type) < sizeof(argument_type) ||
+            (std::is_integral<result_type>::value && std::is_floating_point<argument_type>::value));
+    };
 } // namespace xt
 
 #endif // XCONCEPTS_HPP

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1006,6 +1006,46 @@ namespace xt
 
     #endif
 
+    /*************************
+     * conditional type cast *
+     *************************/
+
+    template <bool condition, class T>
+    struct conditional_cast_functor;
+
+    template <class T>
+    struct conditional_cast_functor<false, T>
+    {
+        template <class U>
+        inline U && operator()(U && u) const
+        {
+            return std::forward<U>(u);
+        }
+    };
+
+    template <class T>
+    struct conditional_cast_functor<true, T>
+    {
+        template <class U>
+        inline auto operator()(U && u) const
+        {
+            return static_cast<T>(std::forward<U>(u));
+        }
+    };
+
+    /** @brief Perform a type cast when a condition is true.
+        If <tt>condition</tt> is true, return <tt>static_cast<T>(u)</tt>,
+        otherwise return <tt>u</tt> unchanged. This is useful when an unconditional
+        static_cast would force undesired type conversions in some situations where
+        an error or warning would be desired. The condition determines when the
+        explicit cast is ok.
+     */
+    template <bool condition, class T, class U>
+    inline auto conditional_cast(U && u)
+    {
+        return conditional_cast_functor<condition, T>()(std::forward<U>(u));
+    };
+
     /************************************
      * arithmetic type promotion traits *
      ************************************/

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -25,6 +25,11 @@ namespace xt
         ASSERT_EQ(1.0, m(0, 1));
         xarray<double> m_assigned = m;
         ASSERT_EQ(1.0, m_assigned(0, 1));
+
+        // assignment with narrowing type cast
+        // (check that the compiler doesn't issue a warning)
+        xarray<uint8_t> c = m;
+        ASSERT_EQ(1, c(0, 1));
     }
 
     TEST(xbuilder, arange_simple)
@@ -332,9 +337,9 @@ namespace xt
 
     TEST(xbuilder, diagonal_advanced)
     {
-        xarray<double> e = {{{{0, 1, 2}, {3, 4, 5}}, 
+        xarray<double> e = {{{{0, 1, 2}, {3, 4, 5}},
                              {{6, 7, 8}, {9, 10, 11}}},
-                            {{{12, 13, 14}, {15, 16, 17}}, 
+                            {{{12, 13, 14}, {15, 16, 17}},
                              {{18, 19, 20}, {21, 22, 23}}}};
 
         xarray<double> d1 = xt::diagonal(e);

--- a/test/test_xconcepts.cpp
+++ b/test/test_xconcepts.cpp
@@ -10,7 +10,7 @@
 #include "xtensor/xconcepts.hpp"
 
 namespace xt
-{    
+{
     template <class T,
               XTENSOR_REQUIRE<std::is_integral<T>::value>>
     int test_concept_check(T) {}
@@ -42,6 +42,26 @@ namespace xt
         {
             bool is_iter = iterator_concept<decltype(std::vector<int>().begin())>::value;
             EXPECT_TRUE(is_iter);
+        }
+    }
+
+    TEST(concepts, is_narrowing_conversion)
+    {
+        {
+            bool is_narrowing = is_narrowing_conversion<int32_t, uint8_t>::value;
+            EXPECT_TRUE(is_narrowing);
+        }
+        {
+            bool is_narrowing = is_narrowing_conversion<double, uint32_t>::value;
+            EXPECT_TRUE(is_narrowing);
+        }
+        {
+            bool is_narrowing = is_narrowing_conversion<uint8_t, int32_t>::value;
+            EXPECT_FALSE(is_narrowing);
+        }
+        {
+            bool is_narrowing = is_narrowing_conversion<uint32_t, double>::value;
+            EXPECT_FALSE(is_narrowing);
         }
     }
 

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -150,6 +150,12 @@ namespace xt
         EXPECT_EQ(forward_real(rlv), 1.0);
     }
 
+    TEST(utils, conditional_cast)
+    {
+        EXPECT_TRUE((std::is_same<decltype(conditional_cast<false, double>(1)), int>::value));
+        EXPECT_TRUE((std::is_same<decltype(conditional_cast<true, double>(1)), double>::value));
+    }
+
     TEST(utils, promote_traits)
     {
         EXPECT_TRUE((std::is_same<promote_type_t<uint8_t>, int>::value));


### PR DESCRIPTION
When compiling an expression like
```c++
xarray<uint8_t> c = ones<uint32_t>({100});
```
compilers issue a "possible loss of data" warning. This PR assumes that users know what they are doing and adds a conditional type cast for narrowing conversions of built-in types to `data_assigner::run()` (other conversions remain untouched).

While the above example looks contrived, warnings for narrowing casts are quite common in mixed-type expressions and will be exposed in my upcoming fix for #429 and related issues.