### PR TITLE
upgraded to google/benchmark version 1.3.0

### DIFF
--- a/benchmark/downloadGBenchmark.cmake.in
+++ b/benchmark/downloadGBenchmark.cmake.in
@@ -13,7 +13,7 @@ project(googlebenchmark-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googlebenchmark
     GIT_REPOSITORY    https://github.com/google/benchmark.git
-    GIT_TAG           v1.2.0
+    GIT_TAG           v1.3.0
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
... because version 1.2.0 doesn't properly recognize C++11 in Visual Studio 2015 and therefore fails to compile benchmark_xtensor