### PR TITLE
More fixes in xadapt

### DIFF
--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -21,7 +21,6 @@
 
 namespace xt
 {
-
     namespace detail
     {
         template <class>
@@ -48,7 +47,8 @@ namespace xt
      * @param shape the shape of the xarray_adaptor
      * @param l the layout_type of the xarray_adaptor
      */
-    template <class C, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class C, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
     xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>
     adapt(C&& container, const SC& shape, layout_type l = L);
 
@@ -59,7 +59,9 @@ namespace xt
      * @param shape the shape of the xarray_adaptor
      * @param strides the strides of the xarray_adaptor
      */
-    template <class C, class SC, class SS, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class C, class SC, class SS,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
     xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>
     adapt(C&& container, SC&& shape, SS&& strides);
 
@@ -74,7 +76,8 @@ namespace xt
      * @param l the layout_type of the xarray_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <class P, class O, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class P, class O, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
     xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, L, SC>
     adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
 
@@ -88,8 +91,10 @@ namespace xt
      * @param shape the shape of the xarray_adaptor
      * @param strides the strides of the xarray_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
-    */
-    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
+     */
+    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
     xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, layout_type::dynamic, std::decay_t<SC>>
     adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A());
 
@@ -98,7 +103,7 @@ namespace xt
      ***************************/
 
     /**
-     * Constructs a 1D xtensor_adaptor of the given stl-like container,
+     * Constructs a 1-D xtensor_adaptor of the given stl-like container,
      * with the specified layout_type.
      * @param container the container to adapt
      * @param l the layout_type of the xtensor_adaptor
@@ -114,7 +119,8 @@ namespace xt
      * @param shape the shape of the xtensor_adaptor
      * @param l the layout_type of the xtensor_adaptor
      */
-    template <class C, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class C, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
     xtensor_adaptor<C, detail::array_size<SC>::value, L>
     adapt(C&& container, const SC& shape, layout_type l = L);
 
@@ -125,12 +131,14 @@ namespace xt
      * @param shape the shape of the xtensor_adaptor
      * @param strides the strides of the xtensor_adaptor
      */
-    template <class C, class SC, class SS, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class C, class SC, class SS,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
     xtensor_adaptor<C, detail::array_size<SC>::value, layout_type::dynamic>
     adapt(C&& container, SC&& shape, SS&& strides);
 
     /**
-     * Constructs a 1D xtensor_adaptor of the given dynamically allocated C array,
+     * Constructs a 1-D xtensor_adaptor of the given dynamically allocated C array,
      * with the specified layout.
      * @param pointer the pointer to the beginning of the dynamic array
      * @param size the size of the dynamic array
@@ -154,7 +162,8 @@ namespace xt
      * @param l the layout_type of the xtensor_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <class P, class O, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class P, class O, class SC, layout_type L = XTENSOR_DEFAULT_LAYOUT, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
     xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, L>
     adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
 
@@ -169,7 +178,9 @@ namespace xt
      * @param strides the strides of the xtensor_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
+    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
     xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, layout_type::dynamic>
     adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A());
 
@@ -178,7 +189,8 @@ namespace xt
      *****************************************/
 
     // shape only - container version
-    template <class C, class SC, layout_type L, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class C, class SC, layout_type L,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
     inline xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>
     adapt(C&& container, const SC& shape, layout_type l)
     {
@@ -187,7 +199,9 @@ namespace xt
     }
 
     // shape and strides - container version
-    template <class C, class SC, class SS, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class C, class SC, class SS,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
     inline xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>
     adapt(C&& container, SC&& shape, SS&& strides)
     {
@@ -198,7 +212,8 @@ namespace xt
     }
 
     // shape only - buffer version
-    template <class P, class O, class SC, layout_type L, class A, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class P, class O, class SC, layout_type L, class A,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
     inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, L, SC>
     adapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
     {
@@ -209,7 +224,9 @@ namespace xt
     }
 
     // shape and strides - buffer version
-    template <class P, class O, class SC, class SS, class A, typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class P, class O, class SC, class SS, class A,
+              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
     inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, layout_type::dynamic, std::decay_t<SC>>
     adapt(P&& pointer, typename A::size_type size, O, SC&& shape, SS&& strides, const A& alloc)
     {
@@ -236,7 +253,8 @@ namespace xt
     }
 
     // shape only - container version
-    template <class C, class SC, layout_type L, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class C, class SC, layout_type L,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
     inline xtensor_adaptor<C, detail::array_size<SC>::value, L>
     adapt(C&& container, const SC& shape, layout_type l)
     {
@@ -246,7 +264,9 @@ namespace xt
     }
 
     // shape and strides - container version
-    template <class C, class SC, class SS, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class C, class SC, class SS,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
     inline xtensor_adaptor<C, detail::array_size<SC>::value, layout_type::dynamic>
     adapt(C&& container, SC&& shape, SS&& strides)
     {
@@ -270,7 +290,8 @@ namespace xt
     }
 
     // shape only - buffer version
-    template <class P, class O, class SC, layout_type L, class A, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class P, class O, class SC, layout_type L, class A,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, L>
     adapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
     {
@@ -282,7 +303,9 @@ namespace xt
     }
 
     // shape and strides - buffer version
-    template <class P, class O, class SC, class SS, class A, typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
+    template <class P, class O, class SC, class SS, class A,
+              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>,
+              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, layout_type::dynamic>
     adapt(P&& pointer, typename A::size_type size, O, SC&& shape, SS&& strides, const A& alloc)
     {

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -30,6 +30,17 @@ namespace xt
         EXPECT_EQ(1, v[2]);
     }
 
+    TEST(xarray_adaptor, adapt_layout)
+    {
+        vec_type v(4, 0);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s({2, 2});
+
+        auto a1 = adapt(v, s, XTENSOR_DEFAULT_LAYOUT);
+        a1(0, 1) = 1;
+        EXPECT_EQ(1, v[a1.strides()[1]]);
+    }
+
     TEST(xarray_adaptor, pointer_no_ownership)
     {
         size_t size = 4;
@@ -76,9 +87,9 @@ namespace xt
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({ 1 });
 
-        auto a1 = adapt(&data1, size, xt::no_ownership(), s);
-        auto a2 = adapt(&data2, size, xt::no_ownership(), s);
-        auto a3 = adapt(&data3, size, xt::no_ownership(), s);
+        auto a1 = adapt(&data1, size, no_ownership(), s);
+        auto a2 = adapt(&data2, size, no_ownership(), s);
+        auto a3 = adapt(&data3, size, no_ownership(), s);
         a3 = a1 + a2;
         EXPECT_EQ(1, data3);
     }
@@ -94,11 +105,26 @@ namespace xt
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({ 1 });
 
-        auto a1 = adapt(data1, size, xt::acquire_ownership(), s);
-        auto a2 = adapt(data2, size, xt::acquire_ownership(), s);
-        auto a3 = adapt(data3, size_t(0), xt::acquire_ownership(), s);
+        auto a1 = adapt(data1, size, acquire_ownership(), s);
+        auto a2 = adapt(data2, size, acquire_ownership(), s);
+        auto a3 = adapt(data3, size_t(0), acquire_ownership(), s);
         a3 = a1 + a2;
         EXPECT_EQ(1, *data3);
+    }
+
+    TEST(xarray_adaptor, ptr_adapt_layout)
+    {
+        size_t size = 4;
+        int* data = new int[size];
+
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s = { size };
+
+        auto a0 = adapt(data, size, no_ownership(), s, XTENSOR_DEFAULT_LAYOUT);
+        a0(3) = 3;
+        EXPECT_EQ(3, data[3]);
+
+        delete[] data;
     }
 
     TEST(xtensor_adaptor, adapt)
@@ -122,6 +148,17 @@ namespace xt
         auto a2 = adapt(v, s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, v[2]);
+    }
+
+    TEST(xtensor_adaptor, adapt_layout)
+    {
+        vec_type v(4, 0);
+        using shape_type = std::array<vec_type::size_type, 2>;
+        shape_type s = {2, 2};
+
+        auto a1 = adapt(v, s, XTENSOR_DEFAULT_LAYOUT);
+        a1(0, 1) = 1;
+        EXPECT_EQ(1, v[a1.strides()[1]]);
     }
 
     TEST(xtensor_adaptor, pointer_no_ownership)
@@ -221,9 +258,9 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 1>;
         shape_type s = { 1 };
 
-        auto a1 = adapt(&data1, size, xt::no_ownership(), s);
-        auto a2 = adapt(&data2, size, xt::no_ownership(), s);
-        auto a3 = adapt(&data3, size, xt::no_ownership(), s);
+        auto a1 = adapt(&data1, size, no_ownership(), s);
+        auto a2 = adapt(&data2, size, no_ownership(), s);
+        auto a3 = adapt(&data3, size, no_ownership(), s);
         a3 = a1 + a2;
         EXPECT_EQ(1, data3);
     }
@@ -241,9 +278,9 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 1>;
         shape_type s = { 1 };
 
-        auto a1 = adapt(p_data1, size, xt::no_ownership(), s);
-        auto a2 = adapt(p_data2, size, xt::no_ownership(), s);
-        auto a3 = adapt(p_data3, size, xt::no_ownership(), s);
+        auto a1 = adapt(p_data1, size, no_ownership(), s);
+        auto a2 = adapt(p_data2, size, no_ownership(), s);
+        auto a3 = adapt(p_data3, size, no_ownership(), s);
 
         a3 = a1 + a2;
 
@@ -261,10 +298,25 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 1>;
         shape_type s = { 1 };
 
-        auto a1 = adapt(data1, size, xt::acquire_ownership(), s);
-        auto a2 = adapt(data2, size, xt::acquire_ownership(), s);
-        auto a3 = adapt(data3, size_t(0), xt::acquire_ownership(), s);
+        auto a1 = adapt(data1, size, acquire_ownership(), s);
+        auto a2 = adapt(data2, size, acquire_ownership(), s);
+        auto a3 = adapt(data3, size_t(0), acquire_ownership(), s);
         a3 = a1 + a2;
         EXPECT_EQ(1, *data3);
+    }
+
+    TEST(xtensor_adaptor, ptr_adapt_layout)
+    {
+        size_t size = 4;
+        int* data = new int[size];
+
+        using shape_type = std::array<vec_type::size_type, 1>;
+        shape_type s = { size };
+
+        auto a0 = adapt(data, size, no_ownership(), s, XTENSOR_DEFAULT_LAYOUT);
+        a0(3) = 3;
+        EXPECT_EQ(3, data[3]);
+
+        delete[] data;
     }
 }


### PR DESCRIPTION
This is meant to prevent wrong overload resolution between

`adapt(C&& container, const SC& shape, layout_type l = L);`

and the catch-all

`adapt(C&& container, SC&& shape, SS&& strides)`

in the case where a layout is specified for the first function.



Another similar issue solved is for the pair

`adapt(P&& pointer, size_type size, const SC& shape, layout_type l = L);`

and the catch-all

`adapt(P&& pointer, size_type size, SC&& shape, SS&& strides)`

in the case when a layout is specified for the fist function.

