### PR TITLE
allow conda-forge as fallback channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: xtensor
 channels:
-  - nodefaults
   - QuantStack
+  - conda-forge
 dependencies:
   - xtensor
   - xtensor-blas


### PR DESCRIPTION
for any packages not provided by QuantStack.

This is instead of opting out of defaults, which results in unsatisfiable dependencies without a provider for the missing packages.

    conda env create -f environment.yml

fails with this file right now, because not all dependencies of the environment are on the QuantStack channel.

Channel priority keeps defaults-channel or conda-forge updates from being used in favor QuantStack-provided packages, regardless of version.

This file is being used on Binder and I'm investigating right now because the quantstack binders are pinning an old version of `notebook` (5.0.0) as a result of packaging `notebook` on the QuantStack channel, which is treated as higher priority than conda-forge.

Because of channel priority, even after this change quantstack notebook (and everything else) is still going to be installed, downgrading whatever was in the env prior from other channels.

What packages are only available / should be installed from the quantstack channel? Because of how conda channel priority is resolved, I would recommend *removing* any conda packages from the quantstack channel that you aren't planning to keep up to date (e.g. 'notebook' itself), and only provide those you need to differ from what's in defaults and/or conda-forge (your preference). You can effectively remove packages without pulling them down by changing the 'label' on anaconda.org to something other than 'main'.