### PR TITLE
Remove use of CS, DS and ES qualifiers for Solaris builds

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,8 @@ Changelog
   `#858 <https://github.com/QuantStack/xtensor/pull/858>`_.
 - Fixup example notebook
   `#861 <https://github.com/QUantStack/xtensor/pull/861>`_.
+- Fix regression with respect to random access stepping with views
+  `#865 <https://github.com/QUantStack/xtensor/pull/865>`_.
 
 0.16.0
 ------

--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -70,16 +70,16 @@ namespace xt
 
     namespace detail
     {
-        template <class F, class E, class ES>
-        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, std::size_t, ES)
+        template <class F, class E, class EVS>
+        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, std::size_t, EVS)
         {
-            static_assert(!std::is_same<evaluation_strategy::lazy, ES>::value, "Lazy accumulators not yet implemented.");
+            static_assert(!std::is_same<evaluation_strategy::lazy, EVS>::value, "Lazy accumulators not yet implemented.");
         }
 
-        template <class F, class E, class ES>
-        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, ES)
+        template <class F, class E, class EVS>
+        xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, EVS)
         {
-            static_assert(!std::is_same<evaluation_strategy::lazy, ES>::value, "Lazy accumulators not yet implemented.");
+            static_assert(!std::is_same<evaluation_strategy::lazy, EVS>::value, "Lazy accumulators not yet implemented.");
         }
 
         template <class T, class R>
@@ -236,11 +236,11 @@ namespace xt
      *
      * @return returns xarray<T> filled with accumulated values
      */
-    template <class F, class E, class ES = DEFAULT_STRATEGY_ACCUMULATORS,
-              typename std::enable_if_t<!std::is_integral<ES>::value, int> = 0>
-    inline auto accumulate(F&& f, E&& e, ES evaluation_strategy = ES())
+    template <class F, class E, class EVS = DEFAULT_STRATEGY_ACCUMULATORS,
+              typename std::enable_if_t<!std::is_integral<EVS>::value, int> = 0>
+    inline auto accumulate(F&& f, E&& e, EVS evaluation_strategy = EVS())
     {
-        // Note we need to check is_integral above in order to prohibit ES = int, and not taking the std::size_t
+        // Note we need to check is_integral above in order to prohibit EVS = int, and not taking the std::size_t
         // overload below!
         return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), evaluation_strategy);
     }
@@ -256,8 +256,8 @@ namespace xt
      *
      * @return returns xarray<T> filled with accumulated values
      */
-    template <class F, class E, class ES = DEFAULT_STRATEGY_ACCUMULATORS>
-    inline auto accumulate(F&& f, E&& e, std::size_t axis, ES evaluation_strategy = ES())
+    template <class F, class E, class EVS = DEFAULT_STRATEGY_ACCUMULATORS>
+    inline auto accumulate(F&& f, E&& e, std::size_t axis, EVS evaluation_strategy = EVS())
     {
         return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), axis, evaluation_strategy);
     }

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -381,9 +381,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
 #undef XTENSOR_UNSIGNED_ABS_FUNC
 
 #define XTENSOR_REDUCER_FUNCTION(NAME, FUNCTOR, RESULT_TYPE)                                                      \
-    template <class E, class X, class ES = DEFAULT_STRATEGY_REDUCERS,                                             \
+    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                                            \
               class = std::enable_if_t<!std::is_base_of<evaluation_strategy::base, std::decay_t<X>>::value, int>> \
-    inline auto NAME(E&& e, X&& axes, ES es = ES())                                                               \
+    inline auto NAME(E&& e, X&& axes, EVS es = EVS())                                                             \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -391,9 +391,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
                       std::forward<X>(axes), es);                                                                 \
     }                                                                                                             \
                                                                                                                   \
-    template <class E, class ES = DEFAULT_STRATEGY_REDUCERS,                                                      \
-              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, ES>::value, int>>               \
-    inline auto NAME(E&& e, ES es = ES())                                                                         \
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,                                                     \
+              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, EVS>::value, int>>              \
+    inline auto NAME(E&& e, EVS es = EVS())                                                                       \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -401,8 +401,8 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
     }
 
 #define XTENSOR_OLD_CLANG_REDUCER(NAME, FUNCTOR, RESULT_TYPE)                                                     \
-    template <class E, class I, class ES = DEFAULT_STRATEGY_REDUCERS>                                             \
-        inline auto NAME(E&& e, std::initializer_list<I> axes, ES es = ES())                                      \
+    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>                                            \
+        inline auto NAME(E&& e, std::initializer_list<I> axes, EVS es = EVS())                                    \
         {                                                                                                         \
             using result_type = RESULT_TYPE;                                                                      \
             using functor_type = FUNCTOR<result_type>;                                                            \
@@ -410,8 +410,8 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
         }                                                                                                         \
 
 #define XTENSOR_MODERN_CLANG_REDUCER(NAME, FUNCTOR, RESULT_TYPE)                                                  \
-    template <class E, class I, std::size_t N, class ES = DEFAULT_STRATEGY_REDUCERS>                              \
-    inline auto NAME(E&& e, const I (&axes)[N], ES es = ES())                                                     \
+    template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>                             \
+    inline auto NAME(E&& e, const I (&axes)[N], EVS es = EVS())                                                   \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -1630,9 +1630,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
      * @return an \ref xexpression of type ``std::array<value_type, 2>``, whose first
      *         and second element represent the minimum and maximum respectively
      */
-    template <class E, class ES = DEFAULT_STRATEGY_REDUCERS,
-              XTENSOR_REQUIRE<std::is_base_of<evaluation_strategy::base, ES>::value>>
-    inline auto minmax(E&& e, ES es = ES())
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTENSOR_REQUIRE<std::is_base_of<evaluation_strategy::base, EVS>::value>>
+    inline auto minmax(E&& e, EVS es = EVS())
     {
         using std::min;
         using std::max;
@@ -1800,9 +1800,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
     }
 
 #define XTENSOR_NAN_REDUCER_FUNCTION(NAME, FUNCTOR, RESULT_TYPE, NAN)                                             \
-    template <class E, class X, class ES = DEFAULT_STRATEGY_REDUCERS,                                             \
+    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,                                            \
               class = std::enable_if_t<!std::is_base_of<evaluation_strategy::base, std::decay_t<X>>::value, int>> \
-    inline auto NAME(E&& e, X&& axes, ES es = ES())                                                               \
+    inline auto NAME(E&& e, X&& axes, EVS es = EVS())                                                             \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -1811,9 +1811,9 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
                       std::forward<X>(axes), es);                                                                 \
     }                                                                                                             \
                                                                                                                   \
-    template <class E, class ES = DEFAULT_STRATEGY_REDUCERS,                                                      \
-              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, ES>::value, int>>               \
-    inline auto NAME(E&& e, ES es = ES())                                                                         \
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,                                                     \
+              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, EVS>::value, int>>              \
+    inline auto NAME(E&& e, EVS es = EVS())                                                                       \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -1822,8 +1822,8 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
     }
 
 #define OLD_CLANG_NAN_REDUCER(NAME, FUNCTOR, RESULT_TYPE, NAN)                                                       \
-    template <class E, class I, class ES = DEFAULT_STRATEGY_REDUCERS>                                                \
-        inline auto NAME(E&& e, std::initializer_list<I> axes, ES es = ES())                                         \
+    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>                                               \
+        inline auto NAME(E&& e, std::initializer_list<I> axes, EVS es = EVS())                                       \
         {                                                                                                            \
             using result_type = RESULT_TYPE;                                                                         \
             using functor_type = FUNCTOR<result_type>;                                                               \
@@ -1832,8 +1832,8 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
         }
 
 #define MODERN_CLANG_NAN_REDUCER(NAME, FUNCTOR, RESULT_TYPE, NAN)                                                 \
-    template <class E, class I, std::size_t N, class ES = DEFAULT_STRATEGY_REDUCERS>                              \
-    inline auto NAME(E&& e, const I (&axes)[N], ES es = ES())                                                     \
+    template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>                             \
+    inline auto NAME(E&& e, const I (&axes)[N], EVS es = EVS())                                                   \
     {                                                                                                             \
         using result_type = RESULT_TYPE;                                                                          \
         using functor_type = FUNCTOR<result_type>;                                                                \
@@ -1895,18 +1895,18 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
     };                                                                          \
     auto merge_func = std::plus<result_type>();                                 \
 
-    template <class E, class ES = DEFAULT_STRATEGY_REDUCERS,
-              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, ES>::value, int>>
-    inline auto count_nonzeros(E&& e, ES es = ES())
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, EVS>::value, int>>
+    inline auto count_nonzeros(E&& e, EVS es = EVS())
     {
         COUNT_NON_ZEROS_CONTENT;
         return reduce(make_xreducer_functor(std::move(reduce_fct), std::move(init_fct), std::move(merge_func)),
                       std::forward<E>(e), es);
     }
 
-    template <class E, class X, class ES = DEFAULT_STRATEGY_REDUCERS,
+    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
               class = std::enable_if_t<!std::is_base_of<evaluation_strategy::base, X>::value, int>>
-    inline auto count_nonzeros(E&& e, X&& axes, ES es = ES())
+    inline auto count_nonzeros(E&& e, X&& axes, EVS es = EVS())
     {
         COUNT_NON_ZEROS_CONTENT;
         return reduce(make_xreducer_functor(std::move(reduce_fct), std::move(init_fct), std::move(merge_func)),
@@ -1914,16 +1914,16 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
     }
 
 #ifdef X_OLD_CLANG
-    template <class E, class I, class ES = DEFAULT_STRATEGY_REDUCERS>
-    inline auto count_nonzeros(E&& e, std::initializer_list<I> axes, ES es = ES())
+    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    inline auto count_nonzeros(E&& e, std::initializer_list<I> axes, EVS es = EVS())
     {
         COUNT_NON_ZEROS_CONTENT;
         return reduce(make_xreducer_functor(std::move(reduce_fct), std::move(init_fct), std::move(merge_func)),
                       std::forward<E>(e), axes, es);
     }
 #else
-    template <class E, class I, std::size_t N, class ES = DEFAULT_STRATEGY_REDUCERS>
-    inline auto count_nonzeros(E&& e, const I (&axes)[N], ES es = ES())
+    template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    inline auto count_nonzeros(E&& e, const I (&axes)[N], EVS es = EVS())
     {
         COUNT_NON_ZEROS_CONTENT;
         return reduce(make_xreducer_functor(std::move(reduce_fct), std::move(init_fct), std::move(merge_func)),

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -39,20 +39,20 @@ namespace xt
 
 #define DEFAULT_STRATEGY_REDUCERS evaluation_strategy::lazy
 
-    template <class F, class E, class X, class ES = DEFAULT_STRATEGY_REDUCERS,
+    template <class F, class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
               class = std::enable_if_t<!std::is_base_of<evaluation_strategy::base, std::decay_t<X>>::value, int>>
-    auto reduce(F&& f, E&& e, X&& axes, ES es = ES());
+    auto reduce(F&& f, E&& e, X&& axes, EVS es = EVS());
 
-    template <class F, class E, class ES = DEFAULT_STRATEGY_REDUCERS,
-              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, ES>::value, int>>
-    auto reduce(F&& f, E&& e, ES es = ES());
+    template <class F, class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              class = std::enable_if_t<std::is_base_of<evaluation_strategy::base, EVS>::value, int>>
+    auto reduce(F&& f, E&& e, EVS es = EVS());
 
 #ifdef X_OLD_CLANG
-    template <class F, class E, class I, class ES = DEFAULT_STRATEGY_REDUCERS>
-    auto reduce(F&& f, E&& e, std::initializer_list<I> axes, ES es = ES());
+    template <class F, class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    auto reduce(F&& f, E&& e, std::initializer_list<I> axes, EVS es = EVS());
 #else
-    template <class F, class E, class I, std::size_t N, class ES = DEFAULT_STRATEGY_REDUCERS>
-    auto reduce(F&& f, E&& e, const I (&axes)[N], ES es = ES());
+    template <class F, class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    auto reduce(F&& f, E&& e, const I (&axes)[N], EVS es = EVS());
 #endif
 
     template <class ST, class X>
@@ -505,14 +505,14 @@ namespace xt
      * depending on whether \p e is an lvalue or an rvalue.
      */
 
-    template <class F, class E, class X, class ES, class>
-    inline auto reduce(F&& f, E&& e, X&& axes, ES evaluation_strategy)
+    template <class F, class E, class X, class EVS, class>
+    inline auto reduce(F&& f, E&& e, X&& axes, EVS evaluation_strategy)
     {
         return detail::reduce_impl(std::forward<F>(f), std::forward<E>(e), std::forward<X>(axes), evaluation_strategy);
     }
 
-    template <class F, class E, class ES, class>
-    inline auto reduce(F&& f, E&& e, ES evaluation_strategy)
+    template <class F, class E, class EVS, class>
+    inline auto reduce(F&& f, E&& e, EVS evaluation_strategy)
     {
         typename std::decay_t<E>::shape_type ar;
         resize_container(ar, e.dimension());
@@ -521,16 +521,16 @@ namespace xt
     }
 
 #ifdef X_OLD_CLANG
-    template <class F, class E, class I, class ES>
-    inline auto reduce(F&& f, E&& e, std::initializer_list<I> axes, ES evaluation_strategy)
+    template <class F, class E, class I, class EVS>
+    inline auto reduce(F&& f, E&& e, std::initializer_list<I> axes, EVS evaluation_strategy)
     {
         using axes_type = std::vector<typename std::decay_t<E>::size_type>;
         using reducer_type = xreducer<F, const_xclosure_t<E>, axes_type>;
         return detail::reduce_impl(std::forward<F>(f), std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), evaluation_strategy);
     }
 #else
-    template <class F, class E, class I, std::size_t N, class ES>
-    inline auto reduce(F&& f, E&& e, const I (&axes)[N], ES evaluation_strategy)
+    template <class F, class E, class I, std::size_t N, class EVS>
+    inline auto reduce(F&& f, E&& e, const I (&axes)[N], EVS evaluation_strategy)
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
         return detail::reduce_impl(std::forward<F>(f), std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), evaluation_strategy);


### PR DESCRIPTION
On Solaris, we have

```
#define CS 15
#define DS 3
#define ES 2
```

coming from `sys/regset.h` which is the reason for the `xtensor-r` CRAN failure on solaris.