### PR TITLE
Removing test guard and dimension check in xscalar

### DIFF
--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -503,7 +503,7 @@ namespace xt
     template <class... Args>
     inline auto xscalar<CT>::operator()(Args...) noexcept -> reference
     {
-        XTENSOR_ASSERT(sizeof...(Args) == 0);
+        XTENSOR_CHECK_DIMENSION((std::array<int, 0>()), Args()...);
         return m_value;
     }
 
@@ -541,7 +541,7 @@ namespace xt
     template <class... Args>
     inline auto xscalar<CT>::operator()(Args...) const noexcept -> const_reference
     {
-        XTENSOR_ASSERT(sizeof...(Args) == 0);
+        XTENSOR_CHECK_DIMENSION((std::array<int, 0>()), Args()...);
         return m_value;
     }
 

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -374,7 +374,6 @@ namespace xt
     TEST(xreducer, wrong_number_of_indices)
     {
         xt::xtensor<double, 4> a = xt::random::rand<double>({5, 5, 5, 5});
-#ifndef XTENSOR_ENABLE_CHECK_DIMENSION
         double e = xt::sum(a)();
         double s1 = xt::sum(a)(0);
         EXPECT_EQ(s1, e);
@@ -385,6 +384,5 @@ namespace xt
         EXPECT_EQ(red(2), red(0, 0, 2));
         EXPECT_EQ(red(1, 2), red(0, 1, 2));
         EXPECT_EQ(red(1, 2), red(1, 1, 1, 1, 1, 0, 1, 2));
-#endif
     }
 }


### PR DESCRIPTION
This completes #879.

The dimension check is done with the macro `XTENSOR_CHECK_DIMENSION` which is never activated in the CI, so the test `xreducer.wrong_number_of_indices` should always be run.