### PR TITLE
ability to cast in the assignment

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -438,12 +438,12 @@ namespace xt
     template <class E1, class E2>
     inline void trivial_assigner<false>::run(E1& e1, const E2& e2)
     {
-        using is_same_type = std::is_same<typename std::decay_t<E1>::value_type,
-                                          typename std::decay_t<E2>::value_type>;
-        // If the types differ, this function is still instantiated but never called.
-        // To avoid compilation problems in effectively unused code (e.g. warnings
-        // on narrowing type conversions), trivial_assigner_run_impl is empty in this case.
-        assigner_detail::trivial_assigner_run_impl(e1, e2, is_same_type());
+        using is_convertible = std::is_convertible<typename std::decay_t<E1>::value_type,
+                                                   typename std::decay_t<E2>::value_type>;
+        // If the types are not compatible, this function is still instantiated but never called.
+        // To avoid compilation problems in effectively unused code trivial_assigner_run_impl is
+        // empty in this case.
+        assigner_detail::trivial_assigner_run_impl(e1, e2, is_convertible());
     }
 }
 

--- a/test/test_xtensor_semantic.cpp
+++ b/test/test_xtensor_semantic.cpp
@@ -46,5 +46,30 @@ namespace xt
         array_type res = t1 + t2;
         EXPECT_EQ(res(0, 0), t1(0, 0) + t2(0, 0));
     }
+
+    TEST(xtensor_semantic, tensor_cast)
+    {
+        using int8_tensor = xtensor<int8_t, 2>;
+        using int32_tensor = xtensor<int32_t, 2>;
+        using double_tensor = xtensor<double, 2>;
+
+        int8_tensor i8t = {{int8_t(0), int8_t(1) },
+                           { int8_t(2) , int8_t(3) },
+                           { int8_t(4) , int8_t(5) }};
+
+        int32_tensor i32t = {{ int32_t(0), int32_t(1) },
+                             { int8_t(2) , int8_t(3) },
+                             { int8_t(4) , int8_t(5) }};
+
+        double_tensor dt = {{0., 1.},
+                            {2., 3.},
+                            {4., 5.}};
+
+        int32_tensor i32res = i8t;
+        EXPECT_EQ(i32res, i32t);
+
+        double_tensor dres = i32t;
+        EXPECT_EQ(dres, dt);
+    }
 }
 


### PR DESCRIPTION
This should fix one of the issue described [here](https://github.com/QuantStack/xtensor-python/issues/116). So now the following should work:

```cpp
inline xt::pyarray<uint8_t> example2(xt::pyarray<uint8_t> &m)
{
    return m + 2;
}
```

However this will issue a warning (just like assigning an int value to a uint8_t value issues a warning). The `xcast` function proposed in the issue is a good way to explicitly get rid of the warning.

@stuarteberg this fix should be available in the next release of the xtensor stack, which should be done by the end of this week. Are you interested in opening a PR for the `xcast` stuff ?