### PR TITLE
Remove FS identifier

### DIFF
--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -28,11 +28,11 @@
 
 namespace xt
 {
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     class xstrided_view;
 
-    template <class CT, class S, layout_type L, class FS>
-    struct xcontainer_inner_types<xstrided_view<CT, S, L, FS>>
+    template <class CT, class S, layout_type L, class FST>
+    struct xcontainer_inner_types<xstrided_view<CT, S, L, FST>>
     {
         using xexpression_type = std::decay_t<CT>;
         using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>>;
@@ -123,8 +123,8 @@ namespace xt
         }
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    struct xiterable_inner_types<xstrided_view<CT, S, L, FS>>
+    template <class CT, class S, layout_type L, class FST>
+    struct xiterable_inner_types<xstrided_view<CT, S, L, FST>>
     {
         using inner_shape_type = S;
         using inner_strides_type = inner_shape_type;
@@ -132,13 +132,13 @@ namespace xt
 
         using const_stepper = std::conditional_t<
             detail::is_indexed_stepper<typename std::decay_t<CT>::stepper>::value,
-            xindexed_stepper<const xstrided_view<CT, S, L, FS>, true>,
-            xstepper<const xstrided_view<CT, S, L, FS>>>;
+            xindexed_stepper<const xstrided_view<CT, S, L, FST>, true>,
+            xstepper<const xstrided_view<CT, S, L, FST>>>;
 
         using stepper = std::conditional_t<
             detail::is_indexed_stepper<typename std::decay_t<CT>::stepper>::value,
-            xindexed_stepper<xstrided_view<CT, S, L, FS>, false>,
-            xstepper<xstrided_view<CT, S, L, FS>>>;
+            xindexed_stepper<xstrided_view<CT, S, L, FST>, false>,
+            xstepper<xstrided_view<CT, S, L, FST>>>;
     };
 
     /*****************
@@ -154,17 +154,17 @@ namespace xt
      *.
      * @tparam CT the closure type of the \ref xexpression type underlying this view
      * @tparam S the strides type of the strided view
-     * @tparam FS the flat storage type used for the strided view.
+     * @tparam FST the flat storage type used for the strided view.
      *
      * @sa strided_view, transpose
      */
-    template <class CT, class S, layout_type L = layout_type::dynamic, class FS = typename detail::flat_storage_type<CT>::type>
-    class xstrided_view : public xview_semantic<xstrided_view<CT, S, L, FS>>,
-                          public xiterable<xstrided_view<CT, S, L, FS>>
+    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = typename detail::flat_storage_type<CT>::type>
+    class xstrided_view : public xview_semantic<xstrided_view<CT, S, L, FST>>,
+                          public xiterable<xstrided_view<CT, S, L, FST>>
     {
     public:
 
-        using self_type = xstrided_view<CT, S, L, FS>;
+        using self_type = xstrided_view<CT, S, L, FST>;
         using xexpression_type = std::decay_t<CT>;
         using semantic_base = xview_semantic<self_type>;
 
@@ -182,7 +182,7 @@ namespace xt
         using size_type = typename xexpression_type::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
-        using inner_storage_type = FS;
+        using inner_storage_type = FST;
         using storage_type = std::decay_t<inner_storage_type>;
 
         using iterable_base = xiterable<self_type>;
@@ -203,8 +203,8 @@ namespace xt
         template <class CTA>
         xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout) noexcept;
 
-        template <class CTA, class FST>
-        xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout, FST&& flatten_strides, layout_type flatten_layout) noexcept;
+        template <class CTA, class FLS>
+        xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept;
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);
@@ -321,7 +321,7 @@ namespace xt
         std::size_t m_offset;
         layout_type m_layout;
 
-        friend class xview_semantic<xstrided_view<CT, S, L, FS>>;
+        friend class xview_semantic<xstrided_view<CT, S, L, FST>>;
     };
 
     /********************************
@@ -341,9 +341,9 @@ namespace xt
      * @param offset the offset of the first element in the underlying container
      * @param layout the layout of the view
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class CTA>
-    inline xstrided_view<CT, S, L, FS>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout) noexcept
+    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout) noexcept
         : m_e(std::forward<CTA>(e)),
           m_storage(detail::get_flat_storage<CT>(m_e)),
           m_shape(std::move(shape)),
@@ -355,11 +355,11 @@ namespace xt
         adapt_strides(m_shape, m_strides, m_backstrides);
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    template <class CTA, class FST>
-    inline xstrided_view<CT, S, L, FS>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout, FST&& flatten_strides, layout_type flatten_layout) noexcept
+    template <class CT, class S, layout_type L, class FST>
+    template <class CTA, class FLS>
+    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept
         : m_e(std::forward<CTA>(e)),
-          m_storage(detail::get_flat_storage<CT>(m_e, std::forward<FST>(flatten_strides), flatten_layout)),
+          m_storage(detail::get_flat_storage<CT>(m_e, std::forward<FLS>(flatten_strides), flatten_layout)),
           m_shape(std::move(shape)),
           m_strides(std::move(strides)),
           m_offset(offset),
@@ -377,24 +377,24 @@ namespace xt
     /**
      * The extended assignment operator.
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class E>
-    inline auto xstrided_view<CT, S, L, FS>::operator=(const xexpression<E>& e) -> self_type&
+    inline auto xstrided_view<CT, S, L, FST>::operator=(const xexpression<E>& e) -> self_type&
     {
         return semantic_base::operator=(e);
     }
     //@}
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class E>
-    inline auto xstrided_view<CT, S, L, FS>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    inline auto xstrided_view<CT, S, L, FST>::operator=(const E& e) -> disable_xexpression<E, self_type>&
     {
         std::fill(this->begin(), this->end(), e);
         return *this;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline void xstrided_view<CT, S, L, FS>::assign_temporary_impl(temporary_type&& tmp)
+    template <class CT, class S, layout_type L, class FST>
+    inline void xstrided_view<CT, S, L, FST>::assign_temporary_impl(temporary_type&& tmp)
     {
         std::copy(tmp.cbegin(), tmp.cend(), this->begin());
     }
@@ -406,8 +406,8 @@ namespace xt
     /**
      * Returns the size of the xstrided_view.
      */
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::size() const noexcept -> size_type
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::size() const noexcept -> size_type
     {
         return compute_size(shape());
     }
@@ -415,8 +415,8 @@ namespace xt
     /**
      * Returns the number of dimensions of the xstrided_view.
      */
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::dimension() const noexcept -> size_type
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::dimension() const noexcept -> size_type
     {
         return m_shape.size();
     }
@@ -424,78 +424,78 @@ namespace xt
     /**
      * Returns the shape of the xstrided_view.
      */
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::shape() const noexcept -> const shape_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::shape() const noexcept -> const shape_type&
     {
         return m_shape;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::strides() const noexcept -> const strides_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::strides() const noexcept -> const strides_type&
     {
         return m_strides;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::backstrides() const noexcept -> const backstrides_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::backstrides() const noexcept -> const backstrides_type&
     {
         return m_backstrides;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::layout() const noexcept -> layout_type
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::layout() const noexcept -> layout_type
     {
         return m_layout;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::storage() noexcept -> storage_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage() noexcept -> storage_type&
     {
         return m_storage;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::storage() const noexcept -> const storage_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage() const noexcept -> const storage_type&
     {
         return m_storage;
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class E>
-    inline auto xstrided_view<CT, S, L, FS>::data() noexcept ->
+    inline auto xstrided_view<CT, S, L, FST>::data() noexcept ->
         std::enable_if_t<has_data_interface<std::decay_t<E>>::value, value_type*>
     {
         return m_e.data();
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class E>
-    inline auto xstrided_view<CT, S, L, FS>::data() const noexcept ->
+    inline auto xstrided_view<CT, S, L, FST>::data() const noexcept ->
         std::enable_if_t<has_data_interface<std::decay_t<E>>::value, const value_type*>
     {
         return m_e.data();
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::data_offset() const noexcept -> size_type
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::data_offset() const noexcept -> size_type
     {
         return m_offset;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::offset() const noexcept -> size_type
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::offset() const noexcept -> size_type
     {
         return m_offset;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::expression() noexcept -> xexpression_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::expression() noexcept -> xexpression_type&
     {
         return m_e;
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::expression() const noexcept -> const xexpression_type&
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::expression() const noexcept -> const xexpression_type&
     {
         return m_e;
     }
@@ -504,21 +504,21 @@ namespace xt
     /**
      * @name Data
      */
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::operator()() -> reference
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::operator()() -> reference
     {
         return m_storage[m_offset];
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::operator()() const -> const_reference
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::operator()() const -> const_reference
     {
         return m_storage[m_offset];
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class... Args>
-    inline auto xstrided_view<CT, S, L, FS>::operator()(Args... args) -> reference
+    inline auto xstrided_view<CT, S, L, FST>::operator()(Args... args) -> reference
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
@@ -533,9 +533,9 @@ namespace xt
      * must be unsigned integers, the number of indices should be equal or greater than
      * the number of dimensions of the view.
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class... Args>
-    inline auto xstrided_view<CT, S, L, FS>::operator()(Args... args) const -> const_reference
+    inline auto xstrided_view<CT, S, L, FST>::operator()(Args... args) const -> const_reference
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
@@ -552,9 +552,9 @@ namespace xt
      * @exception std::out_of_range if the number of argument is greater than the number of dimensions
      * or if indices are out of bounds.
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class... Args>
-    inline auto xstrided_view<CT, S, L, FS>::at(Args... args) -> reference
+    inline auto xstrided_view<CT, S, L, FST>::at(Args... args) -> reference
     {
         check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
@@ -569,54 +569,54 @@ namespace xt
      * @exception std::out_of_range if the number of argument is greater than the number of dimensions
      * or if indices are out of bounds.
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class... Args>
-    inline auto xstrided_view<CT, S, L, FS>::at(Args... args) const -> const_reference
+    inline auto xstrided_view<CT, S, L, FST>::at(Args... args) const -> const_reference
     {
         check_access(shape(), static_cast<size_type>(args)...);
         return this->operator()(args...);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class OS>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](const OS& index)
+    inline auto xstrided_view<CT, S, L, FST>::operator[](const OS& index)
         -> disable_integral_t<OS, reference>
     {
         return element(index.cbegin(), index.cend());
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class I>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](std::initializer_list<I> index)
+    inline auto xstrided_view<CT, S, L, FST>::operator[](std::initializer_list<I> index)
         -> reference
     {
         return element(index.begin(), index.end());
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](size_type i) -> reference
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::operator[](size_type i) -> reference
     {
         return operator()(i);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class OS>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](const OS& index) const
+    inline auto xstrided_view<CT, S, L, FST>::operator[](const OS& index) const
         -> disable_integral_t<OS, const_reference>
     {
         return element(index.cbegin(), index.cend());
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class I>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](std::initializer_list<I> index) const
+    inline auto xstrided_view<CT, S, L, FST>::operator[](std::initializer_list<I> index) const
         -> const_reference
     {
         return element(index.begin(), index.end());
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::operator[](size_type i) const -> const_reference
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::operator[](size_type i) const -> const_reference
     {
         return operator()(i);
     }
@@ -628,17 +628,17 @@ namespace xt
      * The number of indices in the sequence should be equal to or greater than the the number
      * of dimensions of the container..
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class It>
-    inline auto xstrided_view<CT, S, L, FS>::element(It first, It last) -> reference
+    inline auto xstrided_view<CT, S, L, FST>::element(It first, It last) -> reference
     {
         XTENSOR_TRY(check_element_index(shape(), first, last));
         return m_storage[m_offset + element_offset<size_type>(strides(), first, last)];
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class It>
-    inline auto xstrided_view<CT, S, L, FS>::element(It first, It last) const -> const_reference
+    inline auto xstrided_view<CT, S, L, FST>::element(It first, It last) const -> const_reference
     {
         XTENSOR_TRY(check_element_index(shape(), first, last));
         return m_storage[m_offset + element_offset<size_type>(strides(), first, last)];
@@ -654,9 +654,9 @@ namespace xt
      * @param shape the result shape
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class O>
-    inline bool xstrided_view<CT, S, L, FS>::broadcast_shape(O& shape, bool) const
+    inline bool xstrided_view<CT, S, L, FST>::broadcast_shape(O& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }
@@ -666,9 +666,9 @@ namespace xt
      * the broadcasting is trivial.
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class O>
-    inline bool xstrided_view<CT, S, L, FS>::is_trivial_broadcast(const O& str) const noexcept
+    inline bool xstrided_view<CT, S, L, FST>::is_trivial_broadcast(const O& str) const noexcept
     {
         return str.size() == strides().size() &&
             std::equal(str.cbegin(), str.cend(), strides().begin());
@@ -679,88 +679,88 @@ namespace xt
      * stepper api *
      ***************/
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_begin(const ST& shape) -> stepper
+    inline auto xstrided_view<CT, S, L, FST>::stepper_begin(const ST& shape) -> stepper
     {
         size_type offset = shape.size() - dimension();
         return stepper(this, data_xbegin(), offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_end(const ST& shape, layout_type l) -> stepper
+    inline auto xstrided_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type l) -> stepper
     {
         size_type offset = shape.size() - dimension();
         return stepper(this, data_xend(l), offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST, class STEP>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_begin(const ST& shape) const -> std::enable_if_t<!detail::is_indexed_stepper<STEP>::value, STEP>
+    inline auto xstrided_view<CT, S, L, FST>::stepper_begin(const ST& shape) const -> std::enable_if_t<!detail::is_indexed_stepper<STEP>::value, STEP>
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, data_xbegin(), offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST, class STEP>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_end(const ST& shape, layout_type l) const -> std::enable_if_t<!detail::is_indexed_stepper<STEP>::value, STEP>
+    inline auto xstrided_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type l) const -> std::enable_if_t<!detail::is_indexed_stepper<STEP>::value, STEP>
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, data_xend(l), offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST, class STEP>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_begin(const ST& shape) const -> std::enable_if_t<detail::is_indexed_stepper<STEP>::value, STEP>
+    inline auto xstrided_view<CT, S, L, FST>::stepper_begin(const ST& shape) const -> std::enable_if_t<detail::is_indexed_stepper<STEP>::value, STEP>
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class ST, class STEP>
-    inline auto xstrided_view<CT, S, L, FS>::stepper_end(const ST& shape, layout_type /*l*/) const -> std::enable_if_t<detail::is_indexed_stepper<STEP>::value, STEP>
+    inline auto xstrided_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type /*l*/) const -> std::enable_if_t<detail::is_indexed_stepper<STEP>::value, STEP>
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, offset, true);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class It>
-    inline It xstrided_view<CT, S, L, FS>::data_xbegin_impl(It begin) const noexcept
+    inline It xstrided_view<CT, S, L, FST>::data_xbegin_impl(It begin) const noexcept
     {
         return begin + static_cast<std::ptrdiff_t>(m_offset);
     }
 
-    template <class CT, class S, layout_type L, class FS>
+    template <class CT, class S, layout_type L, class FST>
     template <class It>
-    inline It xstrided_view<CT, S, L, FS>::data_xend_impl(It end, layout_type l) const noexcept
+    inline It xstrided_view<CT, S, L, FST>::data_xend_impl(It end, layout_type l) const noexcept
     {
         return strided_data_end(*this, end, l);
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::data_xbegin() noexcept -> container_iterator
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::data_xbegin() noexcept -> container_iterator
     {
         return data_xbegin_impl(m_storage.begin());
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::data_xbegin() const noexcept -> const_container_iterator
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::data_xbegin() const noexcept -> const_container_iterator
     {
         return data_xbegin_impl(m_storage.cbegin());
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::data_xend(layout_type l) noexcept -> container_iterator
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l) noexcept -> container_iterator
     {
         return data_xend_impl(m_storage.end(), l);
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    inline auto xstrided_view<CT, S, L, FS>::data_xend(layout_type l) const noexcept -> const_container_iterator
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l) const noexcept -> const_container_iterator
     {
         return data_xend_impl(m_storage.cend(), l);
     }
@@ -816,8 +816,8 @@ namespace xt
                 compute_strides(m_e.shape(), m_layout, m_strides);
             }
 
-            template <class FS>
-            flat_expression_adaptor(CT& e, FS&& strides, layout_type layout)
+            template <class FST>
+            flat_expression_adaptor(CT& e, FST&& strides, layout_type layout)
                 : m_e(e), m_strides(xtl::forward_sequence<shape_type>(strides)), m_layout(layout)
             {
                 resize_container(m_index, m_e.dimension());
@@ -1098,16 +1098,16 @@ namespace xt
         return view_type(std::forward<E>(e), std::move(std::get<0>(args)), std::move(std::get<1>(args)), std::get<2>(args), std::get<3>(args));
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    auto strided_view(const xstrided_view<CT, S, L, FS>& e, const slice_vector& slices)
+    template <class CT, class S, layout_type L, class FST>
+    auto strided_view(const xstrided_view<CT, S, L, FST>& e, const slice_vector& slices)
     {
         auto args = detail::get_strided_view_args(e.shape(), detail::get_strides(e), detail::get_offset(e), e.layout(), slices);
         using view_type = xstrided_view<xclosure_t<decltype(e.expression())>, std::decay_t<decltype(std::get<0>(args))>>;
         return view_type(e.expression(), std::move(std::get<0>(args)), std::move(std::get<1>(args)), std::get<2>(args), std::get<3>(args));
     }
 
-    template <class CT, class S, layout_type L, class FS>
-    auto strided_view(xstrided_view<CT, S, L, FS>& e, const slice_vector& slices)
+    template <class CT, class S, layout_type L, class FST>
+    auto strided_view(xstrided_view<CT, S, L, FST>& e, const slice_vector& slices)
     {
         auto args = detail::get_strided_view_args(e.shape(), detail::get_strides(e), detail::get_offset(e), e.layout(), slices);
         using view_type = xstrided_view<xclosure_t<decltype(e.expression())>, std::decay_t<decltype(std::get<0>(args))>>;

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -130,10 +130,10 @@ namespace xt
     template <std::size_t... N>
     using xshape = fixed_shape<N...>;
 
-    template <class EC, class FS, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
     class xfixed_container;
 
-    template <class EC, class FS, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
     class xfixed_adaptor;
 
     /**
@@ -152,14 +152,14 @@ namespace xt
      * \endcode
      *
      * @tparam T The value type of the elements.
-     * @tparam FS A xshape template shape.
+     * @tparam FSH A xshape template shape.
      * @tparam L The layout_type of the tensor (default: row_major).
      * @tparam A The allocator of the containers holding the elements.
      */
     template <class T,
-              class FS,
+              class FSH,
               layout_type L = XTENSOR_DEFAULT_LAYOUT>
-    using xtensor_fixed = xfixed_container<T, FS, L>;
+    using xtensor_fixed = xfixed_container<T, FSH, L>;
 
     /**
      * @typedef xtensor_optional


### PR DESCRIPTION
Another solaris build issue. There is a `FS` macro on solaris.

I could find all the namespace polution in an LLVM header: https://llvm.org/doxygen/regset_8h_source.html

So there should not be other.