### PR TITLE
add evaluation_strategy, faster (immediate reducers) and accumulators…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(ver ${xtensor_version_defines})
         set(XTENSOR_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
     endif()
 endforeach()
-set(${PROJECT_NAME}_VERSION 
+set(${PROJECT_NAME}_VERSION
     ${XTENSOR_VERSION_MAJOR}.${XTENSOR_VERSION_MINOR}.${XTENSOR_VERSION_PATCH})
 message(STATUS "Building xtensor v${${PROJECT_NAME}_VERSION}")
 
@@ -35,6 +35,7 @@ message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
 # =====
 
 set(XTENSOR_HEADERS
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xaccumulator.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xadapt.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xarray.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xassign.hpp

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -23,7 +23,7 @@ include(CheckCXXCompilerFlag)
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -ffast-math -Wunused-parameter -Wextra -Wreorder")
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
     if (HAS_CPP14_FLAG)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -114,3 +114,10 @@ add_executable(${XTENSOR_BENCHMARK_TARGET} EXCLUDE_FROM_ALL ${XTENSOR_BENCHMARK}
 target_link_libraries(${XTENSOR_BENCHMARK_TARGET} ${GBENCHMARK_LIBRARIES})
 
 add_custom_target(xbenchmark COMMAND benchmark_xtensor DEPENDS ${XTENSOR_BENCHMARK_TARGET})
+
+add_custom_target(xpowerbench
+    COMMAND echo "sudo needed to set cpu power governor to performance"
+    COMMAND sudo cpupower frequency-set --governor performance
+    COMMAND benchmark_xtensor
+    COMMAND sudo cpupower frequency-set --governor powersave
+    DEPENDS ${XTENSOR_BENCHMARK_TARGET})

--- a/benchmark/benchmark_views.hpp
+++ b/benchmark/benchmark_views.hpp
@@ -29,14 +29,27 @@ namespace xt
             while (state.KeepRunning())
             {
                 res = sum(x, axes);
+                benchmark::DoNotOptimize(res.data());
+            }
+        }
+
+        template <class E, class X>
+        void benchmark_immediate_reducer(benchmark::State& state, const E& x, E& res, const X& axes)
+        {
+            while (state.KeepRunning())
+            {
+                res = sum(x, axes, evaluation_strategy::immediate());
+                benchmark::DoNotOptimize(res.data());
             }
         }
 
         xarray<double> u = ones<double>({ 10, 100000 });
         xarray<double> v = ones<double>({ 100000, 10 });
+        xarray<double> res2 = ones<double>({ 1 });
 
         std::vector<std::size_t> axis0 = { 0 };
         std::vector<std::size_t> axis1 = { 1 };
+        std::vector<std::size_t> axis_both = { 0, 1 };
 
         static auto res0 = xarray<double>::from_shape({ 100000 });
         static auto res1 = xarray<double>::from_shape({ 10 });
@@ -45,6 +58,13 @@ namespace xt
         BENCHMARK_CAPTURE(benchmark_reducer, 10x100000/axis 1, u, res1, axis1);
         BENCHMARK_CAPTURE(benchmark_reducer, 100000x10/axis 1, v, res1, axis0);
         BENCHMARK_CAPTURE(benchmark_reducer, 100000x10/axis 0, v, res0, axis1);
+        BENCHMARK_CAPTURE(benchmark_reducer, 100000x10/axis both, v, res2, axis_both);
+
+        BENCHMARK_CAPTURE(benchmark_immediate_reducer, 10x100000/axis 0, u, res0, axis0);
+        BENCHMARK_CAPTURE(benchmark_immediate_reducer, 10x100000/axis 1, u, res1, axis1);
+        BENCHMARK_CAPTURE(benchmark_immediate_reducer, 100000x10/axis 1, v, res1, axis0);
+        BENCHMARK_CAPTURE(benchmark_immediate_reducer, 100000x10/axis 0, v, res0, axis1);
+        BENCHMARK_CAPTURE(benchmark_immediate_reducer, 100000x10/axis both, v, res2, axis_both);
 
         template <class E, class X>
         inline auto benchmark_strided_reducer(benchmark::State& state, const E& x, E& res, const X& axes)

--- a/benchmark/benchmark_views.hpp
+++ b/benchmark/benchmark_views.hpp
@@ -96,6 +96,7 @@ namespace xt
                     }
                     res(j) = temp;
                 }
+                benchmark::DoNotOptimize(res.data());
             }
         }
 

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -1,16 +1,16 @@
-// /***************************************************************************
-// * Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
-// *                                                                          *
-// * Distributed under the terms of the BSD 3-Clause License.                 *
-// *                                                                          *
-// * The full license is in the file LICENSE, distributed with this software. *
-// ****************************************************************************/
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
 
 #include <benchmark/benchmark.h>
 
-#include "benchmark_assign.hpp"
-#include "benchmark_math.hpp"
+// #include "benchmark_assign.hpp"
+// #include "benchmark_math.hpp"
 #include "benchmark_views.hpp"
-#include "benchmark_container.hpp"
+// #include "benchmark_container.hpp"
 
 BENCHMARK_MAIN();

--- a/docs/source/api/accumulating_functions.rst
+++ b/docs/source/api/accumulating_functions.rst
@@ -1,0 +1,26 @@
+.. Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Accumulating functions
+======================
+
+**xtensor** provides the following accumulating functions for xexpressions:
+
+Defined in ``xtensor/xmath.hpp``
+
+.. _cumsum-function-reference:
+.. doxygenfunction:: cumsum(E&&)
+   :project: xtensor
+
+.. doxygenfunction:: cumsum(E&&, std::size_t)
+   :project: xtensor
+
+.. _cumprod-function-reference:
+.. doxygenfunction:: cumprod(E&&)
+   :project: xtensor
+
+.. doxygenfunction:: cumprod(E&&, std::size_t)
+   :project: xtensor

--- a/docs/source/api/function_index.rst
+++ b/docs/source/api/function_index.rst
@@ -11,6 +11,7 @@ Functions and generators
 
    xfunction
    xreducer
+   xaccumulator
    xgenerator
    xbuilder
    xrandom

--- a/docs/source/api/reducing_functions.rst
+++ b/docs/source/api/reducing_functions.rst
@@ -12,11 +12,11 @@ Reducing functions
 Defined in ``xtensor/xmath.hpp``
 
 .. _sum-function-reference:
-.. doxygenfunction:: sum(E&&, X&&)
+.. doxygenfunction:: sum(E&&, X&&, ES)
    :project: xtensor
 
 .. _prod-function-reference:
-.. doxygenfunction:: prod(E&&, X&&)
+.. doxygenfunction:: prod(E&&, X&&, ES)
    :project: xtensor
 
 .. _mean-function-reference:

--- a/docs/source/api/xmath.rst
+++ b/docs/source/api/xmath.rst
@@ -25,7 +25,7 @@
        background: initial;
    }
    </style>
-   
+
 Mathematical functions
 ======================
 
@@ -260,3 +260,13 @@ Mathematical functions
 +---------------------------------------+----------------------------------------------------+
 | :ref:`norm_induced_linf <nilinf-ref>` | Induced L-infinity norm of a matrix                |
 +---------------------------------------+----------------------------------------------------+
+
+.. toctree::
+
+   accumulating_functions
+
++---------------------------------------------+-------------------------------------------------+
+| :ref:`cumsum <cumsum-function-reference>`   | cumulative sum of elements over a given axis    |
++---------------------------------------------+-------------------------------------------------+
+| :ref:`cumprod <cumprod-function-reference>` | cumulative product of elements over given axes  |
++---------------------------------------------+-------------------------------------------------+

--- a/docs/source/api/xreducer.rst
+++ b/docs/source/api/xreducer.rst
@@ -13,5 +13,5 @@ Defined in ``xtensor/xreducer.hpp``
    :project: xtensor
    :members:
 
-.. doxygenfunction:: xt::reduce(F&&, E&&, X&&)
+.. doxygenfunction:: xt::reduce(F&&, E&&, X&&, ES)
    :project: xtensor

--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -1,0 +1,152 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_ACCUMULATOR_HPP
+#define XTENSOR_ACCUMULATOR_HPP
+
+#include <algorithm>
+#include <numeric>
+#include <type_traits>
+#include <cstddef>
+
+#include "xtensor_forward.hpp"
+#include "xstrides.hpp"
+#include "xexpression.hpp"
+#include <iostream>
+
+namespace xt
+{
+
+#define DEFAULT_STRATEGY_ACCUMULATORS evaluation_strategy::immediate
+
+    /**************
+     * accumulate *
+     **************/
+
+    namespace detail
+    {
+        template <class F, class E, class ES>
+        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, std::size_t, ES)
+        {
+            static_assert(!std::is_same<evaluation_strategy::lazy, ES>::value, "Lazy accumulators not yet implemented.");
+        }
+
+        template <class F, class E, class ES>
+        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, ES)
+        {
+            static_assert(!std::is_same<evaluation_strategy::lazy, ES>::value, "Lazy accumulators not yet implemented.");
+        }
+
+        template <class F, class E>
+        inline auto accumulator_impl(F&& f, E&& e, std::size_t axis, evaluation_strategy::immediate)
+        {
+            using T = typename F::result_type;
+
+            if (axis >= e.dimension())
+            {
+                throw std::runtime_error("Axis larger than expression dimension in accumulator.");
+            }
+
+            // Investigate if doing a trick with transpose is better here: by transposing the
+            // xarray such that the accumulation axis is last, it should be cache friendly
+            xarray<T, layout_type::row_major> result = e;  // assign + make a copy, we need it anyways
+
+            std::size_t outer_stride = result.strides().back();
+            std::size_t inner_stride = result.strides()[axis];
+
+            std::size_t outer_loop_size = std::accumulate(result.shape().cbegin(),
+                                                          result.shape().cbegin() + std::ptrdiff_t(axis),
+                                                          std::size_t(1), std::multiplies<std::size_t>());
+            std::size_t inner_loop_size = std::accumulate(result.shape().cbegin() + std::ptrdiff_t(axis),
+                                                          result.shape().cend(),
+                                                          std::size_t(1), std::multiplies<std::size_t>());
+            inner_loop_size -= inner_stride;
+
+            std::size_t pos = 0;
+
+            for (std::size_t i = 0; i < outer_loop_size; ++i)
+            {
+                for (std::size_t j = 0; j < inner_loop_size; ++j)
+                {
+                    result.data()[pos + inner_stride] = f(result.data()[pos],
+                                                          result.data()[pos + inner_stride]);
+                    pos += outer_stride;
+                }
+                pos += inner_stride;
+            }
+            return result;
+        }
+
+        template <class F, class E>
+        inline auto accumulator_impl(F&& f, E&& e, evaluation_strategy::immediate)
+        {
+            using T = typename F::result_type;
+            std::size_t sz = e.size();
+
+            // if layout == row_major, avoid a copy
+            if (e.layout() == layout_type::row_major)
+            {
+                xarray<T, layout_type::row_major> result = xarray<T, layout_type::row_major>::from_shape({sz});
+                result.data()[0] = e.data()[0];
+                for (std::size_t i = 0; i < sz - 1; ++i)
+                {
+                    result.data()[i + 1] = f(result.data()[i], e.data()[i + 1]);
+                }
+                return result;
+            }
+            else
+            {
+                xarray<T, layout_type::row_major> result = e;
+                result.reshape({sz});
+
+                for (std::size_t i = 0; i < sz - 1; ++i)
+                {
+                    result.data()[i + 1] = f(result.data()[i], result.data()[i + 1]);
+                }
+                return result;
+            }
+        }
+    }
+
+    /**
+     * Accumulate and flatten array
+     * **NOTE** This function is not lazy!
+     *
+     * @param f Functor to use for accumulation
+     * @param e xexpression to be accumulated
+     *
+     * @return returns xarray<T> filled with accumulated values
+     */
+    template <class F, class E, class ES = DEFAULT_STRATEGY_ACCUMULATORS,
+              typename std::enable_if_t<!std::is_integral<ES>::value, int> = 0>
+    inline auto accumulate(F&& f, E&& e, ES evaluation_strategy = ES())
+    {
+        // Note we need to check is_integral above in order to prohibit ES = int, and not taking the std::size_t
+        // overload below!
+        return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), evaluation_strategy);
+    }
+
+    /**
+     * Accumulate over axis
+     * **NOTE** This function is not lazy!
+     *
+     * @param f Functor to use for accumulation
+     * @param e xexpression to accumulate
+     * @param axis Axis to perform accumulation over
+     *
+     * @return returns xarray<T> filled with accumulated values
+     */
+    template <class F, class E, class ES = DEFAULT_STRATEGY_ACCUMULATORS>
+    inline auto accumulate(F&& f, E&& e, std::size_t axis, ES evaluation_strategy = ES())
+    {
+        return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), axis, evaluation_strategy);
+    }
+
+}
+
+#endif

--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -21,10 +21,10 @@
 #include "xmath.hpp"
 #include "xview.hpp"
 
-#if _WIN32
-using precision_type = typename std::streamsize;
+#ifdef _WIN32
+    using precision_type = typename std::streamsize;
 #else
-using precision_type = int;
+    using precision_type = int;
 #endif
 
 namespace xt

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -195,7 +195,8 @@ namespace xt
         bool merge = false;
 
         // TODO there could be some performance gain by removing merge checking
-        //      when axes.size() == 1
+        //      when axes.size() == 1 and even next_idx could be removed for something simpler (next_stride always the same)
+        //      best way to do this would be to create a function that takes (begin, out, outer_loop_size, inner_loop_size, next_idx_lambda)
         // Decide if going about it row-wise or col-wise
         if (inner_stride == 1)
         {

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -140,6 +140,24 @@ namespace xt
         {
         };
     }
+
+    namespace evaluation_strategy
+    {
+        struct base
+        {
+        };
+        struct immediate : base
+        {
+        };
+        struct lazy : base
+        {
+        };
+        /*
+        struct cached
+        {
+        };
+        */
+    }
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 set(XTENSOR_TESTS
     main.cpp
     test_common.hpp
+    test_xaccumulator.cpp
     test_xadapt.cpp
     test_xadaptor_semantic.cpp
     test_xarray.cpp

--- a/test/test_xaccumulator.cpp
+++ b/test/test_xaccumulator.cpp
@@ -1,0 +1,173 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include "xtensor/xaccumulator.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xmath.hpp"
+#include "xtensor/xio.hpp"
+
+namespace xt
+{
+    TEST(xaccumulator, one_d)
+    {
+        xt::xarray<short> a = { short(1), short(2), short(3), short(4)};
+        xt::xarray<long> expected = { 1, 3, 6, 10};
+        auto no_axis = cumsum(a);
+        auto with_axis = cumsum(a, 0);
+        bool promotion_works = std::is_same<decltype(no_axis)::value_type, long long>::value;
+        EXPECT_TRUE(promotion_works);
+        EXPECT_TRUE(all(equal(no_axis, expected)));
+
+        EXPECT_TRUE(all(equal(with_axis, expected)));
+    }
+
+    TEST(xaccumulator, four_d)
+    {
+        xarray<double> arg_0 = {{{{ 0., 1., 2.},
+                                  { 3., 4., 5.}},
+
+                                 {{ 6., 7., 8.},
+                                  { 9.,10.,11.}},
+
+                                 {{12.,13.,14.},
+                                  {15.,16.,17.}}},
+
+
+                                {{{18.,19.,20.},
+                                  {21.,22.,23.}},
+
+                                 {{24.,25.,26.},
+                                  {27.,28.,29.}},
+
+                                 {{30.,31.,32.},
+                                  {33.,34.,35.}}}};
+        auto res = cumsum(arg_0);
+        xarray<double> expected = {  0.,  1.,  3.,  6., 10., 15., 21., 28., 36., 45., 55., 66., 78., 91.,
+                                   105.,120.,136.,153.,171.,190.,210.,231.,253.,276.,300.,325.,351.,378.,
+                                   406.,435.,465.,496.,528.,561.,595.,630.};
+        EXPECT_TRUE(allclose(expected, res));
+
+        auto res_0 = cumsum(arg_0, 0);
+        xarray<double> expected_0 = {{{{ 0., 1., 2.},
+                                       { 3., 4., 5.}},
+
+                                      {{ 6., 7., 8.},
+                                       { 9.,10.,11.}},
+
+                                      {{12.,13.,14.},
+                                       {15.,16.,17.}}},
+
+
+                                     {{{18.,20.,22.},
+                                       {24.,26.,28.}},
+
+                                      {{30.,32.,34.},
+                                       {36.,38.,40.}},
+
+                                      {{42.,44.,46.},
+                                       {48.,50.,52.}}}};
+
+        EXPECT_TRUE(all(equal(expected_0, res_0)));
+
+        auto res_1 = cumsum(arg_0, 1);
+        xarray<double> expected_1 = {{{{ 0., 1., 2.},
+                                       { 3., 4., 5.}},
+
+                                      {{ 6., 8.,10.},
+                                       {12.,14.,16.}},
+
+                                      {{18.,21.,24.},
+                                       {27.,30.,33.}}},
+
+
+                                     {{{18.,19.,20.},
+                                       {21.,22.,23.}},
+
+                                      {{42.,44.,46.},
+                                       {48.,50.,52.}},
+
+                                      {{72.,75.,78.},
+                                       {81.,84.,87.}}}};
+        EXPECT_TRUE(all(equal(res_1, expected_1)));
+
+        auto res_2 = cumsum(arg_0, 2);
+        xarray<double> expected_2 = {{{{ 0., 1., 2.},
+                                      { 3., 5., 7.}},
+
+                                     {{ 6., 7., 8.},
+                                      {15.,17.,19.}},
+
+                                     {{12.,13.,14.},
+                                      {27.,29.,31.}}},
+
+
+                                    {{{18.,19.,20.},
+                                      {39.,41.,43.}},
+
+                                     {{24.,25.,26.},
+                                      {51.,53.,55.}},
+
+                                     {{30.,31.,32.},
+                                      {63.,65.,67.}}}};
+
+        EXPECT_TRUE(all(equal(res_2, expected_2)));
+
+        auto res_3 = cumsum(arg_0, 3);
+        xarray<double> expected_3 = {{{{  0.,  1.,  3.},
+                                       {  3.,  7., 12.}},
+
+                                      {{  6., 13., 21.},
+                                       {  9., 19., 30.}},
+
+                                      {{ 12., 25., 39.},
+                                       { 15., 31., 48.}}},
+
+
+                                     {{{ 18., 37., 57.},
+                                       { 21., 43., 66.}},
+
+                                      {{ 24., 49., 75.},
+                                       { 27., 55., 84.}},
+
+                                      {{ 30., 61., 93.},
+                                       { 33., 67.,102.}}}};
+        EXPECT_TRUE(allclose(expected_3, res_3));
+    }
+
+    TEST(xaccumulator, cumprod)
+    {
+        xarray<long> arg_0 = {{ 0, 1, 2},
+                              { 3, 4, 5},
+                              { 6, 7, 8},
+                              { 9,10,11}};
+        auto res = cumprod(arg_0);
+
+        xarray<long> expected = {0,0,0,0,0,0,0,0,0,0,0,0};
+        EXPECT_TRUE(allclose(expected, res));
+
+        auto res_0 = cumprod(arg_0, 0);
+        xarray<long> expected_0 = {{  0,   1,   2},
+                                   {  0,   4,  10},
+                                   {  0,  28,  80},
+                                   {  0, 280, 880}};
+        EXPECT_TRUE(allclose(expected_0, res_0));
+
+        auto res_1 = cumprod(arg_0, 1);
+        xarray<long> expected_1 = {{  0,  0,   0},
+                                   {  3, 12,  60},
+                                   {  6, 42, 336},
+                                   {  9, 90, 990}};
+        EXPECT_TRUE(allclose(expected_1, res_1));
+
+
+
+    }
+}

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -40,6 +40,7 @@ namespace xt
             }
         }
     }
+
     TEST(xreducer, functor_type)
     {
         auto sum = [](auto const& left, auto const& right) { return left + right; };
@@ -177,5 +178,66 @@ namespace xt
 
         xarray<uint8_t> c = {1, 2};
         EXPECT_EQ(mean(c)(), 1.5);
+    }
+
+    TEST(xreducer, immediate)
+    {
+        xarray<double> a = xt::arange(27);
+        a.reshape({3, 3, 3});
+
+        xarray<double> a_lz = sum(a);
+        auto a_gd = sum(a, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1});
+        a_gd = sum(a, {1}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {0, 2});
+        a_gd = sum(a, {0, 2}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1, 2});
+        a_gd = sum(a, {1, 2}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a = xt::arange(4 * 3 * 6 * 2 * 7);
+        a.reshape({4, 3, 6, 2, 7});
+
+        a_lz = sum(a);
+        a_gd = sum(a, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1});
+        a_gd = sum(a, {1}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {0, 2});
+        a_gd = sum(a, {0, 2}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1, 2});
+        a_gd = sum(a, {1, 2}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1, 3, 4});
+        a_gd = sum(a, {1, 3, 4}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {0, 1, 4});
+        a_gd = sum(a, {0, 1, 4}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {0, 1, 3});
+        a_gd = sum(a, {0, 1, 3}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {0, 2, 3});
+        a_gd = sum(a, {0, 2, 3}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
+
+        a_lz = sum(a, {1, 2, 3});
+        a_gd = sum(a, {1, 2, 3}, evaluation_strategy::immediate());
+        EXPECT_EQ(a_lz, a_gd);
     }
 }

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -137,6 +137,7 @@ namespace xt
         EXPECT_TRUE((std::is_same<promote_type_t<bool>, bool>::value));
 
         EXPECT_TRUE((std::is_same<big_promote_type_t<uint8_t>, unsigned long long>::value));
+        EXPECT_TRUE((std::is_same<big_promote_type_t<short>, long long>::value));
         EXPECT_TRUE((std::is_same<big_promote_type_t<int>, long long>::value));
         EXPECT_TRUE((std::is_same<big_promote_type_t<float>, double>::value));
         EXPECT_TRUE((std::is_same<big_promote_type_t<double>, double>::value));


### PR DESCRIPTION
… (cumsum, cumprod)

This is also split out of the #488 PR.

It still requires fixing for column_major reductions (test currently segfault).