### PR TITLE
filter test added

### DIFF
--- a/test/test_xindex_view.cpp
+++ b/test/test_xindex_view.cpp
@@ -118,4 +118,13 @@ namespace xt
         xarray<double> expected = {{1, 7, 3}, {4, 7, 8}};
         EXPECT_EQ(expected, a);
     }
+
+    TEST(xindex_view, filter)
+    {
+        xarray<double> a = { { 1, 5, 3 },{ 4, 5, 6 } };
+        const xarray<double> b = { { 1, 5, 3 },{ 4, 5, 6 } };
+        filter(a, a > 3) += filter(b, b > 3);
+        xarray<double> expected = { { 1, 10, 3}, {8, 10, 12} };
+        EXPECT_EQ(expected, a);
+    }
 }


### PR DESCRIPTION
Checks the compilation of `xt::filter(a, cond1) += xt::filter(b, cond2)` where `b` is a const array.