### PR TITLE
some warnings removed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake -c conda-forge
-  - conda install xtl -c conda-forge
+  - conda install xtl==0.2.10 -c conda-forge
   - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON .
   - nmake test_xtensor
   - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda install gtest cmake -c conda-forge 
-    - conda install xtl -c conda-forge 
+    - conda install xtl==0.2.10 -c conda-forge 
     # Testing
     - mkdir build
     - cd build

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -269,7 +269,7 @@ namespace xt
     template <class... Args>
     inline auto xbroadcast<CT, X>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -191,7 +191,7 @@ namespace xt
             inline T operator()(const It& /*begin*/, const It& end) const
             {
                 using lvalue_type = typename std::iterator_traits<It>::value_type;
-                return *(end - 1) == *(end - 2) + lvalue_type(m_k) ? T(1) : T(0);
+                return *(end - 1) == *(end - 2) + static_cast<lvalue_type>(static_cast<unsigned int>(m_k)) ? T(1) : T(0);
             }
 
         private:

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -519,7 +519,7 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::at(Args... args) -> reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -536,7 +536,7 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -156,7 +156,7 @@ namespace xt
      *******************/
 
     template <class S, class... Args>
-    inline void check_dimension(const S& shape, Args... args)
+    inline void check_dimension(const S& shape, Args...)
     {
         if (sizeof...(Args) > shape.size())
         {

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -529,7 +529,7 @@ namespace xt
     template <class... Args>
     inline auto xfunction<F, R, CT...>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -386,7 +386,7 @@ namespace xt
     {
         XTENSOR_PRECONDITION(p != 0,
             "norm_lp(): p must be nonzero, use norm_l0() instead.");
-        return pow(norm_lp_to_p(std::forward<E>(e), p), 1.0/p);
+        return pow(norm_lp_to_p(std::forward<E>(e), p, std::forward<X>(axes)), 1.0/p);
     }
 
     template <class E, XTENSOR_REQUIRE<is_xexpression<E>::value>>

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -481,7 +481,7 @@ namespace xt
     template <class... Args>
     inline auto xreducer<F, CT, X>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
     /**

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -206,7 +206,7 @@ namespace xt
         inline std::enable_if_t<std::is_integral<MI>::value &&
                                 std::is_integral<MA>::value &&
                                 std::is_integral<STEP>::value, xstepped_range<int>>
-        get(std::size_t size) const
+        get(std::size_t /*size*/) const
         {
             return xstepped_range<int>(m_min, m_max, m_step);
         }
@@ -233,7 +233,7 @@ namespace xt
         inline std::enable_if_t<std::is_integral<MI>::value &&
                                 std::is_integral<MA>::value &&
                                !std::is_integral<STEP>::value, xrange<int>>
-        get(std::size_t size) const
+        get(std::size_t /*size*/) const
         {
             return xrange<int>(m_min, m_max);
         }

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -388,7 +388,7 @@ namespace xt
     template <class... Args>
     inline auto xstrided_view<CT, S, CD>::at(Args... args) -> reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -405,7 +405,7 @@ namespace xt
     template <class... Args>
     inline auto xstrided_view<CT, S, CD>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -253,7 +253,7 @@ namespace xt
         template <class R, class F, std::size_t I, class... S>
         R apply_one(F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
         {
-            return func(std::get<I>(s));
+            return static_cast<R>(func(std::get<I>(s)));
         }
 
         template <class R, class F, std::size_t... I, class... S>

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -483,7 +483,7 @@ namespace xt
     template <class... Args>
     inline auto xview<CT, S...>::at(Args... args) -> reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -539,7 +539,7 @@ namespace xt
     template <class... Args>
     inline auto xview<CT, S...>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), args...);
+        check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -741,7 +741,7 @@ namespace xt
     inline auto xview<CT, S...>::sliced_access(const xslice<T>& slice, Arg arg, Args... args) const -> size_type
     {
         using ST = typename T::size_type;
-        return slice.derived_cast()(argument<I>(static_cast<ST>(arg), static_cast<ST>(args)...));
+        return static_cast<size_type>(slice.derived_cast()(argument<I>(static_cast<ST>(arg), static_cast<ST>(args)...)));
     }
 
     template <class CT, class... S>

--- a/test/test_xnorm.cpp
+++ b/test/test_xnorm.cpp
@@ -19,12 +19,12 @@ namespace xt
 {
     TEST(xnorm, scalar)
     {
-        EXPECT_EQ(norm_l0(2), 1);
-        EXPECT_EQ(norm_l0(-2), 1);
-        EXPECT_EQ(norm_l0(0), 0);
-        EXPECT_EQ(norm_l0(2.0), 1);
-        EXPECT_EQ(norm_l0(-2.0), 1);
-        EXPECT_EQ(norm_l0(0.0), 0);
+        EXPECT_EQ(norm_l0(2), 1u);
+        EXPECT_EQ(norm_l0(-2), 1u);
+        EXPECT_EQ(norm_l0(0), 0u);
+        EXPECT_EQ(norm_l0(2.0), 1u);
+        EXPECT_EQ(norm_l0(-2.0), 1u);
+        EXPECT_EQ(norm_l0(0.0), 0u);
 
         EXPECT_EQ(norm_l1(2), 2);
         EXPECT_EQ(norm_l1(-2), 2);
@@ -56,7 +56,7 @@ namespace xt
     {
         std::complex<double> c{ 3.0, -4.0 };
 
-        EXPECT_EQ(norm_l0(c), 1);
+        EXPECT_EQ(norm_l0(c), 1u);
         EXPECT_EQ(norm_lp(c, 0), 1.0);
 
         EXPECT_EQ(norm_l1(c), 7.0);
@@ -77,7 +77,7 @@ namespace xt
     {
         xarray<int> a = -ones<int>({9});
 
-        EXPECT_EQ(norm_l0(a)(), 9);
+        EXPECT_EQ(norm_l0(a)(), 9u);
         EXPECT_EQ(norm_lp_to_p(a, 0.0)(), 9.0);
         EXPECT_EQ(norm_l1(a)(), 9);
         EXPECT_EQ(norm_lp(a, 1.0)(), 9.0);
@@ -91,7 +91,7 @@ namespace xt
     {
         xarray<std::complex<double>> a = -ones<std::complex<double>>({9});
 
-        EXPECT_EQ(norm_l0(a)(), 9);
+        EXPECT_EQ(norm_l0(a)(), 9u);
         EXPECT_EQ(norm_lp_to_p(a, 0.0)(), 9.0);
         EXPECT_EQ(norm_l1(a)(), 9.0);
         EXPECT_EQ(norm_lp(a, 1.0)(), 9.0);
@@ -106,7 +106,7 @@ namespace xt
         xarray<double> a = {{ -1.0, 2.0},
                             { -3.0, 4.0}};
 
-        EXPECT_EQ(norm_l0(a)(), 4);
+        EXPECT_EQ(norm_l0(a)(), 4u);
         EXPECT_EQ(norm_l1(a)(), 10.0);
         EXPECT_EQ(norm_sq(a)(), 30.0);
         EXPECT_EQ(norm_linf(a)(), 4.0);

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -114,7 +114,7 @@ namespace xt
 
         // check that there is no overflow
         xarray<uint8_t> c = ones<uint8_t>({1000});
-        EXPECT_EQ(1000, sum(c)());
+        EXPECT_EQ(1000u, sum(c)());
     }
 
     TEST(xreducer, sum_all)


### PR DESCRIPTION
Some warnings remain in xview/xutils, the main reason is we're converting int to long unsigned int, so two conversions actually happen: int => long and then signed => unsigned.

Getting rid of them requires additional work (it implies adding casters depending on the source type and the destination type).