### PR TITLE
V2: Improved result type inference for xexpressions

### DIFF
--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -65,6 +65,12 @@ namespace xt
 #define UNARY_OPERATOR_FUNCTOR(NAME, OP) UNARY_OPERATOR_FUNCTOR_IMPL(NAME, OP, T)
 #define UNARY_BOOL_OPERATOR_FUNCTOR(NAME, OP) UNARY_OPERATOR_FUNCTOR_IMPL(NAME, OP, bool)
 
+    /* In this macro, T is assumed to be the promote_type of all arguments.
+       Nonetheless, operator() is implemented as a function template,
+       because automatic conversion of the actual argument types to T may
+       cause 'possible loss of data' warnings, e.g. when T is double and an
+       argument is uint64_t.
+    */
 #define BINARY_OPERATOR_FUNCTOR_IMPL(NAME, OP, R)                                \
     template <class T>                                                           \
     struct NAME                                                                  \
@@ -75,7 +81,8 @@ namespace xt
         using result_type = typename return_type::type;                          \
         using simd_value_type = xsimd::simd_type<T>;                             \
         using simd_result_type = typename return_type::simd_type;                \
-        constexpr result_type operator()(const T& arg1, const T& arg2) const     \
+        template <class T1, class T2>                                            \
+        constexpr result_type operator()(const T1& arg1, const T2& arg2) const   \
         {                                                                        \
             return (arg1 OP arg2);                                               \
         }                                                                        \
@@ -494,7 +501,7 @@ namespace xt
     /**
      * @ingroup logical_operators
      * @brief return vector of indices where T is not zero
-     * 
+     *
      * @param arr input array
      * @return vector of \a index_types where arr is not equal to zero
      */
@@ -543,7 +550,7 @@ namespace xt
      * @ingroup logical_operators
      * @brief return vector of indices where condition is true
      *        (equivalent to \a nonzero(condition))
-     * 
+     *
      * @param condition input array
      * @return vector of \a index_types where condition is not equal to zero
      */

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -31,7 +31,6 @@
 
 namespace xt
 {
-
     /**********
      * reduce *
      **********/
@@ -80,9 +79,12 @@ namespace xt
      * a reducing function to an \ref xexpression over the specified
      * axes.
      *
-     * @tparam F the function type
+     * @tparam F a binary function type
      * @tparam CT the closure type of the \ref xexpression to reduce
      * @tparam X the list of axes
+     *
+     * The reducer's result_type is deduced from the result type of function @tparam F
+     * when called with elements of the expression @tparam CT.
      *
      * @sa reduce
      */
@@ -97,7 +99,8 @@ namespace xt
         using xexpression_type = std::decay_t<CT>;
         using axes_type = X;
 
-        using value_type = typename xexpression_type::value_type;
+        using substepper_type = typename xexpression_type::const_stepper;
+        using value_type = std::decay_t<decltype(std::declval<functor_type>()(**(substepper_type*)0, **(substepper_type*)0))>;
         using reference = value_type;
         using const_reference = value_type;
         using pointer = value_type*;

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -907,6 +907,42 @@ namespace xt
     template <class... T>
     using promote_type_t = typename promote_type<T...>::type;
 
+    /** @brief Traits class to find the biggest type of the same kind.
+     *   For example, <tt>big_promote_type<unsigned char>::type</tt> is <tt>unsigned long long</tt>.
+     *   The default implementation only supports built-in types and <tt>std::complex</tt>. All
+     *   other types remain unchanged unless <tt>big_promote_type</tt> gets specialized for them.
+     */
+    template <class T>
+    struct big_promote_type
+    {
+      private:
+        using V = std::decay_t<T>;
+        static const bool is_arithmetic = std::is_arithmetic<V>::value;
+        static const bool is_signed = std::is_signed<V>::value;
+        static const bool is_integral = std::is_integral<V>::value;
+        static const bool is_long_double = std::is_same<V, long double>::value;
+
+      public:
+        using type = std::conditional_t<is_arithmetic,
+                        std::conditional_t<is_integral,
+                            std::conditional_t<is_signed, long long, unsigned long long>,
+                            std::conditional_t<is_long_double, long double, double>
+                        >,
+                        V
+                     >;
+    };
+
+    template <class T>
+    struct big_promote_type<std::complex<T>>
+    {
+        using type = std::complex<typename big_promote_type<T>::type>;
+    };
+
+    /** @brief Abbreviation of 'typename big_promote_type<T>::type'.
+     */
+    template <class T>
+    using big_promote_type_t = typename big_promote_type<T>::type;
+
     namespace traits_detail
     {
         using std::sqrt;

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -18,6 +18,140 @@ namespace xt
     using std::size_t;
     using shape_type = std::vector<size_t>;
 
+    /*******************
+     * type conversion *
+     *******************/
+
+#define CHECK_RESULT_TYPE(EXPRESSION, EXPECTED_TYPE)                                  \
+    {                                                                                \
+        using result_type = typename std::decay_t<decltype(EXPRESSION)>::value_type; \
+        EXPECT_TRUE((std::is_same<result_type, EXPECTED_TYPE>::value));              \
+    }
+
+    TEST(xmath, result_type)
+    {
+        shape_type shape = {3, 2};
+        xarray<unsigned char> auchar(shape);
+        xarray<short> ashort(shape);
+        xarray<int> aint(shape);
+        xarray<unsigned int> auint(shape);
+        xarray<unsigned long long> aulong(shape);
+        xarray<float> afloat(shape);
+        xarray<double> adouble(shape);
+        xarray<std::complex<float>> afcomplex(shape);
+        xarray<std::complex<double>> adcomplex(shape);
+
+        /*****************
+         * unsigned char *
+         *****************/
+        CHECK_RESULT_TYPE(auchar + auchar, int);
+        CHECK_RESULT_TYPE(2 * auchar, int);
+        CHECK_RESULT_TYPE(2.0 * auchar, double);
+        CHECK_RESULT_TYPE(sqrt(auchar), double);
+        CHECK_RESULT_TYPE(abs(auchar), int);
+        CHECK_RESULT_TYPE(sum(auchar), unsigned long long);
+        CHECK_RESULT_TYPE(mean(auchar), double);
+
+        /*********
+         * short *
+         *********/
+        CHECK_RESULT_TYPE(ashort + ashort, int);
+        CHECK_RESULT_TYPE(2 * ashort, int);
+        CHECK_RESULT_TYPE(2.0 * ashort, double);
+        CHECK_RESULT_TYPE(sqrt(ashort), double);
+        CHECK_RESULT_TYPE(abs(ashort), int);
+        CHECK_RESULT_TYPE(sum(ashort), long long);
+        CHECK_RESULT_TYPE(mean(ashort), double);
+
+        /*******
+         * int *
+         *******/
+        CHECK_RESULT_TYPE(aint + aint, int);
+        CHECK_RESULT_TYPE(2 * aint, int);
+        CHECK_RESULT_TYPE(2.0 * aint, double);
+        CHECK_RESULT_TYPE(sqrt(aint), double);
+        CHECK_RESULT_TYPE(abs(aint), int);
+        CHECK_RESULT_TYPE(sum(aint), long long);
+        CHECK_RESULT_TYPE(mean(aint), double);
+
+        /****************
+         * unsigned int *
+         ****************/
+        CHECK_RESULT_TYPE(auint + auint, unsigned int);
+        CHECK_RESULT_TYPE(2 * auint, unsigned int);
+        CHECK_RESULT_TYPE(2.0 * auint, double);
+        CHECK_RESULT_TYPE(sqrt(auint), double);
+        CHECK_RESULT_TYPE(abs(auint), unsigned int);
+        CHECK_RESULT_TYPE(sum(auint), unsigned long long);
+        CHECK_RESULT_TYPE(mean(auint), double);
+
+        /**********************
+         * unsigned long long *
+         **********************/
+        CHECK_RESULT_TYPE(aulong + aulong, unsigned long long);
+        CHECK_RESULT_TYPE(2 * aulong, unsigned long long);
+        CHECK_RESULT_TYPE(2.0 * aulong, double);
+        CHECK_RESULT_TYPE(sqrt(aulong), double);
+        CHECK_RESULT_TYPE(abs(aulong), unsigned long long);
+        CHECK_RESULT_TYPE(sum(aulong), unsigned long long);
+        CHECK_RESULT_TYPE(mean(aulong), double);
+
+        /*********
+         * float *
+         *********/
+        CHECK_RESULT_TYPE(afloat + afloat, float);
+        CHECK_RESULT_TYPE(2.0f * afloat, float);
+        CHECK_RESULT_TYPE(2.0 * afloat, double);
+        CHECK_RESULT_TYPE(sqrt(afloat), float);
+        CHECK_RESULT_TYPE(abs(afloat), float);
+        CHECK_RESULT_TYPE(sum(afloat), double);
+        CHECK_RESULT_TYPE(mean(afloat), double);
+
+        /**********
+         * double *
+         **********/
+        CHECK_RESULT_TYPE(adouble + adouble, double);
+        CHECK_RESULT_TYPE(2.0 * adouble, double);
+        CHECK_RESULT_TYPE(sqrt(adouble), double);
+        CHECK_RESULT_TYPE(abs(adouble), double);
+        CHECK_RESULT_TYPE(sum(adouble), double);
+        CHECK_RESULT_TYPE(mean(adouble), double);
+
+        /***********************
+         * std::complex<float> *
+         ***********************/
+        CHECK_RESULT_TYPE(afcomplex + afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(std::complex<float>(2.0) * afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(2.0f * afcomplex, std::complex<float>);
+        CHECK_RESULT_TYPE(sqrt(afcomplex), std::complex<float>);
+        CHECK_RESULT_TYPE(abs(afcomplex), float);
+        CHECK_RESULT_TYPE(sum(afcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(mean(afcomplex), std::complex<double>);
+
+        /************************
+         * std::complex<double> *
+         ************************/
+        CHECK_RESULT_TYPE(adcomplex + adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(std::complex<double>(2.0) * adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(2.0 * adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(sqrt(adcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(abs(adcomplex), double);
+        CHECK_RESULT_TYPE(sum(adcomplex), std::complex<double>);
+        CHECK_RESULT_TYPE(mean(adcomplex), std::complex<double>);
+
+        /***************
+         * mixed types *
+         ***************/
+        CHECK_RESULT_TYPE(auchar + aint, int);
+        CHECK_RESULT_TYPE(ashort + aint, int);
+        CHECK_RESULT_TYPE(aulong + aint, unsigned long long);
+        CHECK_RESULT_TYPE(afloat + aint, float);
+        CHECK_RESULT_TYPE(adouble + aint, double);
+        CHECK_RESULT_TYPE(adouble + adcomplex, std::complex<double>);
+        CHECK_RESULT_TYPE(aulong + adouble, double);
+    }
+
+
     /********************
      * Basic operations *
      ********************/

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -111,6 +111,10 @@ namespace xt
         xarray<double> expectedv1 = 2 * ones<double>({4});
         xarray<double> resv1 = sum(v, {1});
         EXPECT_EQ(expectedv1, resv1);
+
+        // check that there is no overflow
+        xarray<uint8_t> c = ones<uint8_t>({1000});
+        EXPECT_EQ(1000, sum(c)());
     }
 
     TEST(xreducer, sum_all)
@@ -119,6 +123,13 @@ namespace xt
         auto res = sum(features.m_a);
         double expected = 732;
         EXPECT_EQ(res(), expected);
+    }
+
+    TEST(xreducer, prod)
+    {
+        // check that there is no overflow
+        xarray<uint8_t> c = 2*ones<uint8_t>({34});
+        EXPECT_EQ(1ULL << 34, prod(c)());
     }
 
     TEST(xreducer, mean)
@@ -136,5 +147,8 @@ namespace xt
         EXPECT_EQ(mean_all(), expect_all());
         EXPECT_TRUE(all(equal(mean0, expect0)));
         EXPECT_TRUE(all(equal(mean1, expect1)));
+
+        xarray<uint8_t> c = { 1, 2};
+        EXPECT_EQ(mean(c)(), 1.5);
     }
 }

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -147,6 +147,11 @@ namespace xt
         EXPECT_TRUE((std::is_same<promote_type_t<float>, float>::value));
         EXPECT_TRUE((std::is_same<promote_type_t<double>, double>::value));
 
+        EXPECT_TRUE((std::is_same<big_promote_type_t<uint8_t>, unsigned long long>::value));
+        EXPECT_TRUE((std::is_same<big_promote_type_t<int>, long long>::value));
+        EXPECT_TRUE((std::is_same<big_promote_type_t<float>, double>::value));
+        EXPECT_TRUE((std::is_same<big_promote_type_t<double>, double>::value));
+
         EXPECT_TRUE((std::is_same<real_promote_type_t<uint8_t>, double>::value));
         EXPECT_TRUE((std::is_same<real_promote_type_t<int>, double>::value));
         EXPECT_TRUE((std::is_same<real_promote_type_t<float>, float>::value));


### PR DESCRIPTION
same as #433, but rebased on latest master (including xtl migration)

fixes #429 

Summary of the changes:
* xutils.hpp: add `big_promote_type_t` to find the biggest type of the same kind
* xmath.hpp: use `decltype()` to determine the result type of algebraic functions
* xmath.hpp: use `big_promote_type_t` as result type of `sum()` and `prod()`
* xmath.hpp: enforce floating-point results in `mean()`
* xreducer.hpp: determine an xreducer's value_type from the result type of the reduce functor
* additional tests