### PR TITLE
fix stride computation for xtensorf

### DIFF
--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -171,7 +171,7 @@ namespace xt
         template <std::size_t I, std::size_t... X>
         struct calculate_stride_row_major
         {
-            constexpr static std::size_t value = (at<sizeof...(X) - I - 1, X...>::value == 1 ? 0 : at<sizeof...(X) - I - 1, X...>::value) * 
+            constexpr static std::size_t value = (at<sizeof...(X) - I, X...>::value == 1 ? 0 : at<sizeof...(X) - I, X...>::value) *
                 (calculate_stride_row_major<I - 1, X...>::value == 0 ? 
                     1 : calculate_stride_row_major<I - 1, X...>::value);
         };

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 
 #include "xtensor/xfixed.hpp"
+#include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 
@@ -26,16 +27,16 @@
 
 namespace xt
 {
-    using xtensorf3x3 = xtensorf<double, xt::xshape<3, 3>>; 
-    using xtensorf3 = xtensorf<double, xt::xshape<3>>; 
+    using xtensorf3x4 = xtensorf<double, xt::xshape<3, 4>>;
+    using xtensorf4 = xtensorf<double, xt::xshape<4>>;
 
     TEST(xtensorf, basic)
     {
-        xtensorf3x3 a({{1,2,3}, {4,5,6}, {7,8,9}});
-        xtensorf3x3 b({{1,2,3}, {4,5,6}, {7,8,9}});
+        xtensorf3x4 a({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}});
+        xtensorf3x4 b({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}});
 
-        xtensorf3x3 res1 = a + b;
-        xtensorf3x3 res2 = 2.0 * a;
+        xtensorf3x4 res1 = a + b;
+        xtensorf3x4 res2 = 2.0 * a;
 
 #ifndef VS_X86_WORKAROUND
         EXPECT_EQ(res1, res2);
@@ -47,11 +48,11 @@ namespace xt
 
     TEST(xtensorf, broadcast)
     {
-        xtensorf3x3 a({{1,2,3}, {4,5,6}, {7,8,9}});
-        xtensorf3 b({4,5,6});
+        xtensorf3x4 a({{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}});
+        xtensorf4 b({4, 5, 6, 7});
 
-        xtensorf3x3 res = a * b;
-        xtensorf3x3 resb = b * a;
+        xtensorf3x4 res = a * b;
+        xtensorf3x4 resb = b * a;
 
         xarray<double> ax = a;
         xarray<double> bx = b;
@@ -73,22 +74,50 @@ namespace xt
 #endif
         // reshaping fixed container
         EXPECT_THROW(a.reshape({1, 9}), std::runtime_error);
-        EXPECT_NO_THROW(a.reshape({3, 3}));
-        EXPECT_NO_THROW(a.reshape({3, 3}, DEFAULT_LAYOUT));
-        EXPECT_THROW(a.reshape({3, 3}, layout_type::any), std::runtime_error);
+        EXPECT_NO_THROW(a.reshape({3, 4}));
+        EXPECT_NO_THROW(a.reshape({3, 4}, DEFAULT_LAYOUT));
+        EXPECT_THROW(a.reshape({3, 4}, layout_type::any), std::runtime_error);
+    }
+
+    TEST(xtensorf, strides)
+    {
+        xtensorf<double, xshape<3, 7, 2, 5, 3>, layout_type::row_major> arm;
+        xtensor<double, 5, layout_type::row_major> brm = xtensor<double, 5, layout_type::row_major>::from_shape({3, 7, 2, 5, 3});
+
+        EXPECT_TRUE(std::equal(arm.strides().begin(), arm.strides().end(), brm.strides().begin()));
+        EXPECT_EQ(arm.strides().size(), brm.strides().size());
+
+        xtensorf<double, xshape<3, 7, 2, 5, 3>, layout_type::column_major> acm;
+        xtensor<double, 5, layout_type::column_major> bcm = xtensor<double, 5, layout_type::column_major>::from_shape({3, 7, 2, 5, 3});
+
+        EXPECT_TRUE(std::equal(acm.strides().begin(), acm.strides().end(), bcm.strides().begin()));
+        EXPECT_EQ(acm.strides().size(), bcm.strides().size());
+
+        auto s = get_strides<layout_type::row_major>(xshape<3, 4, 5>());
+        EXPECT_EQ(s[0], 20);
+        EXPECT_EQ(s[1], 5);
+        EXPECT_EQ(s[2], 1);
+
+        auto sc = get_strides<layout_type::column_major>(xshape<3, 4, 5>());
+        EXPECT_EQ(sc[0], 1);
+        EXPECT_EQ(sc[1], 3);
+        EXPECT_EQ(sc[2], 12);
     }
 
     TEST(xtensorf, adapt)
     {
-        std::vector<double> a = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-        xfixed_adaptor<decltype(a), xt::xshape<3, 3>> ad(a);
-        xtensorf3x3 b({{1,2,3}, {4,5,6}, {7,8,9}});
+        std::vector<double> a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        std::vector<double> b = a;
 
-        EXPECT_EQ(5.0, ad(1, 1));
-        auto expr = ad + b;
-        EXPECT_EQ(10., expr(1, 1));
-        ad = b * 2;
-        EXPECT_EQ(ad(1, 1), 5 * 2);
+        xfixed_adaptor<std::vector<double>&, xt::xshape<3, 4>> ad(a);
+        auto bd = adapt(b, std::array<std::size_t, 2>{3, 4});
+
+        EXPECT_EQ(ad(1, 1), bd(1, 1));
+        auto expr = ad + bd;
+        EXPECT_EQ(expr(1, 1), bd(1, 1) * 2);
+        ad = bd * 2;
+        EXPECT_EQ(bd(1, 1) * 2, ad(1, 1));
+        EXPECT_EQ(a[0], 2);
     }
 }
 


### PR DESCRIPTION
We / I should really never again test with quadratic shapes :/