### PR TITLE
xscalar_expression_tag added

### DIFF
--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -225,6 +225,10 @@ namespace xt
      * expression tag system *
      *************************/
 
+    struct xscalar_expression_tag
+    {
+    };
+
     struct xtensor_expression_tag
     {
     };
@@ -263,6 +267,24 @@ namespace xt
         struct expression_tag_and<T, T>
         {
             using type = T;
+        };
+
+        template <>
+        struct expression_tag_and<xscalar_expression_tag, xscalar_expression_tag>
+        {
+            using type = xscalar_expression_tag;
+        };
+
+        template <class T>
+        struct expression_tag_and<xscalar_expression_tag, T>
+        {
+            using type = T;
+        };
+
+        template <class T>
+        struct expression_tag_and<T, xscalar_expression_tag>
+            : expression_tag_and<xscalar_expression_tag, T>
+        {
         };
 
         template <>

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -189,6 +189,12 @@ namespace xt
         struct select_xfunction_expression;
 
         template <class F, class... E>
+        struct select_xfunction_expression<xscalar_expression_tag, F, E...>
+        {
+            using type = typename select_xfunction_expression<xtensor_expression_tag, F, E...>::type;
+        };
+
+        template <class F, class... E>
         struct select_xfunction_expression<xtensor_expression_tag, F, E...>
         {
             using type = xfunction<F, typename F::result_type, E...>;
@@ -205,6 +211,12 @@ namespace xt
 
         template <class Tag, template <class...> class F, class... E>
         struct build_functor_type;
+
+        template <template <class...> class F, class... E>
+        struct build_functor_type<xscalar_expression_tag, F, E...>
+        {
+            using type = typename build_functor_type<xtensor_expression_tag, F, E...>::type;
+        };
 
         template <template <class...> class F, class... E>
         struct build_functor_type<xtensor_expression_tag, F, E...>

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -68,6 +68,7 @@ namespace xt
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
+        using expression_tag = xscalar_expression_tag;
 
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;


### PR DESCRIPTION
This allows to mix scalar and any expression type in expression systems built upon the one of xtensor. Without this, a new expression system that wants to mix expressions and scalars has to define tags logic involving the new expression tag and `xtensor_expression_tag`, which is the default tag for `xscalar`.