### PR TITLE
Rename xadapt() -> adapt()

### DIFF
--- a/docs/source/api/xarray_adaptor.rst
+++ b/docs/source/api/xarray_adaptor.rst
@@ -13,19 +13,19 @@ Defined in ``xtensor/xarray.hpp``
    :project: xtensor
    :members:
 
-xadapt (xarray_adaptor)
+adapt (xarray_adaptor)
 =======================
 
 Defined in ``xtensor/xadapt.hpp``
 
-.. doxygenfunction:: xt::xadapt(C&&, const SC&, layout_type)
+.. doxygenfunction:: xt::adapt(C&&, const SC&, layout_type)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(C&&, const SC&, const SC&)
+.. doxygenfunction:: xt::adapt(C&&, const SC&, const SC&)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(P&&, typename A::size_type, O, const SC&, layout_type, const A&)
+.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, const SC&, layout_type, const A&)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(P&&, typename A::size_type, O, const SC&, const SC&, const A&)
+.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, const SC&, const SC&, const A&)
    :project: xtensor

--- a/docs/source/api/xtensor_adaptor.rst
+++ b/docs/source/api/xtensor_adaptor.rst
@@ -13,19 +13,19 @@ Defined in ``xtensor/xtensor.hpp``
    :project: xtensor
    :members:
 
-xadapt (xtensor_adaptor)
+adapt (xtensor_adaptor)
 ========================
 
 Defined in ``xtensor/xadapt.hpp``
 
-.. doxygenfunction:: xt::xadapt(C&&, const std::array<typename std::decay_t<C>::size_type, N>&, layout_type)
+.. doxygenfunction:: xt::adapt(C&&, const std::array<typename std::decay_t<C>::size_type, N>&, layout_type)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(C&&, const std::array<typename std::decay_t<C>::size_type, N>&, const std::array<typename std::decay_t<C>::size_type, N>&)
+.. doxygenfunction:: xt::adapt(C&&, const std::array<typename std::decay_t<C>::size_type, N>&, const std::array<typename std::decay_t<C>::size_type, N>&)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(P&&, typename A::size_type, O, const std::array<typename A::size_type, N>&, layout_type, const A&)
+.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, const std::array<typename A::size_type, N>&, layout_type, const A&)
    :project: xtensor
 
-.. doxygenfunction:: xt::xadapt(P&&, typename A::size_type, O, const std::array<typename A::size_type, N>&, const std::array<typename A::size_type, N>&, const A&)
+.. doxygenfunction:: xt::adapt(P&&, typename A::size_type, O, const std::array<typename A::size_type, N>&, const std::array<typename A::size_type, N>&, const A&)
    :project: xtensor

--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -33,7 +33,7 @@ namespace xt
      * @param l the layout_type of the xarray_adaptor
      */
     template <class C, class SC, layout_type L = DEFAULT_LAYOUT, typename std::enable_if_t<!detail::is_array<SC>::value, int> = 0>
-    auto xadapt(C&& container, const SC& shape, layout_type l = L);
+    auto adapt(C&& container, const SC& shape, layout_type l = L);
 
     /**
      * Constructs an xarray_adaptor of the given stl-like container,
@@ -43,7 +43,7 @@ namespace xt
      * @param strides the strides of the xarray_adaptor
      */
     template <class C, class SC, typename std::enable_if_t<!detail::is_array<SC>::value, int> = 0>
-    auto xadapt(C&& container, const SC& shape, const SC& strides);
+    auto adapt(C&& container, const SC& shape, const SC& strides);
 
     /**
      * Constructs an xarray_adaptor of the given dynamically allocated C array,
@@ -57,7 +57,7 @@ namespace xt
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
     template <class P, class O, class SC, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<P>>>, typename std::enable_if_t<!detail::is_array<SC>::value, int> = 0>
-    auto xadapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
+    auto adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
 
     /**
      * Constructs an xarray_adaptor of the given dynamically allocated C array,
@@ -71,7 +71,7 @@ namespace xt
      * @param alloc the allocator used for allocating / deallocating the dynamic array
     */
     template <class P, class O, class SC, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<P>>>, typename std::enable_if_t<!detail::is_array<SC>::value, int> = 0>
-    auto xadapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, const SC& strides, const A& alloc = A());
+    auto adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, const SC& strides, const A& alloc = A());
 
     /***************************
      * xtensor_adaptor builder *
@@ -85,7 +85,7 @@ namespace xt
      */
     template <class C, layout_type L = DEFAULT_LAYOUT>
     xtensor_adaptor<C, 1, L>
-    xadapt(C&& container, layout_type l = L);
+    adapt(C&& container, layout_type l = L);
     
     /**
      * Constructs an xtensor_adaptor of the given stl-like container,
@@ -96,7 +96,7 @@ namespace xt
      */
     template <class C, std::size_t N, layout_type L = DEFAULT_LAYOUT>
     xtensor_adaptor<C, N, L>
-    xadapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, layout_type l = L);
+    adapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, layout_type l = L);
 
     /**
      * Constructs an xtensor_adaptor of the given stl-like container,
@@ -107,7 +107,7 @@ namespace xt
      */
     template <class C, std::size_t N>
     xtensor_adaptor<C, N, layout_type::dynamic>
-    xadapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, const std::array<typename std::decay_t<C>::size_type, N>& strides);
+    adapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, const std::array<typename std::decay_t<C>::size_type, N>& strides);
 
     /**
      * Constructs a 1D xtensor_adaptor of the given dynamically allocated C array,
@@ -121,7 +121,7 @@ namespace xt
      */
     template <class P, class O, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<P>>>>
     xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, 1, L>
-    xadapt(P&& pointer, typename A::size_type size, O ownership, layout_type l = L, const A& alloc = A());
+    adapt(P&& pointer, typename A::size_type size, O ownership, layout_type l = L, const A& alloc = A());
 
     /**
      * Constructs an xtensor_adaptor of the given dynamically allocated C array,
@@ -136,7 +136,7 @@ namespace xt
      */
     template <class P, std::size_t N, class O, layout_type L = DEFAULT_LAYOUT, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<P>>>>
     xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, N, L>
-    xadapt(P&& pointer, typename A::size_type size, O ownership,
+    adapt(P&& pointer, typename A::size_type size, O ownership,
            const std::array<typename A::size_type, N>& shape, layout_type l = L, const A& alloc = A());
 
     /**
@@ -152,7 +152,7 @@ namespace xt
      */
     template <class P, std::size_t N, class O, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<P>>>>
     xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, N, layout_type::dynamic>
-    xadapt(P&& pointer, typename A::size_type size, O ownership,
+    adapt(P&& pointer, typename A::size_type size, O ownership,
            const std::array<typename A::size_type, N>& shape, const std::array<typename A::size_type, N>& strides, const A& alloc = A());
 
     /*****************************************
@@ -160,19 +160,19 @@ namespace xt
      *****************************************/
 
     template <class C, class SC, layout_type L, typename std::enable_if_t<!detail::is_array<SC>::value, int>>
-    inline auto xadapt(C&& container, const SC& shape, layout_type l)
+    inline auto adapt(C&& container, const SC& shape, layout_type l)
     {
         return xarray_adaptor<xtl::closure_type_t<C>, L, SC>(std::forward<C>(container), shape, l);
     }
 
     template <class C, class SC, typename std::enable_if_t<!detail::is_array<SC>::value, int>>
-    inline auto xadapt(C&& container, const SC& shape, const SC& strides)
+    inline auto adapt(C&& container, const SC& shape, const SC& strides)
     {
         return xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, SC>(std::forward<C>(container), shape, strides);
     }
 
     template <class P, class O, class SC, layout_type L, class A, typename std::enable_if_t<!detail::is_array<SC>::value, int>>
-    inline auto xadapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
+    inline auto adapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
     {
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         buffer_type buf(std::forward<P>(pointer), size, alloc);
@@ -180,7 +180,7 @@ namespace xt
     }
 
     template <class P, class O, class SC, class A, typename std::enable_if_t<!detail::is_array<SC>::value, int>>
-    inline auto xadapt(P&& pointer, typename A::size_type size, O, const SC& shape, const SC& strides, const A& alloc)
+    inline auto adapt(P&& pointer, typename A::size_type size, O, const SC& shape, const SC& strides, const A& alloc)
     {
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         buffer_type buf(std::forward<P>(pointer), size, alloc);
@@ -193,7 +193,7 @@ namespace xt
 
     template <class C, layout_type L>
     inline xtensor_adaptor<C, 1, L>
-    xadapt(C&& container, layout_type l)
+    adapt(C&& container, layout_type l)
     {
         const std::array<typename std::decay_t<C>::size_type, 1> shape{container.size()};
         return xtensor_adaptor<xtl::closure_type_t<C>, 1, L>(std::forward<C>(container), shape, l);
@@ -201,21 +201,21 @@ namespace xt
     
     template <class C, std::size_t N, layout_type L>
     inline xtensor_adaptor<C, N, L>
-    xadapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, layout_type l)
+    adapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, layout_type l)
     {
         return xtensor_adaptor<xtl::closure_type_t<C>, N, L>(std::forward<C>(container), shape, l);
     }
 
     template <class C, std::size_t N>
     inline xtensor_adaptor<C, N, layout_type::dynamic>
-    xadapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, const std::array<typename std::decay_t<C>::size_type, N>& strides)
+    adapt(C&& container, const std::array<typename std::decay_t<C>::size_type, N>& shape, const std::array<typename std::decay_t<C>::size_type, N>& strides)
     {
         return xtensor_adaptor<xtl::closure_type_t<C>, N, layout_type::dynamic>(std::forward<C>(container), shape, strides);
     }
 
     template <class P, class O, layout_type L, class A>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, 1, L>
-    xadapt(P&& pointer, typename A::size_type size, O, layout_type l, const A& alloc)
+    adapt(P&& pointer, typename A::size_type size, O, layout_type l, const A& alloc)
     {
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         buffer_type buf(std::forward<P>(pointer), size, alloc);
@@ -225,7 +225,7 @@ namespace xt
 
     template <class P, std::size_t N, class O, layout_type L, class A>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, N, L>
-    xadapt(P&& pointer, typename A::size_type size, O,
+    adapt(P&& pointer, typename A::size_type size, O,
            const std::array<typename A::size_type, N>& shape, layout_type l, const A& alloc)
     {
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
@@ -235,7 +235,7 @@ namespace xt
 
     template <class P, std::size_t N, class O, class A>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, N, layout_type::dynamic>
-    xadapt(P&& pointer, typename A::size_type size, O,
+    adapt(P&& pointer, typename A::size_type size, O,
            const std::array<typename A::size_type, N>& shape, const std::array<typename A::size_type, N>& strides, const A& alloc)
     {
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;

--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -557,7 +557,7 @@ namespace xt
             {
                 auto cast_elems = cast_impl<T, L>(check_type);
                 m_buffer = nullptr;
-                return xadapt(std::move(std::get<0>(cast_elems)), std::get<1>(cast_elems),
+                return adapt(std::move(std::get<0>(cast_elems)), std::get<1>(cast_elems),
                               acquire_ownership(), std::get<2>(cast_elems), std::get<3>(cast_elems));
             }
 
@@ -565,7 +565,7 @@ namespace xt
             auto cast(bool check_type = true) const &
             {
                 auto cast_elems = cast_impl<T, L>(check_type);
-                return xadapt(std::get<0>(cast_elems), std::get<1>(cast_elems),
+                return adapt(std::get<0>(cast_elems), std::get<1>(cast_elems),
                               no_ownership(), std::get<2>(cast_elems), std::get<3>(cast_elems));
             }
 
@@ -573,7 +573,7 @@ namespace xt
             auto cast(bool check_type = true) &
             {
                 auto cast_elems = cast_impl<T, L>(check_type);
-                return xadapt(std::get<0>(cast_elems), std::get<1>(cast_elems),
+                return adapt(std::get<0>(cast_elems), std::get<1>(cast_elems),
                               no_ownership(), std::get<2>(cast_elems), std::get<3>(cast_elems));
             }
 

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -14,18 +14,18 @@ namespace xt
 {
     using vec_type = std::vector<int>;
 
-    TEST(xarray_adaptor, xadapt)
+    TEST(xarray_adaptor, adapt)
     {
         vec_type v(4, 0);
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({2, 2});
 
-        auto a1 = xadapt(v, s);
+        auto a1 = adapt(v, s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, v[a1.strides()[1]]);
 
         shape_type str({2, 1});
-        auto a2 = xadapt(v, s, str);
+        auto a2 = adapt(v, s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, v[2]);
     }
@@ -37,12 +37,12 @@ namespace xt
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({2, 2});
 
-        auto a1 = xadapt(data, size, no_ownership(), s);
+        auto a1 = adapt(data, size, no_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[a1.strides()[1]]);
 
         shape_type str({2, 1});
-        auto a2 = xadapt(data, size, no_ownership(), s, str);
+        auto a2 = adapt(data, size, no_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data[2]);
 
@@ -57,20 +57,20 @@ namespace xt
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({2, 2});
 
-        auto a1 = xadapt(data, size, acquire_ownership(), s);
+        auto a1 = adapt(data, size, acquire_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[a1.strides()[1]]);
 
         shape_type str({2, 1});
-        auto a2 = xadapt(data2, size, acquire_ownership(), s, str);
+        auto a2 = adapt(data2, size, acquire_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data2[2]);
     }
 
-    TEST(xtensor_adaptor, xadapt)
+    TEST(xtensor_adaptor, adapt)
     {
         vec_type v0(4, 0);
-        auto a0 = xadapt(v0);
+        auto a0 = adapt(v0);
         a0(0) = 1;
         a0(3) = 3;
         EXPECT_EQ(1, v0[0]);
@@ -80,12 +80,12 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = xadapt(v, s);
+        auto a1 = adapt(v, s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, v[a1.strides()[1]]);
 
         shape_type str = {2, 1};
-        auto a2 = xadapt(v, s, str);
+        auto a2 = adapt(v, s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, v[2]);
     }
@@ -95,19 +95,19 @@ namespace xt
         size_t size = 4;
         int* data = new int[size];
 
-        auto a0 = xadapt(data, size, no_ownership());
+        auto a0 = adapt(data, size, no_ownership());
         a0(3) = 3;
         EXPECT_EQ(3, data[3]);
 
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = xadapt(data, size, no_ownership(), s);
+        auto a1 = adapt(data, size, no_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[a1.strides()[1]]);
 
         shape_type str = {2, 1};
-        auto a2 = xadapt(data, size, no_ownership(), s, str);
+        auto a2 = adapt(data, size, no_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data[2]);
 
@@ -121,19 +121,19 @@ namespace xt
         int* data1 = new int[size];
         int* data2 = new int[size];
 
-        auto a0 = xadapt(data0, size, acquire_ownership());
+        auto a0 = adapt(data0, size, acquire_ownership());
         a0(3) = 3;
         EXPECT_EQ(3, data0[3]);
 
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = xadapt(data1, size, acquire_ownership(), s);
+        auto a1 = adapt(data1, size, acquire_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data1[a1.strides()[1]]);
 
         shape_type str = {2, 1};
-        auto a2 = xadapt(data2, size, acquire_ownership(), s, str);
+        auto a2 = adapt(data2, size, acquire_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data2[2]);
     }
@@ -146,12 +146,12 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = xadapt(std::move(data), size, acquire_ownership(), s);
+        auto a1 = adapt(std::move(data), size, acquire_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[a1.strides()[1]]);
 
         shape_type str = {2, 1};
-        auto a2 = xadapt(std::move(data2), size, acquire_ownership(), s, str);
+        auto a2 = adapt(std::move(data2), size, acquire_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data2[2]);
     }


### PR DESCRIPTION
Fixes #546

Technically, this is a breaking change, albeit a small one.  Does that mean it should wait until the next major release?

cc @constantinpape

<details>
<summary>details</summary>

```bash
# Rename xadapt -> adapt
$ git grep -l xadapt | xargs sed -i '' 's/xadapt\([^a-zA-Z.]\)/adapt\1/g'

# Note: Header name is unchanged.
$ git grep xadapt
CMakeLists.txt:    ${XTENSOR_INCLUDE_DIR}/xtensor/xadapt.hpp
docs/source/adaptor.rst:    #include "xtensor/xadapt.hpp"
docs/source/adaptor.rst:    #include "xtensor/xadapt.hpp"
docs/source/adaptor.rst:    #include "xtensor/xadapt.hpp"
docs/source/api/xarray_adaptor.rst:Defined in ``xtensor/xadapt.hpp``
docs/source/api/xtensor_adaptor.rst:Defined in ``xtensor/xadapt.hpp``
docs/source/external-structures.rst:``xadaptor_semantic`` instead.
include/xtensor/xnpy.hpp:#include "xtensor/xadapt.hpp"
test/CMakeLists.txt:    test_xadapt.cpp
test/CMakeLists.txt:    test_xadaptor_semantic.cpp
test/test_xadapt.cpp:#include "xtensor/xadapt.hpp"
```

</details>
