### PR TITLE
fix xsimd activation

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -94,7 +94,7 @@ namespace xt
         };
 
         template <class F, class R>
-        struct simd_return_type<F, R, void_t<decltype(&F::simd_apply)>>
+        struct simd_return_type<F, R, void_t<decltype(&F::template simd_apply<R>)>>
         {
             using type = R;
         };

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -312,4 +312,55 @@ namespace xt
         }
     }
 
+    namespace detail
+    {
+        template <class E1, class E2>
+        bool simd_assign(E1&, const E2&)
+        {
+            constexpr bool contiguous_layout = E1::contiguous_layout && E2::contiguous_layout;
+            constexpr bool same_type = std::is_same<typename E1::value_type, typename E2::value_type>::value;
+            constexpr bool simd_size = xsimd::simd_traits<typename E1::value_type>::size > 1;
+            constexpr bool forbid_simd = detail::forbid_simd_assign<E2>::value;
+            return contiguous_layout && same_type && simd_size && !forbid_simd;
+        }
+    }
+
+    TEST(xfunction, forbid_simd_assign)
+    {
+    #if XTENSOR_USE_XSIMD
+        xarray<double> a, b, c;
+        xarray<int> i;
+        xscalar<double> s_d;
+        xarray<char> cc;
+        xscalar<int> s_i;
+
+        auto f1 = a + b;
+        auto f2 = a + s_d;
+        auto f3 = s_d * b + c * a;
+
+        bool vb = xt::detail::forbid_simd_assign<decltype(f1)>::value;
+        EXPECT_FALSE(vb);
+        vb = xt::detail::forbid_simd_assign<decltype(f2)>::value;
+        EXPECT_FALSE(vb);
+        vb = xt::detail::forbid_simd_assign<decltype(f3)>::value;
+        EXPECT_FALSE(vb);
+
+        auto f4 = s_i * a;
+        auto f5 = cc * cc;
+        vb = xt::detail::forbid_simd_assign<decltype(f4)>::value;
+        EXPECT_FALSE(vb);
+        vb = xt::detail::forbid_simd_assign<decltype(f5)>::value;
+        EXPECT_FALSE(vb);
+
+        vb = xt::detail::forbid_simd_assign<decltype(cc + cc)>::value;
+        EXPECT_FALSE(vb);
+
+        EXPECT_TRUE(detail::simd_assign(a, f1));
+        EXPECT_TRUE(detail::simd_assign(a, f2));
+        EXPECT_TRUE(detail::simd_assign(a, f3));
+        EXPECT_FALSE(detail::simd_assign(a, f4));
+        EXPECT_FALSE(detail::simd_assign(a, f5));
+    #endif
+    }
+
 }


### PR DESCRIPTION
this has a failing test @JohanMabille 

SIMD assign is currently activated even for a mixed expression `[double] = [double] * int;`
This is because the value_type of the xfunction is double, so the is_same in the simd assign check has no effect.

Therefore we might have to check more closely in the xfunction load_simd activation?