### PR TITLE
updated documenation to say maximal for xsort.hpp::argmax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ test/cmake_install.cmake
 docs/CMakeCache.txt
 docs/xml/
 docs/build/
+docs/*.tmp
 
 # Jupyter artefacts
 .ipynb_checkpoints/

--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -284,7 +284,7 @@ namespace xt
      * @param e input xexpression
      * @param axis select axis (or none)
      *
-     * @return returns xarray with positions of minimal value
+     * @return returns xarray with positions of maximal value
      */
     template <class E>
     auto argmax(const xexpression<E>& e, std::size_t axis)


### PR DESCRIPTION
Found a typo in the documentation to say maximal for `include/xtensor/xsort.hpp::argmax`