### PR TITLE
Fixes in strided views

### DIFF
--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -106,20 +106,20 @@ namespace xt
 
             std::size_t outer_loop_size, inner_loop_size, outer_stride, inner_stride, pos = 0;
 
-            auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, ptrdiff_t ax) {
+            auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, std::ptrdiff_t ax) {
                 outer_loop_size = std::accumulate(first, first + ax,
                                                   std::size_t(1), std::multiplies<std::size_t>());
                 inner_loop_size = std::accumulate(first + ax + 1, last,
                                                   std::size_t(1), std::multiplies<std::size_t>());
             };
 
-            auto set_loop_strides = [&outer_stride, &inner_stride](auto first, auto last, ptrdiff_t ax) {
+            auto set_loop_strides = [&outer_stride, &inner_stride](auto first, auto last, std::ptrdiff_t ax) {
                 outer_stride = ax == 0 ? 1 : *std::min_element(first, first + ax);
                 inner_stride = (ax == std::distance(first, last) - 1) ? 1 : *std::min_element(first + ax + 1, last);
             };
 
-            set_loop_sizes(e.shape().begin(), e.shape().end(), static_cast<ptrdiff_t>(axis));
-            set_loop_strides(e.strides().begin(), e.strides().end(), static_cast<ptrdiff_t>(axis));
+            set_loop_sizes(e.shape().begin(), e.shape().end(), static_cast<std::ptrdiff_t>(axis));
+            set_loop_strides(e.strides().begin(), e.strides().end(), static_cast<std::ptrdiff_t>(axis));
 
             if (e.layout() == layout_type::column_major)
             {
@@ -159,7 +159,7 @@ namespace xt
             std::size_t outer_loop_size = 0;
             std::size_t inner_loop_size = 0;
 
-            auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, ptrdiff_t ax) {
+            auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, std::ptrdiff_t ax) {
                 outer_loop_size = std::accumulate(first,
                                                   first + ax,
                                                   std::size_t(1), std::multiplies<std::size_t>());
@@ -171,11 +171,11 @@ namespace xt
 
             if (result_type::static_layout == layout_type::row_major)
             {
-                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<ptrdiff_t>(axis));
+                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis));
             }
             else
             {
-                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<ptrdiff_t>(axis + 1));
+                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis + 1));
                 std::swap(inner_loop_size, outer_loop_size);
             }
 

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -37,7 +37,7 @@ namespace xt
     struct xiterable_inner_types<xgenerator<C, R, S>>
     {
         using inner_shape_type = S;
-        using const_stepper = xindexed_stepper<xgenerator<C, R, S>>;
+        using const_stepper = xindexed_stepper<xgenerator<C, R, S>, true>;
         using stepper = const_stepper;
     };
 

--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -37,7 +37,7 @@ namespace xt
     struct xiterable_inner_types<xindex_view<CT, I>>
     {
         using inner_shape_type = std::array<std::size_t, 1>;
-        using const_stepper = xindexed_stepper<xindex_view<CT, I>>;
+        using const_stepper = xindexed_stepper<xindex_view<CT, I>, true>;
         using stepper = xindexed_stepper<xindex_view<CT, I>, false>;
     };
 

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -165,7 +165,7 @@ namespace xt
      * xindexed_stepper *
      ********************/
 
-    template <class E, bool is_const = true>
+    template <class E, bool is_const>
     class xindexed_stepper
     {
     public:

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -114,7 +114,7 @@ namespace xt
             for (; it != end; ++it)
             {
                 // note that we check is_sorted, so this condition is valid
-                if (std::abs(ptrdiff_t(*it) - ptrdiff_t(last_ax)) == 1)
+                if (std::abs(std::ptrdiff_t(*it) - std::ptrdiff_t(last_ax)) == 1)
                 {
                     last_ax = *it;
                     outer_loop_size *= e.shape()[last_ax];
@@ -137,8 +137,8 @@ namespace xt
         {
             std::size_t last_ax = merge_loops(axes.rbegin(), axes.rend());
 
-            iter_shape.erase(iter_shape.begin() + ptrdiff_t(last_ax), iter_shape.end());
-            iter_strides.erase(iter_strides.begin() + ptrdiff_t(last_ax), iter_strides.end());
+            iter_shape.erase(iter_shape.begin() + std::ptrdiff_t(last_ax), iter_shape.end());
+            iter_strides.erase(iter_strides.begin() + std::ptrdiff_t(last_ax), iter_strides.end());
         }
         else if (e.layout() == layout_type::column_major)
         {
@@ -146,8 +146,8 @@ namespace xt
             std::size_t last_ax = merge_loops(axes.begin(), axes.end());
 
             // erasing the front vs the back
-            iter_shape.erase(iter_shape.begin(), iter_shape.begin() + ptrdiff_t(last_ax + 1));
-            iter_strides.erase(iter_strides.begin(), iter_strides.begin() + ptrdiff_t(last_ax + 1));
+            iter_shape.erase(iter_shape.begin(), iter_shape.begin() + std::ptrdiff_t(last_ax + 1));
+            iter_strides.erase(iter_strides.begin(), iter_strides.begin() + std::ptrdiff_t(last_ax + 1));
 
             // and reversing, to make it work with the same next_idx function
             std::reverse(iter_shape.begin(), iter_shape.end());
@@ -163,7 +163,7 @@ namespace xt
             std::size_t i = iter_shape.size();
             for (; i > 0; --i)
             {
-                if (ptrdiff_t(temp_idx[i - 1]) >= ptrdiff_t(iter_shape[i - 1]) - 1)
+                if (std::ptrdiff_t(temp_idx[i - 1]) >= std::ptrdiff_t(iter_shape[i - 1]) - 1)
                 {
                     temp_idx[i - 1] = 0;
                 }
@@ -175,16 +175,16 @@ namespace xt
             }
             return std::make_pair(i == 0,
                                   std::inner_product(temp_idx.begin(), temp_idx.end(),
-                                                     iter_strides.begin(), ptrdiff_t(0)));
+                                                     iter_strides.begin(), std::ptrdiff_t(0)));
         };
 
         auto begin = e.raw_data();
         auto out = result.raw_data();
         auto out_begin = result.raw_data();
 
-        ptrdiff_t next_stride = 0;
+        std::ptrdiff_t next_stride = 0;
 
-        std::pair<bool, ptrdiff_t> idx_res(false, 0);
+        std::pair<bool, std::ptrdiff_t> idx_res(false, 0);
 
         // Remark: eventually some modifications here to make conditions faster where merge + accumulate is the
         // same function (e.g. check std::is_same<decltype(merge_fct), decltype(acc_fct)>::value) ...

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -27,7 +27,7 @@ namespace xt
         E ev;
         ev.resize({de.size()});
 
-        std::copy(de.begin(), de.end(), ev.begin());
+        std::copy(de.cbegin(), de.cend(), ev.begin());
         std::sort(ev.begin(), ev.end());
 
         return ev;
@@ -40,21 +40,21 @@ namespace xt
         {
             using value_type = typename E::value_type;
             std::size_t n_iters = 1;
-            ptrdiff_t secondary_stride;
+            std::ptrdiff_t secondary_stride;
             if (ev.layout() == layout_type::row_major)
             {
                 n_iters = std::accumulate(ev.shape().begin(), ev.shape().end() - 1,
                                           std::size_t(1), std::multiplies<>());
-                secondary_stride = static_cast<ptrdiff_t>(ev.strides()[ev.dimension() - 2]);
+                secondary_stride = static_cast<std::ptrdiff_t>(ev.strides()[ev.dimension() - 2]);
             }
             else
             {
                 n_iters = std::accumulate(ev.shape().begin() + 1, ev.shape().end(),
                                           std::size_t(1), std::multiplies<>());
-                secondary_stride = static_cast<ptrdiff_t>(ev.strides()[1]);
+                secondary_stride = static_cast<std::ptrdiff_t>(ev.strides()[1]);
             }
 
-            ptrdiff_t offset = 0;
+            std::ptrdiff_t offset = 0;
 
             for (std::size_t i = 0; i < n_iters; ++i, offset += secondary_stride)
             {
@@ -106,7 +106,7 @@ namespace xt
         {
             auto axis_numbers = arange<std::size_t>(de.shape().size());
             std::vector<std::size_t> permutation(axis_numbers.begin(), axis_numbers.end());
-            permutation.erase(permutation.begin() + ptrdiff_t(axis));
+            permutation.erase(permutation.begin() + std::ptrdiff_t(axis));
             if (de.layout() == layout_type::row_major)
             {
                 permutation.push_back(axis);
@@ -159,7 +159,7 @@ namespace xt
         };
 
         template <class IT, class F>
-        inline std::size_t cmp_idx(IT iter, IT end, ptrdiff_t inc, F&& cmp)
+        inline std::size_t cmp_idx(IT iter, IT end, std::ptrdiff_t inc, F&& cmp)
         {
             std::size_t idx = 0;
             double min = *iter;
@@ -196,7 +196,7 @@ namespace xt
             }
 
             xt::dynamic_shape<std::size_t> new_shape = e.shape();
-            new_shape.erase(new_shape.begin() + ptrdiff_t(axis));
+            new_shape.erase(new_shape.begin() + std::ptrdiff_t(axis));
 
             result_type result(new_shape);
             auto result_iter = result.begin();
@@ -221,8 +221,8 @@ namespace xt
             {
                 E input;
                 auto axis_numbers = arange<std::size_t>(e.shape().size());
-                std::vector<std::size_t> permutation(axis_numbers.begin(), axis_numbers.end());
-                permutation.erase(permutation.begin() + ptrdiff_t(axis));
+                std::vector<std::size_t> permutation(axis_numbers.cbegin(), axis_numbers.cend());
+                permutation.erase(permutation.begin() + std::ptrdiff_t(axis));
                 if (input.layout() == layout_type::row_major)
                 {
                     permutation.push_back(axis);

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -10,6 +10,7 @@
 #define XTENSOR_STORAGE_HPP
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <initializer_list>
 #include <iterator>
@@ -1054,7 +1055,7 @@ namespace xt
 
         if (m_end >= m_capacity)
         {
-            ptrdiff_t elt_no = it - m_begin;
+            std::ptrdiff_t elt_no = it - m_begin;
             grow();
             it = m_begin + elt_no;
         }

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -346,7 +346,6 @@ namespace xt
         EXPECT_EQ(size_t(1), view1.dimension());
 
         auto iter = view1.template begin<layout_type::row_major>();
-        auto iter_end = view1.template end<layout_type::row_major>();
 
         EXPECT_EQ(6, *iter);
         ++iter;

--- a/test/test_xview_semantic.cpp
+++ b/test/test_xview_semantic.cpp
@@ -252,7 +252,6 @@ namespace xt
     TYPED_TEST(view_semantic, a_plus_equal_b)
     {
         view_op_tester<std::plus<>, TypeParam> t;
-        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major += row_major");
@@ -294,7 +293,6 @@ namespace xt
     TYPED_TEST(view_semantic, a_minus_equal_b)
     {
         view_op_tester<std::minus<>, TypeParam> t;
-        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major -= row_major");
@@ -336,7 +334,6 @@ namespace xt
     TYPED_TEST(view_semantic, a_times_equal_b)
     {
         view_op_tester<std::multiplies<>, TypeParam> t;
-        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major *= row_major");
@@ -378,7 +375,6 @@ namespace xt
     TYPED_TEST(view_semantic, a_divide_by_equal_b)
     {
         view_op_tester<std::divides<>, TypeParam> t;
-        auto viewa = view(t.a, t.x_slice, t.y_slice, t.z_slice);
 
         {
             SCOPED_TRACE("row_major /= row_major");


### PR DESCRIPTION
Now removing the `CD` template argument from `xstrided_view`, which can be determined as a typedef, and the constructor taking the `data`, which can be computed from the expression in the constructor with `get_data`.
 