### PR TITLE
fix return type of xfunction_base::load_simd_impl()

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -94,9 +94,9 @@ namespace xt
         };
 
         template <class F, class R>
-        struct simd_return_type<F, R, void_t<decltype(&F::simd_apply)>>
+        struct simd_return_type<F, R, void_t<typename std::decay_t<F>::simd_result_type>>
         {
-            using type = R;
+            using type = typename std::decay_t<F>::simd_result_type;
         };
 
         template <class F, class R>
@@ -290,7 +290,7 @@ namespace xt
         const_reference data_element_impl(std::index_sequence<I...>, size_type i) const;
 
         template <class align, class simd, std::size_t... I>
-        simd load_simd_impl(std::index_sequence<I...>, size_type i) const;
+        detail::simd_return_type_t<functor_type, simd> load_simd_impl(std::index_sequence<I...>, size_type i) const;
 
         template <class Func, std::size_t... I>
         const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
@@ -814,7 +814,7 @@ namespace xt
 
     template <class F, class R, class... CT>
     template <class align, class simd, std::size_t... I>
-    inline auto xfunction_base<F, R, CT...>::load_simd_impl(std::index_sequence<I...>, size_type i) const -> simd
+    inline auto xfunction_base<F, R, CT...>::load_simd_impl(std::index_sequence<I...>, size_type i) const -> detail::simd_return_type_t<functor_type, simd>
     {
         return m_f.simd_apply((std::get<I>(m_e).template load_simd<align, simd>(i))...);
     }

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -454,6 +454,16 @@ namespace xt
         EXPECT_EQ(expected, where(a));
     }
 
+    TYPED_TEST(operation, where)
+    {
+        TypeParam a = {{1, 2, 3}, {0, 1, 0}, {0, 4, 1}};
+        // TypeParam res(a.shape());
+        double b = 1.0;
+        TypeParam res = where(a > b, b, a);
+        TypeParam expected = {{1, 1, 1}, {0, 1, 0}, {0, 1, 1}};
+        EXPECT_EQ(expected, res);
+    }
+
     TYPED_TEST(operation, cast)
     {
         using int_container_t = rebind_container_t<TypeParam, int>;


### PR DESCRIPTION
The following code
```
xarray<double> a = {{1, 2, 3}, {0, 1, 0}, {0, 4, 1}};
double b = 1.0;
xarray<double> res = where(a > b, b, a);
```
fails to compile when `XTENSOR_USE_SIMD=ON`. This PR adds a reproducing test case and proposes a fix.