### PR TITLE
Forbid simd bis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-      env: COMPILER=gcc GCC=6 COLUMN_MAJOR_LAYOUT=1
+      env: COMPILER=gcc GCC=6 COLUMN_MAJOR_LAYOUT=1 DISABLE_XSIMD=1
     - os: linux
       addons:
         apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 
 if(XTENSOR_USE_XSIMD)
     add_definitions(-DXTENSOR_USE_XSIMD)
-    find_package(xsimd 4.1.3 REQUIRED)
+    find_package(xsimd 4.1.4 REQUIRED)
     message(STATUS "Found xsimd: ${xsimd_INCLUDE_DIRS}/xsimd")
     target_link_libraries(xtensor INTERFACE xsimd)
 endif()

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -46,7 +46,7 @@ namespace xt
             return OP arg;                                                      \
         }                                                                       \
         template <class B>                                                      \
-        constexpr typename frt<typename B::value_type, R>::simd_type            \
+        constexpr typename frt<get_value_type_t<B>, R>::simd_type               \
         simd_apply(const B& arg) const                                          \
         {                                                                       \
             return OP arg;                                                      \
@@ -85,7 +85,7 @@ namespace xt
             return (arg1 OP arg2);                                               \
         }                                                                        \
         template <class B>                                                       \
-        constexpr typename frt<typename B::value_type, R>::simd_type             \
+        constexpr typename frt<get_value_type_t<B>, R>::simd_type                \
         simd_apply(const B& arg1, const B& arg2) const                           \
         {                                                                        \
             return (arg1 OP arg2);                                               \

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -389,6 +389,25 @@ namespace xt
         return size == N;
     }
 
+    /******************
+     * get_value_type *
+     ******************/
+
+    template <class T, class = void_t<>>
+    struct get_value_type
+    {
+        using type = T;
+    };
+
+    template <class T>
+    struct get_value_type<T, void_t<typename T::value_type>>
+    {
+        using type = typename T::value_type;
+    };
+
+    template <class T>
+    using get_value_type_t = typename get_value_type<T>::type;
+
     /***************************
      * apply_cv implementation *
      ***************************/

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -495,6 +495,9 @@ namespace xt
         EXPECT_EQ(res, expected);
     }
 
+    template <class T>
+    struct PRINT;
+
     TYPED_TEST(operation, assign_traits)
     {
         TypeParam a = { { 0., 1., 2. },{ 3., 4., 5. } };
@@ -504,6 +507,9 @@ namespace xt
             SCOPED_TRACE("xarray<double> + xarray<double>");
             auto fd = a + b;
             using assign_traits_double = xassign_traits<TypeParam, decltype(fd)>;
+            // SFINAE on load_simd is broken on mingw when xsimd is disabled. This using
+            // triggers the same error as the one caught by mingw.
+            using return_type = decltype(fd.template load_simd<aligned_mode>(std::size_t(0)));
 #if XTENSOR_USE_XSIMD
             EXPECT_TRUE(assign_traits_double::same_type());
             EXPECT_TRUE(assign_traits_double::simd_size());
@@ -512,7 +518,9 @@ namespace xt
 #else
             EXPECT_TRUE(assign_traits_double::same_type());
             EXPECT_FALSE(assign_traits_double::simd_size());
+            EXPECT_TRUE(assign_traits_double::forbid_simd());
             EXPECT_FALSE(assign_traits_double::simd_assign());
+            EXPECT_TRUE((std::is_same<return_type, double>::value));
 #endif
         }
 
@@ -521,6 +529,7 @@ namespace xt
             xscalar<double> sd = 2.;
             auto fsd = sd * a;
             using assign_traits_scalar_double = xassign_traits<TypeParam, decltype(fsd)>;
+            using return_type = decltype(fsd.template load_simd<aligned_mode>(std::size_t(0)));
 #if XTENSOR_USE_XSIMD
             EXPECT_TRUE(assign_traits_scalar_double::same_type());
             EXPECT_TRUE(assign_traits_scalar_double::simd_size());
@@ -529,7 +538,9 @@ namespace xt
 #else
             EXPECT_TRUE(assign_traits_scalar_double::same_type());
             EXPECT_FALSE(assign_traits_scalar_double::simd_size());
+            EXPECT_TRUE(assign_traits_scalar_double::forbid_simd());
             EXPECT_FALSE(assign_traits_scalar_double::simd_assign());
+            EXPECT_TRUE((std::is_same<return_type, double>::value));
 #endif
         }
 
@@ -539,6 +550,7 @@ namespace xt
             int_container_t c = { { 0, 1, 2 },{ 3, 4, 5 } };
             auto fm = a + c;
             using assign_traits_mixed = xassign_traits<TypeParam, decltype(fm)>;
+            using return_type = decltype(fm.template load_simd<aligned_mode>(std::size_t(0)));
 #if XTENSOR_USE_XSIMD
             EXPECT_TRUE(assign_traits_mixed::same_type());
             EXPECT_TRUE(assign_traits_mixed::simd_size());
@@ -547,7 +559,9 @@ namespace xt
 #else
             EXPECT_TRUE(assign_traits_mixed::same_type());
             EXPECT_FALSE(assign_traits_mixed::simd_size());
+            EXPECT_TRUE(assign_traits_mixed::forbid_simd());
             EXPECT_FALSE(assign_traits_mixed::simd_assign());
+            EXPECT_TRUE((std::is_same<return_type, double>::value));
 #endif
         }
 
@@ -556,7 +570,7 @@ namespace xt
             xscalar<int> si = 2;
             auto fsm = si * a;
             using assign_traits_scalar_mixed = xassign_traits<TypeParam, decltype(fsm)>;
-            TypeParam res = fsm;
+            using return_type = decltype(fsm.template load_simd<aligned_mode>(std::size_t(0)));
 #if XTENSOR_USE_XSIMD
             EXPECT_TRUE(assign_traits_scalar_mixed::same_type());
             EXPECT_TRUE(assign_traits_scalar_mixed::simd_size());
@@ -565,7 +579,9 @@ namespace xt
 #else
             EXPECT_TRUE(assign_traits_scalar_mixed::same_type());
             EXPECT_FALSE(assign_traits_scalar_mixed::simd_size());
+            EXPECT_TRUE(assign_traits_scalar_mixed::forbid_simd());
             EXPECT_FALSE(assign_traits_scalar_mixed::simd_assign());
+            EXPECT_TRUE((std::is_same<return_type, double>::value));
 #endif
         }
 
@@ -575,7 +591,7 @@ namespace xt
             char_container_t d = { { 0, 1, 2 },{ 3, 4, 5 } };
             auto fdc = a + d;
             using assign_traits_char_double = xassign_traits<TypeParam, decltype(fdc)>;
-            //TypeParam res = fdc;
+            using return_type = decltype(fdc.template load_simd<aligned_mode>(std::size_t(0)));
 #if XTENSOR_USE_XSIMD
             EXPECT_TRUE(assign_traits_char_double::same_type());
             EXPECT_TRUE(assign_traits_char_double::simd_size());
@@ -584,7 +600,9 @@ namespace xt
 #else
             EXPECT_TRUE(assign_traits_char_double::same_type());
             EXPECT_FALSE(assign_traits_char_double::simd_size());
+            EXPECT_TRUE(assign_traits_char_double::forbid_simd());
             EXPECT_FALSE(assign_traits_char_double::simd_assign());
+            EXPECT_TRUE((std::is_same<return_type, double>::value));
 #endif
         }
     }

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -315,7 +315,7 @@ namespace xt
         using bool_container = rebind_container_t<container_1d, bool>;
         bool_container a = {0, 0, 0, 1, 0};
         bool_container expected = {0, 0, 0, 0, 0};
-        bool_container b = a && 0;
+        bool_container b = a && false;
         bool_container c = a && a;
         EXPECT_EQ(expected, b);
         EXPECT_EQ(c, a);
@@ -328,8 +328,8 @@ namespace xt
         bool_container a = {0, 0, 0, 1, 0};
         bool_container other = {0, 0, 0, 0, 0};
         bool_container b = a || other;
-        bool_container c = a || 0;
-        bool_container d = a || 1;
+        bool_container c = a || false;
+        bool_container d = a || true;
         EXPECT_EQ(b, a);
         EXPECT_EQ(c, a);
 
@@ -494,9 +494,6 @@ namespace xt
         TypeParam expected = {{0., 3., 6.}, {9., 12., 15.}};
         EXPECT_EQ(res, expected);
     }
-
-    template <class T>
-    struct PRINT;
 
     TYPED_TEST(operation, assign_traits)
     {


### PR DESCRIPTION
Comes on the top of #873. (closes #873)

We still need to use a promote trait for the return type for non-boolean functors.