### PR TITLE
xreducer: Don't require functor to be passed via rvalue reference

### DIFF
--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -149,9 +149,9 @@ namespace xt
     public:
 
         using self_type = xreducer<F, CT, X>;
-        using reduce_functor_type = typename F::reduce_functor_type;
-        using init_functor_type = typename F::init_functor_type;
-        using merge_functor_type = typename F::merge_functor_type;
+        using reduce_functor_type = typename std::decay_t<F>::reduce_functor_type;
+        using init_functor_type = typename std::decay_t<F>::init_functor_type;
+        using merge_functor_type = typename std::decay_t<F>::merge_functor_type;
         using xexpression_type = std::decay_t<CT>;
         using axes_type = X;
 

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -40,6 +40,17 @@ namespace xt
             }
         }
     }
+    TEST(xreducer, functor_type)
+    {
+        auto sum = [](auto const & left, auto const & right){ return left + right; };
+        auto sum_functor = xt::make_xreducer_functor(sum);
+        xt::xarray<int> a = {{1,2,3}, {4,5,6}};
+        xt::xarray<int> a_sums = xt::reduce(std::move(sum_functor), a, {1});
+        xt::xarray<int> a_sums2 = xt::reduce(sum_functor, a, {1});
+        xt::xarray<int> expect = {6, 15};
+        EXPECT_EQ(a_sums, expect);
+        EXPECT_EQ(a_sums2, expect);
+    }
 
     TEST(xreducer, shape)
     {


### PR DESCRIPTION
There is a minor but unnecessary subtlety in the `xt::reduce` API. Given an arbitrary `xreducer_functors` object such as the following:

```c++
auto sum = [](auto const & left, auto const & right){ return left + right; };
auto sum_functor = xt::make_xreducer_functor(sum);
```

...one can use `xt::reduce` as follows:

```c++
xt::xarray<int> a_sums = xt::reduce(std::move(sum_functor), a, {1});
```

But without `std::move`, it doesn't compile:

```c++
xt::xarray<int> a_sums2 = xt::reduce(sum_functor, a, {1});
```

```
In file included from /workspace/xtensor/include/xtensor/xmath.hpp:21:
/workspace/xtensor/include/xtensor/xreducer.hpp:152:46: error: type 'xt::xreducer_functors<(lambda at
      /workspace/xtensor/test/test_xreducer.cpp:45:20), xt::identity_functor, (lambda at
      /workspace/xtensor/test/test_xreducer.cpp:45:20)> &' cannot be used prior to '::' because it has no members
        using reduce_functor_type = typename F::reduce_functor_type;
```

With this PR, either form is permitted.