### PR TITLE
Add index access example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,34 @@ Outputs:
  {7, 8, 9}}
 ```
 
+**Index Access**
+
+```cpp
+#include <iostream>
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+
+xt::xarray<double> arr1
+  {{1.0, 2.0, 3.0},
+   {2.0, 5.0, 7.0},
+   {2.0, 5.0, 7.0}};
+
+std::cout << arr1(0, 0) << std::endl;
+
+xt::xarray<int> arr2
+  {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  
+std::cout << arr2(0);
+```
+
+Outputs:
+
+```
+1.0
+1
+```
+
+       
 ## The numpy to xtensor cheat sheet
 
 If you are familiar with numpy APIs, and you are interested in xtensor, you can check out the [numpy to xtensor cheat sheet](https://xtensor.readthedocs.io/en/latest/numpy.html) provided in the documentation.

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -56,6 +56,33 @@ Outputs:
      {4, 5, 6},
      {7, 8, 9}}
 
+**Index Access**
+
+.. code::
+
+    #include <iostream>
+    #include "xtensor/xarray.hpp"
+    #include "xtensor/xio.hpp"
+
+    xt::xarray<double> arr1
+      {{1.0, 2.0, 3.0},
+       {2.0, 5.0, 7.0},
+       {2.0, 5.0, 7.0}};
+    
+    std::cout << arr1(0, 0) << std::endl;
+
+    xt::xarray<int> arr2
+      {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    std::cout << arr2(0);
+
+Outputs:
+
+.. code::
+
+    1.0
+    1
+     
 **Broadcasting the** ``xt::pow`` **universal functions.**
 
 .. code::


### PR DESCRIPTION
Add index access examples to README and basic usage in docs, as this is where most people land.

Coming from python, some people (including me...) might try to access indices with `someXArray [0]`, `someXArray[0][0]` etc.