### PR TITLE
Use more general fp_type

### DIFF
--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -271,8 +271,9 @@ namespace xt
     template <class T>
     inline auto linspace(T start, T stop, std::size_t num_samples = 50, bool endpoint = true) noexcept
     {
-        double step = double(stop - start) / double(num_samples - (endpoint ? 1 : 0));
-        return cast<T>(detail::make_xgenerator(detail::arange_impl<double>(double(start), double(stop), step), {num_samples}));
+        using fp_type = std::common_type_t<T, double>;
+        fp_type step = fp_type(stop - start) / fp_type(num_samples - (endpoint ? 1 : 0));
+        return cast<T>(detail::make_xgenerator(detail::arange_impl<fp_type>(fp_type(start), fp_type(stop), step), {num_samples}));
     }
 
     /**


### PR DESCRIPTION
In case people use xtensor with arbitrary precision floating point types (such as MPFR), they probably don't want to use `double` here.

So taking the common type with double to handle the case of integral types.