### PR TITLE
random access iterators

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake -c conda-forge
-  - conda install xtl==0.3.7 -c conda-forge
+  - conda install xtl==0.3.8 -c conda-forge
   - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON .
   - nmake test_xtensor
   - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda install gtest cmake -c conda-forge 
-    - conda install xtl==0.3.7 -c conda-forge 
+    - conda install xtl==0.3.8 -c conda-forge 
     # Testing
     - mkdir build
     - cd build

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -96,12 +96,13 @@ namespace xt
         using shape_type = typename E1::shape_type;
         using index_type = xindex_type_t<shape_type>;
         using size_type = typename lhs_iterator::size_type;
+        using difference_type = typename lhs_iterator::difference_type;
 
         data_assigner(E1& e1, const E2& e2);
 
         void run();
 
-        void step(size_type i);
+        void step(size_type i, size_type n);
         void reset(size_type i);
 
         void to_end(layout_type);
@@ -323,10 +324,10 @@ namespace xt
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::step(size_type i)
+    inline void data_assigner<E1, E2, L>::step(size_type i, size_type n)
     {
-        m_lhs.step(i);
-        m_rhs.step(i);
+        m_lhs.step(i, n);
+        m_rhs.step(i, n);
     }
 
     template <class E1, class E2, layout_type L>

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -135,14 +135,14 @@ namespace xt
     private:
 
         template <layout_type L>
-        const_layout_iterator<L> get_cbegin(bool reverse) const noexcept;
+        const_layout_iterator<L> get_cbegin(bool end_index) const noexcept;
         template <layout_type L>
-        const_layout_iterator<L> get_cend(bool reverse) const noexcept;
+        const_layout_iterator<L> get_cend(bool end_index) const noexcept;
 
         template <class S, layout_type L>
-        const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool reverse) const noexcept;
+        const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool end_index) const noexcept;
         template <class S, layout_type L>
-        const_broadcast_iterator<S, L> get_cend(const S& shape, bool reverse) const noexcept;
+        const_broadcast_iterator<S, L> get_cend(const S& shape, bool end_index) const noexcept;
 
         template <class S>
         const_stepper get_stepper_begin(const S& shape) const noexcept;
@@ -242,14 +242,14 @@ namespace xt
     private:
 
         template <layout_type L>
-        layout_iterator<L> get_begin(bool reverse) noexcept;
+        layout_iterator<L> get_begin(bool end_index) noexcept;
         template <layout_type L>
-        layout_iterator<L> get_end(bool reverse) noexcept;
+        layout_iterator<L> get_end(bool end_index) noexcept;
 
         template <class S, layout_type L>
-        broadcast_iterator<S, L> get_begin(const S& shape, bool reverse) noexcept;
+        broadcast_iterator<S, L> get_begin(const S& shape, bool end_index) noexcept;
         template <class S, layout_type L>
-        broadcast_iterator<S, L> get_end(const S& shape, bool reverse) noexcept;
+        broadcast_iterator<S, L> get_end(const S& shape, bool end_index) noexcept;
 
         template <class S>
         stepper get_stepper_begin(const S& shape) noexcept;
@@ -317,7 +317,7 @@ namespace xt
     template <layout_type L>
     inline auto xconst_iterable<D>::cend() const noexcept -> const_layout_iterator<L>
     {
-        return get_cend<L>(false);
+        return get_cend<L>(true);
     }
     //@}
 
@@ -368,7 +368,7 @@ namespace xt
     template <layout_type L>
     inline auto xconst_iterable<D>::crend() const noexcept -> const_reverse_layout_iterator<L>
     {
-        return const_reverse_layout_iterator<L>(get_cbegin<L>(true));
+        return const_reverse_layout_iterator<L>(get_cbegin<L>(false));
     }
     //@}
 
@@ -429,7 +429,7 @@ namespace xt
     template <class S, layout_type L>
     inline auto xconst_iterable<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cend<S, L>(shape, false);
+        return get_cend<S, L>(shape, true);
     }
     //@}
 
@@ -490,7 +490,7 @@ namespace xt
     template <class S, layout_type L>
     inline auto xconst_iterable<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(get_cbegin<S, L>(shape, true));
+        return const_reverse_broadcast_iterator<S, L>(get_cbegin<S, L>(shape, false));
     }
     //@}
 
@@ -552,30 +552,30 @@ namespace xt
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cbegin(bool reverse) const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::get_cbegin(bool end_index) const noexcept -> const_layout_iterator<L>
     {
-        return const_layout_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), reverse);
+        return const_layout_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), end_index);
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cend(bool reverse) const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::get_cend(bool end_index) const noexcept -> const_layout_iterator<L>
     {
-        return const_layout_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), reverse);
+        return const_layout_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), end_index);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool reverse) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, reverse);
+        return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xconst_iterable<D>::get_cend(const S& shape, bool reverse) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::get_cend(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, reverse);
+        return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
     }
 
     template <class D>
@@ -632,7 +632,7 @@ namespace xt
     template <layout_type L>
     inline auto xiterable<D>::end() noexcept -> layout_iterator<L>
     {
-        return get_end<L>(false);
+        return get_end<L>(true);
     }
     //@}
 
@@ -660,7 +660,7 @@ namespace xt
     template <layout_type L>
     inline auto xiterable<D>::rend() noexcept -> reverse_layout_iterator<L>
     {
-        return reverse_layout_iterator<L>(get_begin<L>(true));
+        return reverse_layout_iterator<L>(get_begin<L>(false));
     }
     //@}
 
@@ -693,7 +693,7 @@ namespace xt
     template <class S, layout_type L>
     inline auto xiterable<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return get_end<S, L>(shape, false);
+        return get_end<S, L>(shape, true);
     }
     //@}
 
@@ -726,7 +726,7 @@ namespace xt
     template <class S, layout_type L>
     inline auto xiterable<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(get_begin<S, L>(shape, true));
+        return reverse_broadcast_iterator<S, L>(get_begin<S, L>(shape, false));
     }
     //@}
 
@@ -760,30 +760,30 @@ namespace xt
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_begin(bool reverse) noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::get_begin(bool end_index) noexcept -> layout_iterator<L>
     {
-        return layout_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), reverse);
+        return layout_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), end_index);
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_end(bool reverse) noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::get_end(bool end_index) noexcept -> layout_iterator<L>
     {
-        return layout_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), reverse);
+        return layout_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), end_index);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::get_begin(const S& shape, bool reverse) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::get_begin(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, reverse);
+        return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
     }
 
     template <class D>
     template <class S, layout_type L>
-    inline auto xiterable<D>::get_end(const S& shape, bool reverse) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::get_end(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, reverse);
+        return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
     }
 
     template <class D>

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -133,28 +133,17 @@ namespace xt
     template <layout_type L>
     struct stepper_tools
     {
-
-        template <class S, class IT, class ST>
-        static void increment_stepper(S& stepper,
-                                      IT& index,
-                                      const ST& shape);
-
-        template <class S, class IT, class ST>
-        static void decrement_stepper(S& stepper,
-                                      IT& index,
-                                      const ST& shape);
-
         template <class S, class IT, class ST>
         static void increment_stepper(S& stepper,
                                       IT& index,
                                       const ST& shape,
-                                      typename S::size_type n);
+                                      typename S::size_type n = 1);
 
         template <class S, class IT, class ST>
         static void decrement_stepper(S& stepper,
                                       IT& index,
                                       const ST& shape,
-                                      typename S::size_type n);
+                                      typename S::size_type n = 1);
     };
 
     /********************
@@ -434,38 +423,6 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper,
                                                                   IT& index,
-                                                                  const ST& shape)
-    {
-        using size_type = typename S::size_type;
-        size_type i = index.size();
-        while (i != 0)
-        {
-            --i;
-            if (index[i] != shape[i] - 1)
-            {
-                ++index[i];
-                stepper.step(i);
-                return;
-            }
-            else
-            {
-                index[i] = 0;
-                if (i != 0)
-                {
-                    stepper.reset(i);
-                }
-            }
-        }
-        if (i == 0)
-        {
-            stepper.to_end(layout_type::row_major);
-        }
-    }
-
-    template <>
-    template <class S, class IT, class ST>
-    void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper,
-                                                                  IT& index,
                                                                   const ST& shape,
                                                                   typename S::size_type n)
     {
@@ -481,7 +438,7 @@ namespace xt
                 index[i] += inc;
                 stepper.step(i, inc);
                 n -= inc;
-                if (i != leading_i)
+                if (i != leading_i || index.size() == 1)
                 {
                     i = index.size();
                 }
@@ -511,38 +468,6 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::row_major>::decrement_stepper(S& stepper,
                                                                   IT& index,
-                                                                  const ST& shape)
-    {
-        using size_type = typename S::size_type;
-        size_type i = index.size();
-        while (i != 0)
-        {
-            --i;
-            if (index[i] != 0)
-            {
-                --index[i];
-                stepper.step_back(i);
-                return;
-            }
-            else
-            {
-                index[i] = shape[i] - 1;
-                if (i != 0)
-                {
-                    stepper.reset_back(i);
-                }
-            }
-        }
-        if (i == 0)
-        {
-            stepper.to_begin();
-        }
-    }
-
-    template <>
-    template <class S, class IT, class ST>
-    void stepper_tools<layout_type::row_major>::decrement_stepper(S& stepper,
-                                                                  IT& index,
                                                                   const ST& shape,
                                                                   typename S::size_type n)
     {
@@ -558,7 +483,7 @@ namespace xt
                 index[i] -= inc;
                 stepper.step_back(i, inc);
                 n -= inc;
-                if (i != leading_i)
+                if (i != leading_i || index.size() == 1)
                 {
                     i = index.size();
                 }
@@ -588,39 +513,6 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper,
                                                                      IT& index,
-                                                                     const ST& shape)
-    {
-        using size_type = typename S::size_type;
-        size_type size = index.size();
-        size_type i = 0;
-        while (i != size)
-        {
-            if (index[i] != shape[i] - 1)
-            {
-                ++index[i];
-                stepper.step(i);
-                return;
-            }
-            else
-            {
-                index[i] = 0;
-                if (i != size - 1)
-                {
-                    stepper.reset(i);
-                }
-            }
-            ++i;
-        }
-        if (i == size)
-        {
-            stepper.to_end(layout_type::column_major);
-        }
-    }
-
-    template <>
-    template <class S, class IT, class ST>
-    void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper,
-                                                                     IT& index,
                                                                      const ST& shape,
                                                                      typename S::size_type n)
     {
@@ -636,7 +528,7 @@ namespace xt
                 index[i] += inc;
                 stepper.step(i, inc);
                 n -= inc;
-                if (i != leading_i)
+                if (i != leading_i || index.size() == 1)
                 {
                     i = 0;
                     continue;
@@ -668,39 +560,6 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::column_major>::decrement_stepper(S& stepper,
                                                                      IT& index,
-                                                                     const ST& shape)
-    {
-        using size_type = typename S::size_type;
-        size_type size = index.size();
-        size_type i = 0;
-        while (i != size)
-        {
-            if (index[i] != 0)
-            {
-                --index[i];
-                stepper.step_back(i);
-                return;
-            }
-            else
-            {
-                index[i] = shape[i] - 1;
-                if (i != size - 1)
-                {
-                    stepper.reset_back(i);
-                }
-            }
-            ++i;
-        }
-        if (i == size)
-        {
-            stepper.to_begin();
-        }
-    }
-
-    template <>
-    template <class S, class IT, class ST>
-    void stepper_tools<layout_type::column_major>::decrement_stepper(S& stepper,
-                                                                     IT& index,
                                                                      const ST& shape,
                                                                      typename S::size_type n)
     {
@@ -716,7 +575,7 @@ namespace xt
                 index[i] -= inc;
                 stepper.step_back(i, inc);
                 n -= inc;
-                if (i != leading_i)
+                if (i != leading_i || index.size() == 1)
                 {
                     i = 0;
                     continue;

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -31,6 +31,7 @@ namespace xt
     {
         using vector_type = uvector<int, DEFAULT_ALLOCATOR(int)>;
         using size_type = typename C::value_type;
+        using difference_type = typename C::difference_type;
         using shape_type = C;
         using strides_type = C;
 
@@ -115,6 +116,7 @@ namespace xt
     {
         using vector_type = std::vector<int>;
         using size_type = typename C::value_type;
+        using difference_type = typename C::difference_type;
         using shape_type = C;
         using strides_type = C;
 

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -250,23 +250,17 @@ namespace xt
 
         {
             SCOPED_TRACE("same shape");
-            std::cout << "before same shape" << std::endl;
             test_xfunction_iterator(f.m_a, f.m_a);
-            std::cout << "after same shape" << std::endl;
         }
 
         {
             SCOPED_TRACE("different shape");
-            std::cout << "before different shape" << std::endl;
             test_xfunction_iterator(f.m_a, f.m_b);
-            std::cout << "after different shape" << std::endl;
         }
 
         {
             SCOPED_TRACE("different dimensions");
-            std::cout << "before different dimensions" << std::endl;
             test_xfunction_iterator(f.m_c, f.m_a);
-            std::cout << "after different dimensions" << std::endl;
         }
     }
 


### PR DESCRIPTION
Fixes #542.
Do not squash the commits, we must be able to retrieve each of the changes in the history.