### PR TITLE
fix codacity warnings

### DIFF
--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -71,7 +71,7 @@ namespace xt
     {
     public:
 
-        transpose_error(const std::string& msg);
+        explicit transpose_error(const std::string& msg);
 
         virtual const char* what() const noexcept;
 

--- a/include/xtensor/xfunctorview.hpp
+++ b/include/xtensor/xfunctorview.hpp
@@ -146,7 +146,7 @@ namespace xt
         using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
         using const_reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_iterator>;
 
-        xfunctorview(CT) noexcept;
+        explicit xfunctorview(CT) noexcept;
 
         template <class Func, class E>
         xfunctorview(Func&&, E&&) noexcept;

--- a/include/xtensor/xinfo.hpp
+++ b/include/xtensor/xinfo.hpp
@@ -17,7 +17,7 @@ namespace xt
     struct static_string
     {
         template <std::size_t N>
-        constexpr static_string(const char (&a)[N]) noexcept
+        explicit constexpr static_string(const char (&a)[N]) noexcept
             : data(a), size(N - 1)
         {
         }


### PR DESCRIPTION
This fixes 3/4 codacity warnings. 

Last one is a xconcepts struct that is never used, I think.