### PR TITLE
Assigning an expression to a view throws if it has more dimensions

### DIFF
--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -340,6 +340,10 @@ namespace xt
         using value_type = typename S2::value_type;
         auto output_index = output.size();
         auto input_index = input.size();
+        if (output_index < input_index)
+        {
+            throw_broadcast_error(output, input);
+        }
         for (; input_index != 0; --input_index, --output_index)
         {
             // First case: output = (0, 0, ...., 0)

--- a/test/test_xview_semantic.cpp
+++ b/test/test_xview_semantic.cpp
@@ -449,4 +449,16 @@ namespace xt
 
         EXPECT_EQ(res, a);
     }
+
+    TYPED_TEST(view_semantic, higher_dimension_broadcast)
+    {
+        using container_2d = redim_container_t<TypeParam, 2>;
+
+        container_2d a = { {1, 2, 3}, {4, 5, 6} };
+        container_2d b = { {11, 12, 13} };
+        container_2d res = { { 11, 12, 13 }, { 4, 5, 6 } };
+
+        auto viewa = view(a, 0, all());
+        EXPECT_ANY_THROW(viewa = b);
+    }
 }


### PR DESCRIPTION
Partially fixes #907.