### PR TITLE
assign functions optimized

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -177,7 +177,8 @@ namespace xt
         template <class E1, class E2>
         inline bool is_trivial_broadcast(const E1& e1, const E2& e2)
         {
-            return e2.is_trivial_broadcast(e1.strides());
+            return (E1::contiguous_layout && E2::contiguous_layout && (E1::static_layout == E2::static_layout))
+                    || e2.is_trivial_broadcast(e1.strides());
         }
 
         template <class D, class E2, class... SL>
@@ -243,7 +244,7 @@ namespace xt
 
         size_type dim = de2.dimension();
         shape_type shape = xtl::make_sequence<shape_type>(dim, size_type(1));
-        bool trivial_broadcast = de2.broadcast_shape(shape);
+        bool trivial_broadcast = de2.broadcast_shape(shape, true);
 
         if (dim > de1.dimension() || shape > de1.shape())
         {
@@ -276,7 +277,7 @@ namespace xt
         const E2& de2 = e2.derived_cast();
         size_type size = de2.dimension();
         shape_type shape = xtl::make_sequence<shape_type>(size, size_type(1));
-        de2.broadcast_shape(shape);
+        de2.broadcast_shape(shape, true);
         if (shape.size() > de1.shape().size() || shape > de1.shape())
         {
             throw broadcast_error(shape, de1.shape());
@@ -292,7 +293,7 @@ namespace xt
         const E2& de2 = e2.derived_cast();
         size_type size = de2.dimension();
         shape_type shape = xtl::make_sequence<shape_type>(size, size_type(1));
-        bool trivial_broadcast = de2.broadcast_shape(shape);
+        bool trivial_broadcast = de2.broadcast_shape(shape, true);
         e1.derived_cast().resize(std::move(shape));
         return trivial_broadcast;
     }

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -123,7 +123,7 @@ namespace xt
         const_reference element(It, It last) const;
 
         template <class S>
-        bool broadcast_shape(S& shape) const;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
@@ -329,7 +329,7 @@ namespace xt
      */
     template <class CT, class X>
     template <class S>
-    inline bool xbroadcast<CT, X>::broadcast_shape(S& shape) const
+    inline bool xbroadcast<CT, X>::broadcast_shape(S& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -153,7 +153,7 @@ namespace xt
         const size_type raw_data_offset() const noexcept;
 
         template <class S>
-        bool broadcast_shape(S& shape) const;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
@@ -717,7 +717,7 @@ namespace xt
      */
     template <class D>
     template <class S>
-    inline bool xcontainer<D>::broadcast_shape(S& shape) const
+    inline bool xcontainer<D>::broadcast_shape(S& shape, bool) const
     {
         return xt::broadcast_shape(this->shape(), shape);
     }

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -26,7 +26,10 @@ namespace xt
      **************************************/
 
     template <class T, class A = std::allocator<T>>
-    xtensor_container<std::vector<T, A>, 2> load_csv(std::istream& stream);
+    using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
+
+    template <class T, class A = std::allocator<T>>
+    xcsv_tensor<T, A> load_csv(std::istream& stream);
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -93,10 +96,10 @@ namespace xt
      * @param stream the input stream containing the CSV encoded values
      */
     template <class T, class A>
-    xtensor_container<std::vector<T, A>, 2> load_csv(std::istream& stream)
+    xcsv_tensor<T, A> load_csv(std::istream& stream)
     {
-        using container_type = typename std::vector<T, A>;
-        using tensor_type = xtensor_container<container_type, 2>;
+        using tensor_type = xcsv_tensor<T, A>;
+        using container_type = typename tensor_type::container_type;
         using size_type = typename tensor_type::size_type;
         using inner_shape_type = typename tensor_type::inner_shape_type;
         using inner_strides_type = typename tensor_type::inner_strides_type;

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -402,7 +402,7 @@ namespace xt
         void reshape(ST&& shape, layout_type layout = L) const;
 
         template <class ST>
-        bool broadcast_shape(ST& s) const;
+        bool broadcast_shape(ST& s, bool reuse_cache = false) const;
 
     private:
 
@@ -617,7 +617,7 @@ namespace xt
 
     template <class ET, class S, layout_type L, class Tag>
     template <class ST>
-    inline bool xfixed_container<ET, S, L, Tag>::broadcast_shape(ST& shape) const
+    inline bool xfixed_container<ET, S, L, Tag>::broadcast_shape(ST& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -193,7 +193,7 @@ namespace xt
         const_reference element(IT first, IT last) const;
 
         template <class S>
-        bool broadcast_shape(S& shape) const;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const;
@@ -670,13 +670,14 @@ namespace xt
     /**
      * Broadcast the shape of the function to the specified parameter.
      * @param shape the result shape
+     * @param reuse_cache boolean for reusing a previously computed shape
      * @return a boolean indicating whether the broadcasting is trivial
      */
     template <class F, class CT>
     template <class S>
-    inline bool xfunctor_view<F, CT>::broadcast_shape(S& shape) const
+    inline bool xfunctor_view<F, CT>::broadcast_shape(S& shape, bool reuse_cache) const
     {
-        return m_e.broadcast_shape(shape);
+        return m_e.broadcast_shape(shape, reuse_cache);
     }
 
     /**

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -102,7 +102,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class O>
-        bool broadcast_shape(O& shape) const;
+        bool broadcast_shape(O& shape, bool reuse_cache = false) const;
 
         template <class O>
         bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
@@ -270,7 +270,7 @@ namespace xt
      */
     template <class F, class R, class S>
     template <class O>
-    inline bool xgenerator<F, R, S>::broadcast_shape(O& shape) const
+    inline bool xgenerator<F, R, S>::broadcast_shape(O& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -132,7 +132,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class O>
-        bool broadcast_shape(O& shape) const;
+        bool broadcast_shape(O& shape, bool reuse_cache = false) const;
 
         template <class O>
         bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
@@ -418,7 +418,7 @@ namespace xt
      */
     template <class CT, class I>
     template <class O>
-    inline bool xindex_view<CT, I>::broadcast_shape(O& shape) const
+    inline bool xindex_view<CT, I>::broadcast_shape(O& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xoptional_assembly_base.hpp
+++ b/include/xtensor/xoptional_assembly_base.hpp
@@ -160,7 +160,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class S>
-        bool broadcast_shape(S& shape) const;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
@@ -649,10 +649,10 @@ namespace xt
      */
     template <class D>
     template <class S>
-    inline bool xoptional_assembly_base<D>::broadcast_shape(S& shape) const
+    inline bool xoptional_assembly_base<D>::broadcast_shape(S& shape, bool reuse_cache) const
     {
-        bool res = value().broadcast_shape(shape);
-        return res && has_value().broadcast_shape(shape);
+        bool res = value().broadcast_shape(shape, reuse_cache);
+        return res && has_value().broadcast_shape(shape, reuse_cache);
     }
 
     /**

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -419,7 +419,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class S>
-        bool broadcast_shape(S& shape) const;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
@@ -783,7 +783,7 @@ namespace xt
      */
     template <class F, class CT, class X>
     template <class S>
-    inline bool xreducer<F, CT, X>::broadcast_shape(S& shape) const
+    inline bool xreducer<F, CT, X>::broadcast_shape(S& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -138,7 +138,7 @@ namespace xt
         const_reference element(It, It) const noexcept;
 
         template <class S>
-        bool broadcast_shape(S& shape) const noexcept;
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const noexcept;
 
         template <class S>
         bool is_trivial_broadcast(const S& strides) const noexcept;
@@ -576,7 +576,7 @@ namespace xt
 
     template <class CT>
     template <class S>
-    inline bool xscalar<CT>::broadcast_shape(S&) const noexcept
+    inline bool xscalar<CT>::broadcast_shape(S&, bool) const noexcept
     {
         return true;
     }

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -165,7 +165,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class O>
-        bool broadcast_shape(O& shape) const;
+        bool broadcast_shape(O& shape, bool reuse_cache = false) const;
 
         template <class O>
         bool is_trivial_broadcast(const O& strides) const noexcept;
@@ -525,7 +525,7 @@ namespace xt
      */
     template <class CT, class S, class CD>
     template <class O>
-    inline bool xstrided_view<CT, S, CD>::broadcast_shape(O& shape) const
+    inline bool xstrided_view<CT, S, CD>::broadcast_shape(O& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -146,7 +146,7 @@ namespace xt
         const_reference element(It first, It last) const;
 
         template <class ST>
-        bool broadcast_shape(ST& shape) const;
+        bool broadcast_shape(ST& shape, bool reuse_cache = false) const;
 
         template <class ST>
         bool is_trivial_broadcast(const ST& strides) const;
@@ -707,7 +707,7 @@ namespace xt
      */
     template <class CT, class... S>
     template <class ST>
-    inline bool xview<CT, S...>::broadcast_shape(ST& shape) const
+    inline bool xview<CT, S...>::broadcast_shape(ST& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }

--- a/test/test_xshape.cpp
+++ b/test/test_xshape.cpp
@@ -77,7 +77,7 @@ namespace xt
         EXPECT_EQ(size_t(10), c.size());
         EXPECT_EQ(2, c[2]);
 
-        std::vector<double> src(10, 1);
+        std::vector<std::size_t> src(10, std::size_t(1));
         vector_type d(src.cbegin(), src.cend());
         EXPECT_EQ(size_t(10), d.size());
         EXPECT_EQ(1, d[2]);
@@ -117,10 +117,10 @@ namespace xt
     TEST(svector, iterator)
     {
         vector_type a(10);
-        std::iota(a.begin(), a.end(), 0.);
+        std::iota(a.begin(), a.end(), std::size_t(0));
         for (size_t i = 0; i < a.size(); ++i)
         {
-            EXPECT_EQ(double(i), a[i]);
+            EXPECT_EQ(i, a[i]);
         }
     }
 


### PR DESCRIPTION
@wolfv This avoids duplicated calls to ``broadcast``, and skips strides comparison when layouts can be compared at compile time.

This should remove the remaining overhead in the assign mechanism, let me know if you still see some overhead in your benchmarks.