### PR TITLE
Modulus operator

### DIFF
--- a/docs/source/operator.rst
+++ b/docs/source/operator.rst
@@ -18,6 +18,7 @@ Arithmetic operators
 - ``operator-``
 - ``operator*``
 - ``operator/``
+- ``operator%``
 
 All these operators are element-wise operators and apply the lazy broadcasting rules explained in
 a previous section.

--- a/include/xtensor/xindexview.hpp
+++ b/include/xtensor/xindexview.hpp
@@ -206,6 +206,9 @@ namespace xt
         template <class E>
         disable_xexpression<E, self_type&> operator/=(const E&);
 
+        template <class E>
+        disable_xexpression<E, self_type&> operator%=(const E&);
+        
     private:
 
         template <class F>
@@ -558,6 +561,18 @@ namespace xt
     inline auto xfiltration<ECT, CCT>::operator/=(const E& e) -> disable_xexpression<E, self_type&>
     {
         return apply([this, &e](const_reference v, bool cond) { return cond ? v / e : v; });
+    }
+
+    /**
+     * Computes the remainder of \c *this after division by the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class ECT, class CCT>
+    template <class E>
+    inline auto xfiltration<ECT, CCT>::operator%=(const E& e) -> disable_xexpression<E, self_type&>
+    {
+        return apply([this, &e](const_reference v, bool cond) { return cond ? v % e : v; });
     }
 
     template <class ECT, class CCT>

--- a/include/xtensor/xnoalias.hpp
+++ b/include/xtensor/xnoalias.hpp
@@ -37,6 +37,9 @@ namespace xt
         template <class E>
         A& operator/=(const xexpression<E>& e);
 
+        template <class E>
+        A& operator%=(const xexpression<E>& e);
+        
     private:
 
         A& m_array;
@@ -90,6 +93,13 @@ namespace xt
         return m_array.divides_assign(e);
     }
 
+    template <class A>
+    template <class E>
+    inline A& noalias_proxy<A>::operator%=(const xexpression<E>& e)
+    {
+        return m_array.modulus_assign(e);
+    }
+    
     template <class A>
     inline noalias_proxy<A> noalias(A& a) noexcept
     {

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -119,6 +119,7 @@ namespace xt
         BINARY_OPERATOR_FUNCTOR(minus, -);
         BINARY_OPERATOR_FUNCTOR(multiplies, *);
         BINARY_OPERATOR_FUNCTOR(divides, /);
+        BINARY_OPERATOR_FUNCTOR(modulus, %);
         BINARY_BOOL_OPERATOR_FUNCTOR(logical_or, ||);
         BINARY_BOOL_OPERATOR_FUNCTOR(logical_and, &&);
         UNARY_BOOL_OPERATOR_FUNCTOR(logical_not, !);
@@ -363,6 +364,23 @@ namespace xt
         return detail::make_xfunction<detail::divides>(std::forward<E1>(e1), std::forward<E2>(e2));
     }
 
+    /**
+     * @ingroup arithmetic_operators
+     * @brief Modulus
+     *
+     * Returns an \ref xfunction for the element-wise modulus
+     * of \a e1 by \a e2.
+     * @param e1 an \ref xexpression or a scalar
+     * @param e2 an \ref xexpression or a scalar
+     * @return an \ref xfunction
+     */
+    template <class E1, class E2>
+    inline auto operator%(E1&& e1, E2&& e2) noexcept
+    -> detail::xfunction_type_t<detail::modulus, E1, E2>
+    {
+        return detail::make_xfunction<detail::modulus>(std::forward<E1>(e1), std::forward<E2>(e2));
+    }
+    
     /**
      * @defgroup logical_operators Logical operators
      */

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -51,6 +51,9 @@ namespace xt
         disable_xexpression<E, derived_type&> operator/=(const E&);
 
         template <class E>
+        disable_xexpression<E, derived_type&> operator%=(const E&);
+        
+        template <class E>
         disable_xexpression<E, derived_type&> operator&=(const E&);
 
         template <class E>
@@ -70,6 +73,9 @@ namespace xt
 
         template <class E>
         derived_type& operator/=(const xexpression<E>&);
+
+        template <class E>
+        derived_type& operator%=(const xexpression<E>&);
 
         template <class E>
         derived_type& operator&=(const xexpression<E>&);
@@ -94,7 +100,10 @@ namespace xt
 
         template <class E>
         derived_type& divides_assign(const xexpression<E>&);
-
+        
+        template <class E>
+        derived_type& modulus_assign(const xexpression<E>&);
+        
     protected:
 
         xsemantic_base() = default;
@@ -258,6 +267,18 @@ namespace xt
     }
 
     /**
+     * Computes the remainder of \c *this after division by the scalar \c e.
+     * @param e the scalar involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator%=(const E& e) -> disable_xexpression<E, derived_type&>
+    {
+        return this->derived_cast().scalar_computed_assign(e, std::modulus<>());
+    }
+    
+    /**
      * Computes the bitwise and of \c *this and the scalar \c e and assigns it to \c *this.
      * @param e the scalar involved in the operation.
      * @return a reference to \c *this.
@@ -341,6 +362,18 @@ namespace xt
         return operator=(this->derived_cast() / e.derived_cast());
     }
 
+    /**
+     * Computes the remainder of \c *this after division by the xexpression \c e.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::operator%=(const xexpression<E>& e) -> derived_type&
+    {
+        return operator=(this->derived_cast() % e.derived_cast());
+    }
+    
     /**
      * Computes the bitwise and of \c *this and the xexpression \c e and assigns it to \c *this.
      * @param e the xexpression involved in the operation.
@@ -446,6 +479,19 @@ namespace xt
         return this->derived_cast().computed_assign(this->derived_cast() / e.derived_cast());
     }
 
+    /**
+     * Computes the remainder of \c *this after division by the xexpression \c e.
+     * Ensures no temporary will be used to perform the assignment.
+     * @param e the xexpression involved in the operation.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::modulus_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() % e.derived_cast());
+    }
+    
     template <class D>
     template <class E>
     inline auto xsemantic_base<D>::operator=(const xexpression<E>& e) -> derived_type&

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -137,6 +137,23 @@ namespace xt
         EXPECT_EQ((sa / b)(0, 0), sa / b(0, 0));
     }
 
+    TYPED_TEST(operation, modulus)
+    {
+        using int_container = rebind_container_t<TypeParam, int>;
+        using shape_type = typename int_container::shape_type;
+
+        shape_type shape = {3, 2};
+        int_container a(shape, 11);
+        int_container b(shape, 3);
+        EXPECT_EQ((a % b)(0, 0), a(0, 0) % b(0, 0));
+        
+        int sb = 3;
+        EXPECT_EQ((a % sb)(0, 0), a(0, 0) % sb);
+        
+        int sa = 11;
+        EXPECT_EQ((sa % b)(0, 0), sa % b(0, 0));
+    }
+    
     template <class T>
     struct int_rebind;
 


### PR DESCRIPTION
I think it would be nice if `xtensor` supported `operator%` for `xexpression`s.  This requires a slightly more complicated implementation than the other arithmetic operators, since one can't use `%` with non-integer operands.

My first attempt at implementing this PR failed.  I had attempted to selectively disable the modulus function in `xsemantic.hpp` (and elsewhere) for non-integer types via `enable_if`, but it turns out that doesn't work.  The `xexpression_type` is "incomplete" (since the `xsemantic` hierarchy employs the CRTP), so `enable_if` can't be used at that level.  (Unless I'm missing something... I'm not an expert.)

Instead, this PR uses a simpler solution.  The `modulus` operation exists for all `xexpression` (even non-integer ones), but the implementation for non-integer types throws an exception at runtime.

(Except for the code in `xoperation.hpp`, the rest of this PR is merely copied from the other arithmetic operators.)