### PR TITLE
Workaround msvc 15.7 bug

### DIFF
--- a/include/xtensor/xvectorize.hpp
+++ b/include/xtensor/xvectorize.hpp
@@ -53,8 +53,12 @@ namespace xt
     template <class F, class R, class... Args>
     xvectorizer<F, R> vectorize(F&& f, R (*)(Args...));
 
+// Workaround for Visual Studio 15.7.1.
+// Error C2668 (ambiguous call to overloaded function) on forward declarations vs definitions.
+#ifndef _MSC_VER
     template <class F>
     auto vectorize(F&& f) -> decltype(vectorize(std::forward<F>(f), std::declval<detail::get_function_type<F>*>()));
+#endif
 
     /******************************
      * xvectorizer implementation *


### PR DESCRIPTION
Fixes #857 

Visual studio 2017 does not like forward declarations.