### PR TITLE
Change and document print options

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,8 @@ Breaking changes
 
 - The API for ``xbuffer_adaptor`` has changed. The template parameter is the type of the buffer, not just the value type.
   `#482 <https://github.com/QuantStack/xtensor/pull/482>`_
+- Change ``edge_items`` print option to ``edgeitems`` for better numpy consistency.
+  `#489 <https://github.com/QuantStack/xtensor/pull/489>`_.
 - xtensor now depends on ``xtl`` version `~0.3.1`.
 
 Other changes

--- a/docs/source/numpy.rst
+++ b/docs/source/numpy.rst
@@ -304,6 +304,21 @@ More generally, one can use the ``xt::reduce(function, input, axes)`` which allo
 of an arbitrary binary function for the reduction. The binary function must be cummutative and
 associative up to rounding errors.
 
+I/0
+---
+
+These options determine the way floating point numbers, tensors and other xtensor expressions are displayed.
+
++-----------------------------------------------+-----------------------------------------------+
+|            Python 3 - numpy                   |                C++ 14 - xtensor               |
++===============================================+===============================================+
+| ``np.set_printoptions(precision=4)``          | ``xt::print_options::set_precision(4)``       |
++-----------------------------------------------+-----------------------------------------------+
+| ``np.set_printoptions(threshold=5)``          | ``xt::print_options::set_threshold(5)``       |
++-----------------------------------------------+-----------------------------------------------+
+| ``np.set_printoptions(edgeitems=3)``          | ``xt::print_options::set_edgeitems(3)``       |
++-----------------------------------------------+-----------------------------------------------+
+
 Mathematical functions
 ----------------------
 

--- a/docs/source/related.rst
+++ b/docs/source/related.rst
@@ -326,6 +326,14 @@ The xsimd_ project provides a unified API for making use of the SIMD features of
 
 xsimd_ is an optional dependency to ``xtensor`` which enable SIMD vectorization of xtensor operations. This feature is enabled with the ``XTENSOR_USE_XSIMD`` compilation flag, which is set to *false* by default.
 
+xtl
+---
+
+.. image:: xtl.svg
+   :alt: xtl
+
+The xtl_ project, the only dependency of ``xtensor`` is a C++ template library holding the implementation of basic tools used accross the libraries in the QuantStack ecosystem.
+
 .. _xtensor-python: https://github.com/QuantStack/xtensor-python
 .. _xtensor-python-cookiecutter: https://github.com/QuantStack/xtensor-python-cookiecutter
 .. _xtensor-julia: https://github.com/QuantStack/xtensor-julia
@@ -334,3 +342,4 @@ xsimd_ is an optional dependency to ``xtensor`` which enable SIMD vectorization 
 .. _xtensor-blas: https://github.com/QuantStack/xtensor-blas
 .. _xtensor-fftw: https://github.com/egpbos/xtensor-fftw
 .. _xsimd: https://github.com/egpbos/xsimd
+.. _xtl: https://github.com/QuantStack/xtl

--- a/docs/source/xtl.svg
+++ b/docs/source/xtl.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 86.783217 46.600001"
+   width="278.74695"
+   height="149.678801"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="xtl.svg"><metadata
+     id="metadata30"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs28" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1617"
+     inkscape:window-height="783"
+     id="namedview26"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="7.6277944"
+     inkscape:cx="52.210005"
+     inkscape:cy="19.495744"
+     inkscape:window-x="299"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Calque_1" /><style
+     type="text/css"
+     id="style20">
+	.st0{fill:#7FD787;}
+	.st1{opacity:0.28;fill:#7FD787;enable-background:new    ;}
+</style><path
+     class="st0"
+     d="m 73.8,14.700001 0,0 0,0 z M 66.1,35.5 C 65.6,34.400001 65.4,33.200001 65.4,32 l 0,-17.399999 8.4,0 -1.1,-2.1 -7.3,0 0,-7.700001 -2.4,0 0,7.600001 -7.4,0 -1.1,2.2 8.5,0 L 63,31.3 c -0.1,1.8 0.2,3.6 0.8,5.1 0,0.1 0.7,1.5 1.8,2.9 0.6,0.6 1.7,1.6 3.2,2.7 l 1.1,-2.2 c -1.2,-0.8 -2,-1.5 -2.5,-2 -0.8,-1.2 -1.3,-2.3 -1.3,-2.3 z M 39.2,4.5 c -1.5,0.9 -2.6,2.1 -3.5,3.4 -0.4,0.7000004 -6.6,9.900001 -10.1,15.2 -2.9,4.400001 -10.3,15.5 -10.8,16.200001 -1.2,2 -2.9,3.799999 -4.8,5.1 0,0.1 -2.1,1.3 -4.6,2.1 -0.2,0 -0.4,0.1 -0.5,0.1 l 36.8,0 c -0.1,0 -0.2,-0.1 -0.4,-0.1 -2.5,-0.8 -4.5,-2 -4.6,-2.1 -1.9,-1.3 -3.6,-3.1 -4.8,-5.1 L 23.3,26.4 c 0.8,-1.199999 1.5,-2.3 2.1,-3.1 0,0.1 0.1,0.1 0.1,0.2 3.5,5.3 9.7,14.5 10.1,15.200001 0.9,1.299999 2,2.5 3.5,3.399999 0,0 1.5,1 3.5,1.600001 0.8,0.299999 2.2,0.5 4,0.7 l 0,2.1 0.1,0 L 46.7,2.2 c -1.8,0.2 -3.2,0.4 -4,0.7 -2,0.6 -3.5,1.6 -3.5,1.6 z M 11,38.800001 C 11.4,38.1 17.6,28.9 21.1,23.6 24,19.1 31.4,8.1 31.9,7.3 c 1.2,-2 2.9,-3.8 4.8,-5.1 0,-0.1 2.1,-1.3 4.6,-2.1 0.2,0 0.4,-0.1 0.5,-0.1 L 5,0 c 0.1,0 0.3,0.1 0.4,0.1 2.5,0.8 4.5,2 4.6,2.1 1.9,1.3 3.6,3.1 4.8,5.1 l 8.6,12.900001 c -0.8,1.199999 -1.5,2.3 -2.1,3.1 0,-0.1 -0.1,-0.1 -0.1,-0.200001 C 17.6,17.9 11.4,8.6000004 11,7.9 10.1,6.6 9,5.4 7.5,4.5 7.5,4.5 6,3.5 4,2.9 3.2,2.6 1.8,2.4 0,2.2 l 0,42.4 c 1.8,-0.199999 3.2,-0.399999 4,-0.699999 2,-0.6 3.5,-1.6 3.5,-1.6 1.5,-1.1 2.7,-2.200001 3.5,-3.5 z"
+     id="path22"
+     inkscape:connector-curvature="0"
+     style="fill:#d77f7f;fill-opacity:1"
+     sodipodi:nodetypes="cccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" /><path
+     class="st1"
+     d="m 25.4,23.300001 c -0.6,0.8 -1.3,1.9 -2.1,3.1 3.4,5.1 8.1,12.3 8.6,12.9 1.2,2 2.9,3.799999 4.8,5.1 0,0.1 2.1,1.3 4.6,2.1 0.2,0 0.4,0.1 0.5,0.1 l 4.8,0 0,-2.2 c -1.8,-0.2 -3.2,-0.400001 -4,-0.7 C 40.6,43.1 39.1,42.1 39.1,42.1 37.6,41.200001 36.5,40 35.6,38.700001 35.2,38 29,28.800001 25.5,23.500001 l 0,0 c 0,0 0,-0.100001 -0.1,-0.2 M 4.8,0 0,0 0,2.2 c 1.8,0.2 3.2,0.4 4,0.7 2,0.6 3.5,1.6 3.5,1.6 1.5,0.9 2.6,2.1 3.5,3.4 0.4,0.7000004 6.6,9.900001 10.1,15.2 l 0,0 c 0,0.100001 0.1,0.100001 0.1,0.2 0.6,-0.8 1.3,-1.9 2.1,-3.1 C 19.9,15.100001 15.2,7.9 14.7,7.3 13.5,5.3 11.8,3.5 9.9,2.2 9.9,2.1 7.8,0.9 5.3,0.1 5.2,0.1 5,0 4.8,0"
+     id="path24"
+     inkscape:connector-curvature="0"
+     style="opacity:0.28000004;fill:#d77f7f;fill-opacity:1;enable-background:new" /><path
+     inkscape:connector-curvature="0"
+     class="st0"
+     d="m 85.783221,1.2999959 -2.3,0.4 0,31.4000021 c 0,3.9 0.2,7.5 1,10.4 l 2.3,0 c -0.8,-2.9 -1,-6.6 -1,-10.3 z"
+     id="path11"
+     style="fill:#d77f7f;fill-opacity:1"
+     sodipodi:nodetypes="ccsccsc" /></svg>

--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XADAPT_HPP
-#define XADAPT_HPP
+#ifndef XTENSOR_ADAPT_HPP
+#define XTENSOR_ADAPT_HPP
 
 #include <array>
 #include <cstddef>

--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XARRAY_HPP
-#define XARRAY_HPP
+#ifndef XTENSOR_ARRAY_HPP
+#define XTENSOR_ARRAY_HPP
 
 #include <algorithm>
 #include <initializer_list>

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XASSIGN_HPP
-#define XASSIGN_HPP
+#ifndef XTENSOR_ASSIGN_HPP
+#define XTENSOR_ASSIGN_HPP
 
 #include <algorithm>
 

--- a/include/xtensor/xaxis_iterator.hpp
+++ b/include/xtensor/xaxis_iterator.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XAXIS_ITERATOR_HPP
-#define XAXIS_ITERATOR_HPP
+#ifndef XTENSOR_AXIS_ITERATOR_HPP
+#define XTENSOR_AXIS_ITERATOR_HPP
 
 #include "xtl/xclosure.hpp"
 #include "xview.hpp"

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XBROADCAST_HPP
-#define XBROADCAST_HPP
+#ifndef XTENSOR_BROADCAST_HPP
+#define XTENSOR_BROADCAST_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XBUFFER_ADAPTOR_HPP
-#define XBUFFER_ADAPTOR_HPP
+#ifndef XTENSOR_BUFFER_ADAPTOR_HPP
+#define XTENSOR_BUFFER_ADAPTOR_HPP
 
 #include <algorithm>
 #include <functional>

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -10,8 +10,8 @@
  * @brief standard mathematical functions for xexpressions
  */
 
-#ifndef XBUILDER_HPP
-#define XBUILDER_HPP
+#ifndef XTENSOR_BUILDER_HPP
+#define XTENSOR_BUILDER_HPP
 
 #include <array>
 #include <cmath>

--- a/include/xtensor/xcomplex.hpp
+++ b/include/xtensor/xcomplex.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XCOMPLEX_HPP
-#define XCOMPLEX_HPP
+#ifndef XTENSOR_COMPLEX_HPP
+#define XTENSOR_COMPLEX_HPP
 
 #include <type_traits>
 #include <utility>

--- a/include/xtensor/xconcepts.hpp
+++ b/include/xtensor/xconcepts.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XCONCEPTS_HPP
-#define XCONCEPTS_HPP
+#ifndef XTENSOR_CONCEPTS_HPP
+#define XTENSOR_CONCEPTS_HPP
 
 #include <type_traits>
 

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XCONTAINER_HPP
-#define XCONTAINER_HPP
+#ifndef XTENSOR_CONTAINER_HPP
+#define XTENSOR_CONTAINER_HPP
 
 #include <algorithm>
 #include <functional>

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XCSV_HPP
-#define XCSV_HPP
+#ifndef XTENSOR_CSV_HPP
+#define XTENSOR_CSV_HPP
 
 #include <exception>
 #include <istream>

--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XEVAL_HPP
-#define XEVAL_HPP
+#ifndef XTENSOR_EVAL_HPP
+#define XTENSOR_EVAL_HPP
 
 #include "xarray.hpp"
 #include "xtensor.hpp"

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XEXCEPTION_HPP
-#define XEXCEPTION_HPP
+#ifndef XTENSOR_EXCEPTION_HPP
+#define XTENSOR_EXCEPTION_HPP
 
 #include <exception>
 #include <iterator>

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XEXPRESSION_HPP
-#define XEXPRESSION_HPP
+#ifndef XTENSOR_EXPRESSION_HPP
+#define XTENSOR_EXPRESSION_HPP
 
 #include <cstddef>
 #include <type_traits>

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XFUNCTION_HPP
-#define XFUNCTION_HPP
+#ifndef XTENSOR_FUNCTION_HPP
+#define XTENSOR_FUNCTION_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XFUNCTORVIEW_HPP
-#define XFUNCTORVIEW_HPP
+#ifndef XTENSOR_FUNCTORVIEW_HPP
+#define XTENSOR_FUNCTORVIEW_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XGENERATOR_HPP
-#define XGENERATOR_HPP
+#ifndef XTENSOR_GENERATOR_HPP
+#define XTENSOR_GENERATOR_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XINDEXVIEW_HPP
-#define XINDEXVIEW_HPP
+#ifndef XTENSOR_INDEXVIEW_HPP
+#define XTENSOR_INDEXVIEW_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/xtensor/xinfo.hpp
+++ b/include/xtensor/xinfo.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XINFO_HPP
-#define XINFO_HPP
+#ifndef XTENSOR_INFO_HPP
+#define XTENSOR_INFO_HPP
 
 #include <string>
 

--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XIO_HPP
-#define XIO_HPP
+#ifndef XTENSOR_IO_HPP
+#define XTENSOR_IO_HPP
 
 #include <complex>
 #include <cstddef>
@@ -37,7 +37,7 @@ namespace xt
     {
         struct print_options_impl
         {
-            std::size_t edge_items = 3;
+            std::size_t edgeitems = 3;
             std::size_t line_width = 75;
             std::size_t threshold = 1000;
             precision_type precision = -1;  // default precision
@@ -76,11 +76,11 @@ namespace xt
          *        triggered, this value defines how many items of each dimension
          *        are printed.
          *
-         * @param edge_items The number of edge items
+         * @param edgeitems The number of edge items
          */
-        inline void set_edge_items(std::size_t edge_items)
+        inline void set_edgeitems(std::size_t edgeitems)
         {
-            print_options().edge_items = edge_items;
+            print_options().edgeitems = edgeitems;
         }
 
         /**
@@ -118,7 +118,7 @@ namespace xt
         {
             template <class E, class F>
             static std::ostream& output(std::ostream& out, const E& e, F& printer, std::size_t blanks,
-                                        precision_type element_width, std::size_t edge_items, std::size_t line_width)
+                                        precision_type element_width, std::size_t edgeitems, std::size_t line_width)
             {
                 using size_type = typename E::size_type;
 
@@ -138,7 +138,7 @@ namespace xt
                     out << '{';
                     for (; i != e.shape()[0] - 1; ++i)
                     {
-                        if (edge_items && e.shape()[0] > (edge_items * 2) && i == edge_items)
+                        if (edgeitems && e.shape()[0] > (edgeitems * 2) && i == edgeitems)
                         {
                             out << "..., ";
                             if (e.dimension() > 1)
@@ -147,7 +147,7 @@ namespace xt
                                 out << std::endl
                                     << indents;
                             }
-                            i = e.shape()[0] - edge_items;
+                            i = e.shape()[0] - edgeitems;
                         }
                         if (e.dimension() == 1 && line_lim != 0 && elems_on_line >= line_lim)
                         {
@@ -156,7 +156,7 @@ namespace xt
                             elems_on_line = 0;
                         }
 
-                        xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edge_items, line_width) << ',';
+                        xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edgeitems, line_width) << ',';
 
                         elems_on_line++;
 
@@ -175,7 +175,7 @@ namespace xt
                         out << std::endl
                             << indents;
                     }
-                    xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edge_items, line_width) << '}';
+                    xout<I - 1>::output(out, view(e, i), printer, blanks + 1, element_width, edgeitems, line_width) << '}';
                 }
                 return out;
             }
@@ -649,7 +649,7 @@ namespace xt
         std::size_t sz = compute_size(d.shape());
         if (sz > print_options::print_options().threshold)
         {
-            lim = print_options::print_options().edge_items;
+            lim = print_options::print_options().edgeitems;
         }
         if (sz == 0)
         {

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XITERABLE_HPP
-#define XITERABLE_HPP
+#ifndef XTENSOR_ITERABLE_HPP
+#define XTENSOR_ITERABLE_HPP
 
 #include "xiterator.hpp"
 

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XITERATOR_HPP
-#define XITERATOR_HPP
+#ifndef XTENSOR_ITERATOR_HPP
+#define XTENSOR_ITERATOR_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xlayout.hpp
+++ b/include/xtensor/xlayout.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XLAYOUT_HPP
-#define XLAYOUT_HPP
+#ifndef XTENSOR_LAYOUT_HPP
+#define XTENSOR_LAYOUT_HPP
 
 namespace xt
 {

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -10,8 +10,8 @@
  * @brief standard mathematical functions for xexpressions
  */
 
-#ifndef XMATH_HPP
-#define XMATH_HPP
+#ifndef XTENSOR_MATH_HPP
+#define XTENSOR_MATH_HPP
 
 #include <cmath>
 #include <complex>

--- a/include/xtensor/xnoalias.hpp
+++ b/include/xtensor/xnoalias.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XNOALIAS_HPP
-#define XNOALIAS_HPP
+#ifndef XTENSOR_NOALIAS_HPP
+#define XTENSOR_NOALIAS_HPP
 
 #include "xsemantic.hpp"
 

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XNORM_HPP
-#define XNORM_HPP
+#ifndef XTENSOR_NORM_HPP
+#define XTENSOR_NORM_HPP
 
 #include <cmath>
 // std::abs(int) prior to C++ 17

--- a/include/xtensor/xoffsetview.hpp
+++ b/include/xtensor/xoffsetview.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XOFFSETVIEW_HPP
-#define XOFFSETVIEW_HPP
+#ifndef XTENSOR_OFFSETVIEW_HPP
+#define XTENSOR_OFFSETVIEW_HPP
 
 #include "xtl/xcomplex.hpp"
 

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XOPERATION_HPP
-#define XOPERATION_HPP
+#ifndef XTENSOR_OPERATION_HPP
+#define XTENSOR_OPERATION_HPP
 
 #include <algorithm>
 #include <functional>

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XOPTIONAL_HPP
-#define XOPTIONAL_HPP
+#ifndef XTENSOR_OPTIONAL_HPP
+#define XTENSOR_OPTIONAL_HPP
 
 #include <type_traits>
 #include <utility>

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -10,8 +10,8 @@
  * @brief functions to obtain xgenerators generating random numbers with given shape
  */
 
-#ifndef XRANDOM_HPP
-#define XRANDOM_HPP
+#ifndef XTENSOR_RANDOM_HPP
+#define XTENSOR_RANDOM_HPP
 
 #include <functional>
 #include <random>

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XREDUCER_HPP
-#define XREDUCER_HPP
+#ifndef XTENSOR_REDUCER_HPP
+#define XTENSOR_REDUCER_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSCALAR_HPP
-#define XSCALAR_HPP
+#ifndef XTENSOR_SCALAR_HPP
+#define XTENSOR_SCALAR_HPP
 
 #include <array>
 #include <cstddef>

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSEMANTIC_HPP
-#define XSEMANTIC_HPP
+#ifndef XTENSOR_SEMANTIC_HPP
+#define XTENSOR_SEMANTIC_HPP
 
 #include <functional>
 #include <utility>

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSLICE_HPP
-#define XSLICE_HPP
+#ifndef XTENSOR_SLICE_HPP
+#define XTENSOR_SLICE_HPP
 
 #include <cstddef>
 #include <type_traits>

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSTORAGE_HPP
-#define XSTORAGE_HPP
+#ifndef XTENSOR_STORAGE_HPP
+#define XTENSOR_STORAGE_HPP
 
 #include <algorithm>
 #include <functional>

--- a/include/xtensor/xstridedview.hpp
+++ b/include/xtensor/xstridedview.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSTRIDEDVIEW_HPP
-#define XSTRIDEDVIEW_HPP
+#ifndef XTENSOR_STRIDEDVIEW_HPP
+#define XTENSOR_STRIDEDVIEW_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XSTRIDES_HPP
-#define XSTRIDES_HPP
+#ifndef XTENSOR_STRIDES_HPP
+#define XTENSOR_STRIDES_HPP
 
 #include <cstddef>
 #include <functional>

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XTENSOR_HPP
-#define XTENSOR_HPP
+#ifndef XTENSOR_TENSOR_HPP
+#define XTENSOR_TENSOR_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XUTILS_HPP
-#define XUTILS_HPP
+#ifndef XTENSOR_UTILS_HPP
+#define XTENSOR_UTILS_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xvectorize.hpp
+++ b/include/xtensor/xvectorize.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XVECTORIZE_HPP
-#define XVECTORIZE_HPP
+#ifndef XTENSOR_VECTORIZE_HPP
+#define XTENSOR_VECTORIZE_HPP
 
 #include <type_traits>
 #include <utility>

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XVIEW_HPP
-#define XVIEW_HPP
+#ifndef XTENSOR_VIEW_HPP
+#define XTENSOR_VIEW_HPP
 
 #include <algorithm>
 #include <array>

--- a/include/xtensor/xview_utils.hpp
+++ b/include/xtensor/xview_utils.hpp
@@ -6,8 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#ifndef XVIEW_UTILS_HPP
-#define XVIEW_UTILS_HPP
+#ifndef XTENSOR_VIEW_UTILS_HPP
+#define XTENSOR_VIEW_UTILS_HPP
 
 #include <array>
 

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -170,7 +170,7 @@ namespace xt
         xt::xarray<double, layout_type::row_major> rn = xt::random::rand<double>({100, 100}, -10, 10);
 
         xt::print_options::set_line_width(150);
-        xt::print_options::set_edge_items(10);
+        xt::print_options::set_edgeitems(10);
         xt::print_options::set_precision(10);
         xt::print_options::set_threshold(100);
 
@@ -180,7 +180,7 @@ namespace xt
 
         // reset back to default
         xt::print_options::set_line_width(75);
-        xt::print_options::set_edge_items(3);
+        xt::print_options::set_edgeitems(3);
         xt::print_options::set_precision(-1);
         xt::print_options::set_threshold(1000);
     }


### PR DESCRIPTION
- change `edge_items` to `edgeitems` to be more consistent with numpy.
- add section about print options in the numpy cheat sheet.
- lengthen inclusion guards to reduce collision risk.
- add xtl in the related projects section.