### PR TITLE
Prevent expansion of min and max macros on windows

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -7,45 +7,87 @@
 Compiler workarounds
 ====================
 
-This page tracks the workarounds for the various compiler issues that we encountered in the development. This is mostly of interest for developers interested in contributing to xtensor.
+This page tracks the workarounds for the various compiler issues that we
+encountered in the development. This is mostly of interest for developers
+interested in contributing to xtensor.
 
 Visual Studio 2015 and ``std::enable_if``
 -----------------------------------------
 
-With Visual Studio, ``std::enable_if`` evaluates its second argument, even if the condition is false. This is the reason for the presence of the indirection in the implementation of the ``xfunction_type_t`` meta-function.
+With Visual Studio, ``std::enable_if`` evaluates its second argument, even if
+the condition is false. This is the reason for the presence of the indirection
+in the implementation of the ``xfunction_type_t`` meta-function.
 
 Visual Studio 2017 and alias templates with non-class template parameters and multiple aliasing levels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Alias template with non-class parameters only, and multiple levels of aliasing are not properly considered as types by Visual Studio 2017. The base ``xcontainer`` template class underlying xtensor container types has such alias templates defined. We avoid the multiple levels of aliasing in the case of Visual Studio.
+Alias template with non-class parameters only, and multiple levels of aliasing
+are not properly considered as types by Visual Studio 2017. The base
+``xcontainer`` template class underlying xtensor container types has such alias
+templates defined. We avoid the multiple levels of aliasing in the case of Visual
+Studio.
+
+Visual Studio and ``min`` and ``max`` macros
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Visual Studio defines ``min`` and ``max`` macros causing calls to e.g.
+``std::min`` and ``std::max`` to be interpreted as syntax errors. The
+``NOMINMAX`` definition may be used to disable these macros.
+
+In xtensor, to prevent macro replacements of ``min`` and ``max`` functions, we
+wrap them with parentheses, so that client code does not need the ``NOMINMAX``
+definition.
 
 GCC-4.9 and Clang < 3.8 and constexpr ``std::min`` and ``std::max``
 -------------------------------------------------------------------
 
-``std::min`` and ``std::max`` are not constexpr in these compilers. In ``xio.hpp``, we locally define a ``XTENSOR_MIN`` macro used instead of ``std::min``. The macro is undefined right after it is used.
+``std::min`` and ``std::max`` are not constexpr in these compilers. In
+``xio.hpp``, we locally define a ``XTENSOR_MIN`` macro used instead of
+``std::min``. The macro is undefined right after it is used.
 
 Clang < 3.8 matching ``initializer_list`` with static arrays
 ------------------------------------------------------------
 
-Old versions of Clang don't handle overload resolution with braced initializer lists correctly: braced initializer lists are not properly matched to static arrays. This prevent compile-time detection of the length of a braced initializer list.
+Old versions of Clang don't handle overload resolution with braced initializer
+lists correctly: braced initializer lists are not properly matched to static
+arrays. This prevent compile-time detection of the length of a braced
+initializer list.
 
-A consequence is that we need to use stack-allocated shape types in these cases. Workarounds for this compiler bug arise in various files of the code base. Everywhere, the handling of `Clang < 3.8` is wrapped with checks for the ``X_OLD_CLANG`` macro.
+A consequence is that we need to use stack-allocated shape types in these cases.
+Workarounds for this compiler bug arise in various files of the code base.
+Everywhere, the handling of `Clang < 3.8` is wrapped with checks for the
+``X_OLD_CLANG`` macro.
 
 GCC < 5.1 and ``std::is_trivially_default_constructible``
 ---------------------------------------------------------
 
-The versions of the STL shipped with versions of GCC older than 5.1 are missing a number of type traits, such as ``std::is_trivially_default_constructible``. However, for some of them, equivalent type traits with different names are provided, such as ``std::has_trivial_default_constructor``.
+The versions of the STL shipped with versions of GCC older than 5.1 are missing
+a number of type traits, such as ``std::is_trivially_default_constructible``.
+However, for some of them, equivalent type traits with different names are
+provided, such as ``std::has_trivial_default_constructor``.
 
-In this case, we polyfill the proper standard names using the deprecated ``std::has_trivial_default_constructor``. This must also be done when the compiler is clang when it makes use of the GCC implementation of the STL, which is the default behavior on linux. Properly detecting the version of the GCC STL used by clang cannot be done with the ``__GNUC__``  macro, which are overridden by clang. Instead, we check for the definition of the macro ``_GLIBCXX_USE_CXX11_ABI`` which is only defined with GCC versions greater than 5.
+In this case, we polyfill the proper standard names using the deprecated
+``std::has_trivial_default_constructor``. This must also be done when the
+compiler is clang when it makes use of the GCC implementation of the STL,
+which is the default behavior on linux. Properly detecting the version of the
+GCC STL used by clang cannot be done with the ``__GNUC__``  macro, which are
+overridden by clang. Instead, we check for the definition of the macro
+``_GLIBCXX_USE_CXX11_ABI`` which is only defined with GCC versions greater than
+``5``.
 
 GCC-6 and the signature of ``std::isnan`` and ``std::isinf``
 ------------------------------------------------------------
 
-We are not directly using ``std::isnan`` or ``std::isinf`` for the implementation of ``xt::isnan`` and ``xt::isinf``, as a workaround to the following bug in GCC-6 for the following reason.
+We are not directly using ``std::isnan`` or ``std::isinf`` for the
+implementation of ``xt::isnan`` and ``xt::isinf``, as a workaround to the
+following bug in GCC-6 for the following reason.
 
 - C++11 requires that the ``<cmath>`` header declares ``bool std::isnan(double)`` and ``bool std::isinf(double)``.
 - C99 requires that the ``<math.h>`` header declares ``int ::isnan(double)`` and ``int ::isinf(double)``.
 
 These two definitions would clash when importing both headers and using namespace std.
 
-As of version 6, GCC detects whether the obsolete functions are present in the C ``<math.h>`` header and uses them if they are, avoiding the clash. However, this means that the function might return int instead of bool as C++11 requires, which is a bug.
+As of version 6, GCC detects whether the obsolete functions are present in the
+C header ``<math.h>`` and uses them if they are, avoiding the clash. However,
+this means that the function might return int instead of bool as C++11
+requires, which is a bug.

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -127,7 +127,7 @@ namespace xt
     inline void check_element_index(const S& shape, It first, It last)
     {
         auto dst = static_cast<typename S::size_type>(last - first);
-        It efirst = last - static_cast<std::ptrdiff_t>(std::min(shape.size(), dst));
+        It efirst = last - static_cast<std::ptrdiff_t>((std::min)(shape.size(), dst));
         std::size_t axis = 0;
         while (efirst != last)
         {

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -895,7 +895,7 @@ namespace xt
     template <class F, class R, class... CT>
     inline auto xfunction_base<F, R, CT...>::compute_dimension() const noexcept -> size_type
     {
-        auto func = [](size_type d, auto&& e) noexcept { return std::max(d, e.dimension()); };
+        auto func = [](size_type d, auto&& e) noexcept { return (std::max)(d, e.dimension()); };
         return accumulate(func, size_type(0), m_e);
     }
 
@@ -980,7 +980,7 @@ namespace xt
                                                                 const data_type& rhs) const -> difference_type
     {
         auto diff = std::make_tuple((std::get<I>(lhs) - std::get<I>(rhs))...);
-        auto func = [](difference_type n, auto&& v) { return std::max(n, v); };
+        auto func = [](difference_type n, auto&& v) { return (std::max)(n, v); };
         return accumulate(func, difference_type(0), diff);
     }
 

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -1476,7 +1476,7 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
                     return a == b;
                 }
                 auto d = math::abs(internal_type(a) - internal_type(b));
-                return d <= m_atol || d <= m_rtol * double(std::max(math::abs(a), math::abs(b)));
+                return d <= m_atol || d <= m_rtol * double((std::max)(math::abs(a), math::abs(b)));
             }
 
             template <class U>
@@ -1640,16 +1640,16 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
         using result_type = std::array<value_type, 2>;
 
         auto reduce_func = [](result_type r, value_type const& v) {
-            r[0] = min(r[0], v);
-            r[1] = max(r[1], v);
+            r[0] = (min)(r[0], v);
+            r[1] = (max)(r[1], v);
             return r;
         };
         auto init_func = [](value_type const& v) {
             return result_type{v, v};
         };
         auto merge_func = [](result_type r, result_type const& s) {
-            r[0] = min(r[0], s[0]);
-            r[1] = max(r[1], s[1]);
+            r[0] = (min)(r[0], s[0]);
+            r[1] = (max)(r[1], s[1]);
             return r;
         };
         return reduce(make_xreducer_functor(std::move(reduce_func),
@@ -1736,7 +1736,7 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
                     }
                     else
                     {
-                        return std::numeric_limits<result_type>::max();
+                        return (std::numeric_limits<result_type>::max)();
                     }
                 }
                 return a;

--- a/include/xtensor/xnorm.hpp
+++ b/include/xtensor/xnorm.hpp
@@ -141,7 +141,7 @@ namespace xt
     template <class T>
     inline auto norm_linf(const std::complex<T>& t) noexcept
     {
-        return std::max(std::abs(t.real()), std::abs(t.imag()));
+        return (std::max)(std::abs(t.real()), std::abs(t.imag()));
     }
 
     /**
@@ -223,7 +223,7 @@ namespace xt
     XTENSOR_NORM_FUNCTION(norm_l0, unsigned long long, XTENSOR_EMPTY, +, std::plus)
     XTENSOR_NORM_FUNCTION(norm_l1, big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
     XTENSOR_NORM_FUNCTION(norm_sq, big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
-    XTENSOR_NORM_FUNCTION(norm_linf, decltype(norm_linf(std::declval<value_type>())), std::max<result_type>, XTENSOR_COMMA, math::maximum)
+    XTENSOR_NORM_FUNCTION(norm_linf, decltype(norm_linf(std::declval<value_type>())), (std::max<result_type>), XTENSOR_COMMA, math::maximum)
 
 #undef XTENSOR_EMPTY
 #undef XTENSOR_COMMA

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -41,7 +41,7 @@ namespace xt
                   E& engine = random::get_default_random_engine());
 
         template <class T, class S, class E = random::default_engine_type>
-        auto randint(const S& shape, T lower = 0, T upper = std::numeric_limits<T>::max(),
+        auto randint(const S& shape, T lower = 0, T upper = (std::numeric_limits<T>::max)(),
                      E& engine = random::get_default_random_engine());
 
         template <class T, class S, class E = random::default_engine_type>
@@ -55,7 +55,7 @@ namespace xt
 
         template <class T, class I, class E = random::default_engine_type>
         auto randint(std::initializer_list<I> shape,
-                     T lower = 0, T upper = std::numeric_limits<T>::max(),
+                     T lower = 0, T upper = (std::numeric_limits<T>::max)(),
                      E& engine = random::get_default_random_engine());
 
         template <class T, class I, class E = random::default_engine_type>
@@ -67,7 +67,7 @@ namespace xt
                   E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class E = random::default_engine_type>
-        auto randint(const I (&shape)[L], T lower = 0, T upper = std::numeric_limits<T>::max(),
+        auto randint(const I (&shape)[L], T lower = 0, T upper = (std::numeric_limits<T>::max)(),
                      E& engine = random::get_default_random_engine());
 
         template <class T, class I, std::size_t L, class E = random::default_engine_type>

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1106,12 +1106,16 @@ namespace xt
         }
 
         if (rhs.size() > this->capacity())
+        {
             this->resize(rhs.size());
+        }
         if (this->size() > rhs.capacity())
+        {
             rhs.resize(this->size());
+        }
 
         // Swap the shared elements.
-        size_t num_shared = std::min(this->size(), rhs.size());
+        size_t num_shared = (std::min)(this->size(), rhs.size());
 
         for (size_type i = 0; i != num_shared; ++i)
         {

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -1527,7 +1527,7 @@ namespace xt
     template <std::size_t N, class E>
     auto atleast_Nd(E&& e)
     {
-        slice_vector sv(std::max(e.dimension(), N), xt::all());
+        slice_vector sv((std::max)(e.dimension(), N), xt::all());
         if (e.dimension() < N)
         {
             std::size_t i = 0;

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -151,7 +151,7 @@ namespace xt
     inline size_type element_offset(const S& strides, It first, It last) noexcept
     {
         using difference_type = typename std::iterator_traits<It>::difference_type;
-        auto size = static_cast<difference_type>(std::min(static_cast<typename S::size_type>(std::distance(first, last)), strides.size()));
+        auto size = static_cast<difference_type>((std::min)(static_cast<typename S::size_type>(std::distance(first, last)), strides.size()));
         return std::inner_product(last - size, last, strides.cend() - size, size_type(0));
     }
 


### PR DESCRIPTION
I had this issue with Xtensor.jl including `windows.h`.

In xtensor, if we wrap calls to `std::min` and `std::max` with parenthesis, the macros will not be expanded. This will allow client code to use xtensor without having to add the `NOMINMAX` definition.