### PR TITLE
WIP: norm implementation

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -506,7 +506,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::maximum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -514,7 +514,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::maximum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -523,7 +523,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::maximum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -531,7 +531,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::maximum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -550,7 +550,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::minimum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -558,7 +558,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::minimum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -567,7 +567,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::minimum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -575,7 +575,7 @@ namespace xt
     {
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::minimum<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -1431,7 +1431,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -1439,7 +1439,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -1448,7 +1448,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -1456,7 +1456,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -1475,7 +1475,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -1483,7 +1483,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -1492,7 +1492,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -1500,7 +1500,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -504,30 +504,34 @@ namespace xt
     template <class E, class X>
     inline auto amax(E&& e, X&& axes) noexcept
     {
-        using functor_type = math::maximum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::maximum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
     inline auto amax(E&& e) noexcept
     {
-        using functor_type = math::maximum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e));
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::maximum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
     template <class E, class I>
     inline auto amax(E&& e, std::initializer_list<I> axes) noexcept
     {
-        using functor_type = math::maximum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::maximum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
     inline auto amax(E&& e, const I (&axes)[N]) noexcept
     {
-        using functor_type = math::maximum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::maximum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -544,30 +548,34 @@ namespace xt
     template <class E, class X>
     inline auto amin(E&& e, X&& axes) noexcept
     {
-        using functor_type = math::minimum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::minimum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
     inline auto amin(E&& e) noexcept
     {
-        using functor_type = math::minimum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e));
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::minimum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
     template <class E, class I>
     inline auto amin(E&& e, std::initializer_list<I> axes) noexcept
     {
-        using functor_type = math::minimum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
-    }
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::minimum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
+   }
 #else
     template <class E, class I, std::size_t N>
     inline auto amin(E&& e, const I (&axes)[N]) noexcept
     {
-        using functor_type = math::minimum<typename std::decay_t<E>::value_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        using result_type = typename std::decay_t<E>::value_type;
+        using functor_type = math::minimum<result_type>;
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -1423,7 +1431,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -1431,7 +1439,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(functor_type(), std::forward<E>(e));
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -1440,7 +1448,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -1448,7 +1456,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::plus<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 
@@ -1467,7 +1475,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), std::forward<X>(axes));
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), std::forward<X>(axes));
     }
 
     template <class E>
@@ -1475,7 +1483,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(functor_type(), std::forward<E>(e));
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e));
     }
 
 #ifdef X_OLD_CLANG
@@ -1484,7 +1492,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #else
     template <class E, class I, std::size_t N>
@@ -1492,7 +1500,7 @@ namespace xt
     {
         using result_type = big_promote_type_t<typename std::decay_t<E>::value_type>;
         using functor_type = std::multiplies<result_type>;
-        return reduce(functor_type(), std::forward<E>(e), axes);
+        return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
     }
 #endif
 

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -568,7 +568,7 @@ namespace xt
         using result_type = typename std::decay_t<E>::value_type;
         using functor_type = math::minimum<result_type>;
         return reduce(make_xreducer_functor<result_type>(functor_type()), std::forward<E>(e), axes);
-   }
+    }
 #else
     template <class E, class I, std::size_t N>
     inline auto amin(E&& e, const I (&axes)[N]) noexcept

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -1,0 +1,229 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XNORM_HPP
+#define XNORM_HPP
+
+#include <cmath>
+#include <cstdlib>   // std::abs(int) prior to C++ 17
+#include <complex>
+
+#include "xconcepts.hpp"
+#include "xutils.hpp"
+#include "xmath.hpp"
+#include "xoperation.hpp"
+
+namespace xt
+{
+    /*************************************
+     * norm functions for built-in types *
+     *************************************/
+
+        /** \brief The L2-norm of a numerical object.
+
+            For scalar types: implemented as <tt>abs(t)</tt><br>
+            otherwise: implemented as <tt>sqrt(norm_sq(t))</tt>.
+        */
+    template <class T>
+    inline auto norm_l2(T && t)
+    {
+        using std::sqrt;
+        return sqrt(norm_sq(std::forward<T>(t)));
+    }
+
+    #define XTENSOR_DEFINE_SIGNED_NORMS(T)                       \
+        inline auto                                              \
+        norm_lp(T t, double p) -> decltype(std::abs(t))          \
+        {                                                        \
+            return p == 0.0                                      \
+                      ? (t != 0)                                 \
+                      : std::abs(t);                             \
+        }                                                        \
+        inline size_t norm_l0(T t)   { return (t != 0); }        \
+        inline auto   norm_l1(T t)   { return std::abs(t); }     \
+        inline auto   norm_l2(T t)   { return std::abs(t); }     \
+        inline auto   norm_linf(T t) { return std::abs(t); }     \
+        inline auto   norm_sq(T t)   { return t*t; }
+
+    XTENSOR_DEFINE_SIGNED_NORMS(signed char)
+    XTENSOR_DEFINE_SIGNED_NORMS(short)
+    XTENSOR_DEFINE_SIGNED_NORMS(int)
+    XTENSOR_DEFINE_SIGNED_NORMS(long)
+    XTENSOR_DEFINE_SIGNED_NORMS(long long)
+    XTENSOR_DEFINE_SIGNED_NORMS(float)
+    XTENSOR_DEFINE_SIGNED_NORMS(double)
+    XTENSOR_DEFINE_SIGNED_NORMS(long double)
+
+    #undef XTENSOR_DEFINE_SIGNED_NORMS
+
+    #define XTENSOR_DEFINE_UNSIGNED_NORMS(T)                   \
+        inline T norm_lp(T t, double p)                        \
+        {                                                      \
+            return p == 0.0                                    \
+                      ? t != 0                                 \
+                      : t;                                     \
+        }                                                      \
+        inline T    norm_l0(T t)   { return t != 0 ? 1 : 0; }  \
+        inline T    norm_l1(T t)   { return t; }               \
+        inline T    norm_l2(T t)   { return t; }               \
+        inline T    norm_linf(T t) { return t; }               \
+        inline auto norm_sq(T t)   { return t*t; }
+
+    XTENSOR_DEFINE_UNSIGNED_NORMS(unsigned char)
+    XTENSOR_DEFINE_UNSIGNED_NORMS(unsigned short)
+    XTENSOR_DEFINE_UNSIGNED_NORMS(unsigned int)
+    XTENSOR_DEFINE_UNSIGNED_NORMS(unsigned long)
+    XTENSOR_DEFINE_UNSIGNED_NORMS(unsigned long long)
+
+    #undef XTENSOR_DEFINE_UNSIGNED_NORMS
+
+    /***********************************
+     * norm functions for std::complex *
+     ***********************************/
+
+        /** \brief L2-norm of a complex number.
+
+            Equivalent to <tt>std::abs(t)</tt>.
+        */
+    template <class T>
+    inline auto norm_l2(std::complex<T> & t)
+    {
+        return std::abs(t);
+    }
+    template <class T>
+    inline auto norm_l2(std::complex<T> const & t)
+    {
+        return std::abs(t);
+    }
+
+        /** \brief Squared norm of a complex number.
+
+            Equivalent to <tt>std::norm(t)</tt> (yes, the C++ standard really defines
+            <tt>norm()</tt> to compute the squared norm).
+        */
+    template <class T>
+    inline auto norm_sq(std::complex<T> & t)
+    {
+        return std::norm(t);
+    }
+    template <class T>
+    inline auto norm_sq(std::complex<T> const & t)
+    {
+        return std::norm(t);
+    }
+
+    template <class T>
+    inline uint64_t norm_l0(std::complex<T> & t)
+    {
+        return t.real() != 0 || t.imag() != 0;
+    }
+    template <class T>
+    inline uint64_t norm_l0(std::complex<T> const & t)
+    {
+        return t.real() != 0 || t.imag() != 0;
+    }
+
+    /***********************************
+     * norm functions for xexpressions *
+     ***********************************/
+
+     // FIXME: support axes
+
+    /**
+     * Calculate L1 norm of an array-like argument.
+     *
+     * @param e array-like
+     * @return scalar result
+     *
+     * @tparam type of array-like
+     */
+    template <class E>
+    auto norm_l1(E && e)
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using result_type = big_promote_type_t<value_type>;
+
+        auto norm_func = [](result_type const & r, result_type const & v)
+                         {
+                             return r + norm_l1(v);
+                         };
+        auto init_func = [](value_type const & v)
+                         {
+                             return norm_l1(v);
+                         };
+        return reduce(make_xreducer_functor<result_type>(std::move(norm_func), std::move(init_func), std::plus<result_type>()),
+                      std::forward<E>(e));
+    }
+
+    template <class E>
+    auto norm_sq(E && e)
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using result_type = big_promote_type_t<value_type>;
+
+        auto norm_func = [](result_type const & r, value_type const & v)
+                         {
+                             return r + norm_sq(v);
+                         };
+        auto init_func = [](value_type const & v)
+                         {
+                             return norm_sq(v);
+                         };
+        return reduce(make_xreducer_functor<result_type>(std::move(norm_func), std::move(init_func), std::plus<result_type>()),
+                      std::forward<E>(e));
+    }
+
+    template <class E>
+    auto norm_linf(E && e)
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using result_type = decltype(norm_linf(*(value_type*)0));
+
+        auto norm_func = [](result_type const & r, value_type const & v)
+                         {
+                             return std::max<result_type>(r, norm_linf(v));
+                         };
+        auto init_func = [](value_type const & v)
+                         {
+                             return norm_linf(v);
+                         };
+        auto merge_func = [](result_type const & r1, result_type const & r2)
+                          {
+                              return std::max(r1, r2);
+                          };
+        return reduce(make_xreducer_functor<result_type>(std::move(norm_func), std::move(init_func), std::move(merge_func)),
+                      std::forward<E>(e));
+    }
+
+    template <class E>
+    auto norm_l0(E && e)
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        using result_type = unsigned long long;
+
+        auto norm_func = [](result_type const & r, value_type const & v)
+                         {
+                             return r + norm_l0(v);
+                         };
+        auto init_func = [](value_type const & v)
+                         {
+                             return norm_l0(v);
+                         };
+        return reduce(make_xreducer_functor<result_type>(std::move(norm_func), std::move(init_func), std::plus<result_type>()),
+                      std::forward<E>(e));
+    }
+
+    template <class E>
+    auto norm_lp(E && e, double p)
+    {
+        return pow(sum(pow(abs(std::forward<E>(e)), p)), 1.0/p);
+    }
+
+} // namespace xt
+
+#endif

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -787,28 +787,25 @@ namespace xt
      * static_if *
      *************/
 
-    namespace static_if_detail
+    struct identity_functor
     {
-        struct identity
+        template <class T>
+        T&& operator()(T&& x) const
         {
-            template <class T>
-            T&& operator()(T&& x) const
-            {
-                return std::forward<T>(x);
-            }
-        };
-    }
+            return std::forward<T>(x);
+        }
+    };
 
     template <class TF, class FF>
     auto static_if(std::true_type, const TF& tf, const FF&)
     {
-        return tf(static_if_detail::identity());
+        return tf(identity_functor());
     }
 
     template <class TF, class FF>
     auto static_if(std::false_type, const TF&, const FF& ff)
     {
-        return ff(static_if_detail::identity());
+        return ff(identity_functor());
     }
 
     template <bool cond, class TF, class FF>
@@ -842,12 +839,8 @@ namespace xt
 
     template <class T>
     struct conditional_cast_functor<false, T>
+    : public identity_functor
     {
-        template <class U>
-        inline U && operator()(U && u) const
-        {
-            return std::forward<U>(u);
-        }
     };
 
     template <class T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ set(XTENSOR_TESTS
     test_xlayout.cpp
     test_xmath.cpp
     test_xnoalias.cpp
+    test_xnorm.cpp
     test_xoperation.cpp
     test_xoptional.cpp
     test_xrandom.cpp

--- a/test/test_xnorm.cpp
+++ b/test/test_xnorm.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+* Copyright (c) 2017, Ullrich Koethe                                       *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xnorm.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xnoalias.hpp"
+
+#include <limits>
+
+namespace xt
+{
+    TEST(xnorm, scalar)
+    {
+        EXPECT_EQ(norm_l0(2), 1);
+        EXPECT_EQ(norm_l0(-2), 1);
+        EXPECT_EQ(norm_l0(0), 0);
+        EXPECT_EQ(norm_l0(2.0), 1);
+        EXPECT_EQ(norm_l0(-2.0), 1);
+        EXPECT_EQ(norm_l0(0.0), 0);
+
+        EXPECT_EQ(norm_l1(2), 2);
+        EXPECT_EQ(norm_l1(-2), 2);
+        EXPECT_EQ(norm_l1(2.0), 2.0);
+        EXPECT_EQ(norm_l1(-2.0), 2.0);
+
+        EXPECT_EQ(norm_l2(2), 2);
+        EXPECT_EQ(norm_l2(-2), 2);
+        EXPECT_EQ(norm_l2(2.0), 2.0);
+        EXPECT_EQ(norm_l2(-2.0), 2.0);
+
+        EXPECT_EQ(norm_linf(2), 2);
+        EXPECT_EQ(norm_linf(-2), 2);
+        EXPECT_EQ(norm_linf(2.0), 2.0);
+        EXPECT_EQ(norm_linf(-2.0), 2.0);
+
+        EXPECT_EQ(norm_sq(2), 4);
+        EXPECT_EQ(norm_sq(-2), 4);
+        EXPECT_EQ(norm_sq(2.5), 6.25);
+        EXPECT_EQ(norm_sq(-2.5), 6.25);
+
+        EXPECT_EQ(norm_lp(0, 0), 0);
+        EXPECT_EQ(norm_lp(-2, 0), 1);
+        EXPECT_EQ(norm_lp(0, 1), 0);
+        EXPECT_EQ(norm_lp(-2, 1), 2);
+    }
+
+    TEST(xnorm, complex)
+    {
+        std::complex<double> c{ 3.0, 4.0 };
+        EXPECT_EQ(norm_sq(c), 25.0);
+        EXPECT_EQ(norm_sq(c), std::norm(c));
+
+        EXPECT_EQ(norm_l2(c), 5.0);
+        EXPECT_EQ(norm_l2(c), std::abs(c));
+    }
+
+    TEST(xnorm, scalar_array)
+    {
+        xarray<int> i1 = -ones<int>({9});
+
+        EXPECT_EQ(norm_l0(i1)(), 9);
+        EXPECT_EQ(norm_l1(i1)(), 9);
+        EXPECT_EQ(norm_lp(i1, 1.0)(), 9);
+        EXPECT_EQ(norm_sq(i1)(), 9);
+        EXPECT_EQ(norm_l2(i1)(), 3);
+        EXPECT_EQ(norm_lp(i1, 2.0)(), 3);
+        EXPECT_EQ(norm_linf(i1)(), 1);
+    }
+
+    TEST(xnorm, complex_array)
+    {
+        xarray<std::complex<double>> i1 = -ones<std::complex<double>>({9});
+
+        EXPECT_EQ(norm_l0(i1)(), 9);
+        EXPECT_EQ(norm_sq(i1)(), 9.0);
+        EXPECT_EQ(norm_l2(i1)(), 3.0);
+    }
+} // namespace xt

--- a/test/test_xnorm.cpp
+++ b/test/test_xnorm.cpp
@@ -67,11 +67,12 @@ namespace xt
         xarray<int> i1 = -ones<int>({9});
 
         EXPECT_EQ(norm_l0(i1)(), 9);
+        EXPECT_EQ(norm_lp_to_p(i1, 0.0)(), 9.0);
         EXPECT_EQ(norm_l1(i1)(), 9);
-        EXPECT_EQ(norm_lp(i1, 1.0)(), 9);
+        EXPECT_EQ(norm_lp(i1, 1.0)(), 9.0);
         EXPECT_EQ(norm_sq(i1)(), 9);
-        EXPECT_EQ(norm_l2(i1)(), 3);
-        EXPECT_EQ(norm_lp(i1, 2.0)(), 3);
+        EXPECT_EQ(norm_l2(i1)(), 3.0);
+        EXPECT_EQ(norm_lp(i1, 2.0)(), 3.0);
         EXPECT_EQ(norm_linf(i1)(), 1);
     }
 

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -22,7 +22,7 @@ namespace xt
         xarray<double> m_a;
         using shape_type = xarray<double>::shape_type;
 
-        using func = xreducer_functors<double, std::plus<double>>;
+        using func = xreducer_functors<std::plus<double>>;
         xreducer<func, const xarray<double>&, axes_type> m_red;
 
         xreducer_features();

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -22,7 +22,7 @@ namespace xt
         xarray<double> m_a;
         using shape_type = xarray<double>::shape_type;
 
-        using func = std::plus<double>;
+        using func = xreducer_functors<double, std::plus<double>>;
         xreducer<func, const xarray<double>&, axes_type> m_red;
 
         xreducer_features();


### PR DESCRIPTION
Initial proof-of-concept for https://github.com/QuantStack/xtensor/issues/417, please comment!

Remark: I had to remove auto-deduction of the xreducer's result_type, because it didn't work in all cases. Instead, the result_type must be specified explicitly in the call to `make_xreducer_functor`.

