### PR TITLE
add xexpression_shaped experiment

### DIFF
--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -114,6 +114,11 @@ namespace xt
         template <class E>
         xarray_container& operator=(const xexpression<E>& e);
 
+        const shape_type& shape_impl() const
+        {
+            return base_type::container_shape_impl();
+        }
+
     private:
 
         storage_type m_storage;

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -111,8 +111,7 @@ namespace xt
         size_type size() const noexcept;
 
         constexpr size_type dimension() const noexcept;
-
-        constexpr const inner_shape_type& shape() const noexcept;
+        
         constexpr const inner_strides_type& strides() const noexcept;
         constexpr const inner_backstrides_type& backstrides() const noexcept;
 
@@ -424,8 +423,8 @@ namespace xt
 
         explicit xstrided_container(inner_shape_type&&, inner_strides_type&&) noexcept;
 
-        inner_shape_type& shape_impl() noexcept;
-        const inner_shape_type& shape_impl() const noexcept;
+        inner_shape_type& container_shape_impl() noexcept;
+        const inner_shape_type& container_shape_impl() const noexcept;
 
         inner_strides_type& strides_impl() noexcept;
         const inner_strides_type& strides_impl() const noexcept;
@@ -480,7 +479,7 @@ namespace xt
     template <class D>
     inline auto xcontainer<D>::size() const noexcept -> size_type
     {
-        return contiguous_layout ? storage().size() : compute_size(shape());
+        return contiguous_layout ? storage().size() : compute_size(derived_cast().shape_impl());
     }
 
     /**
@@ -489,16 +488,7 @@ namespace xt
     template <class D>
     inline constexpr auto xcontainer<D>::dimension() const noexcept -> size_type
     {
-        return shape().size();
-    }
-
-    /**
-     * Returns the shape of the container.
-     */
-    template <class D>
-    constexpr inline auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
-    {
-        return derived_cast().shape_impl();
+        return derived_cast().shape_impl().size();
     }
 
     /**
@@ -546,8 +536,8 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::operator()(Args... args) -> reference
     {
-        XTENSOR_TRY(check_index(shape(), args...));
-        XTENSOR_CHECK_DIMENSION(shape(), args...);
+        XTENSOR_TRY(check_index(derived_cast().shape_impl(), args...));
+        XTENSOR_CHECK_DIMENSION(derived_cast().shape_impl(), args...);
         size_type index = static_cast<size_type>(xt::data_offset<std::ptrdiff_t>(strides(), static_cast<std::ptrdiff_t>(args)...));
         return storage()[index];
     }
@@ -562,8 +552,8 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::operator()(Args... args) const -> const_reference
     {
-        XTENSOR_TRY(check_index(shape(), args...));
-        XTENSOR_CHECK_DIMENSION(shape(), args...);
+        XTENSOR_TRY(check_index(derived_cast().shape_impl(), args...));
+        XTENSOR_CHECK_DIMENSION(derived_cast().shape_impl(), args...);
         size_type index = static_cast<std::size_t>(xt::data_offset<std::ptrdiff_t>(strides(), static_cast<std::ptrdiff_t>(args)...));
         return storage()[index];
     }
@@ -581,7 +571,7 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::at(Args... args) -> reference
     {
-        check_access(shape(), static_cast<size_type>(args)...);
+        check_access(derived_cast().shape_impl(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -598,7 +588,7 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::at(Args... args) const -> const_reference
     {
-        check_access(shape(), static_cast<size_type>(args)...);
+        check_access(derived_cast().container_shape_impl(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
@@ -721,7 +711,7 @@ namespace xt
     template <class It>
     inline auto xcontainer<D>::element(It first, It last) -> reference
     {
-        XTENSOR_TRY(check_element_index(shape(), first, last));
+        XTENSOR_TRY(check_element_index(derived_cast().shape_impl(), first, last));
         return storage()[element_offset<size_type>(strides(), first, last)];
     }
 
@@ -736,7 +726,7 @@ namespace xt
     template <class It>
     inline auto xcontainer<D>::element(It first, It last) const -> const_reference
     {
-        XTENSOR_TRY(check_element_index(shape(), first, last));
+        XTENSOR_TRY(check_element_index(derived_cast().shape_impl(), first, last));
         return storage()[element_offset<size_type>(strides(), first, last)];
     }
 
@@ -1262,13 +1252,13 @@ namespace xt
     }
 
     template <class D>
-    inline auto xstrided_container<D>::shape_impl() noexcept -> inner_shape_type&
+    inline auto xstrided_container<D>::container_shape_impl() noexcept -> inner_shape_type&
     {
         return m_shape;
     }
 
     template <class D>
-    inline auto xstrided_container<D>::shape_impl() const noexcept -> const inner_shape_type&
+    inline auto xstrided_container<D>::container_shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -302,6 +302,16 @@ namespace xt
                                                   >
     {
     };
+
+    template <class D, class S>
+    class xexpression_shaped : public xexpression<D>
+    {
+    public:
+
+        using base_type = xexpression<D>;
+        using derived_type = typename base_type::derived_type;
+        using base_type::derived_cast;
+    };
 }
 
 #endif

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -70,6 +70,7 @@ namespace xt
     struct xcontainer_inner_types<xfunctor_view<F, CT>>
     {
         using xexpression_type = std::decay_t<CT>;
+        using shape_type = typename xexpression_type::shape_type;
         using temporary_type = typename xfunctor_view_temporary_type<F, xexpression_type>::type;
     };
 

--- a/include/xtensor/xindex_view.hpp
+++ b/include/xtensor/xindex_view.hpp
@@ -30,6 +30,7 @@ namespace xt
     struct xcontainer_inner_types<xindex_view<CT, I>>
     {
         using xexpression_type = std::decay_t<CT>;
+        using shape_type = std::array<std::size_t, 1>;
         using temporary_type = xarray<typename xexpression_type::value_type, xexpression_type::static_layout>;
     };
 

--- a/include/xtensor/xoptional_assembly.hpp
+++ b/include/xtensor/xoptional_assembly.hpp
@@ -33,6 +33,7 @@ namespace xt
         using flag_storage_type = typename flag_expression::storage_type&;
         using storage_type = xoptional_assembly_storage<value_storage_type, flag_storage_type>;
         using temporary_type = xoptional_assembly<VE, FE>;
+        using shape_type = typename VE::inner_shape_type;
     };
 
     template <class VE, class FE>
@@ -152,6 +153,7 @@ namespace xt
                                                      const typename flag_expression::storage_type&,
                                                      typename flag_expression::storage_type&>;
         using storage_type = xoptional_assembly_storage<value_storage_type, flag_storage_type>;
+        using shape_type = typename std::decay_t<VEC>::inner_shape_type;
         using temporary_type = xoptional_assembly<value_expression, flag_expression>;
     };
 

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -28,7 +28,7 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xsemantic_base : public xexpression<D>
+    class xsemantic_base : public xexpression_shaped<D, typename xcontainer_inner_types<D>::shape_type>
     {
     public:
 

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -34,6 +34,7 @@ namespace xt
     {
         using xexpression_type = std::decay_t<CT>;
         using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>>;
+        using shape_type = S;
     };
 
     template <class CT, class S, layout_type L, class FST>

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -109,6 +109,11 @@ namespace xt
         template <class E>
         xtensor_container& operator=(const xexpression<E>& e);
 
+        const shape_type& shape_impl() const
+        {
+            return base_type::container_shape_impl();
+        }
+
     private:
 
         storage_type m_storage;

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -33,18 +33,28 @@ namespace xt
      * xview declaration *
      *********************/
 
+    template <class ST, class... S>
+    struct xview_shape_type;
+
     template <class CT, class... S>
     struct xcontainer_inner_types<xview<CT, S...>>
     {
         using xexpression_type = std::decay_t<CT>;
+        using shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
         using temporary_type = view_temporary_type_t<xexpression_type, S...>;
     };
 
     template <bool is_const, class CT, class... S>
     class xview_stepper;
 
-    template <class ST, class... S>
-    struct xview_shape_type;
+    template <class CT, class... S>
+    struct xiterable_inner_types<xview<CT, S...>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using inner_shape_type = typename xview_shape_type<typename xexpression_type::shape_type, S...>::type;
+        using stepper = xview_stepper<std::is_const<std::remove_reference_t<CT>>::value, CT, S...>;
+        using const_stepper = xview_stepper<true, std::remove_cv_t<CT>, S...>;
+    };
 
     namespace detail
     {


### PR DESCRIPTION
This will most likely fail on travis etc. but this could be a way to add the feature of #860 ?

this allows for overloads like this:

```c++
template <class T>
int fn(xexpression_shaped<T, dynamic_shape<size_t>>)
{
    std::cout << "xarray" << std::endl;
    return 123;
}

template <class T>
int fn(xexpression_shaped<T, std::array<size_t, 2>>& x)
{
    std::cout << "xtensor" << std::endl;
    std::cout << x.derived_cast()[0] << std::endl;
    return 123;
}
```

we could also add some shorthand forms for `xexpression_shaped<T, S>` like `xtensor_t<...>` etc.