### PR TITLE
README: add include of xview.hpp in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ by defining the macro `XTENSOR_USE_XSIMD` *before* including any header of `xten
 #include <iostream>
 #include "xtensor/xarray.hpp"
 #include "xtensor/xio.hpp"
+#include "xtensor/xview.hpp"
 
 xt::xarray<double> arr1
   {{1.0, 2.0, 3.0},


### PR DESCRIPTION
Fix
```
error: no member named 'view' in namespace 'xt'
```
Necessary as of 0.16.0