### PR TITLE
Step simd generator

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -108,15 +108,15 @@ endif()
 include_directories(${GBENCHMARK_INCLUDE_DIRS})
 
 set(XTENSOR_BENCHMARK
-    benchmark_assign.cpp
+    # benchmark_assign.cpp
     benchmark_builder.cpp
-    benchmark_container.cpp
-    benchmark_increment_stepper.cpp
-    benchmark_math.cpp
-    benchmark_random.cpp
-    benchmark_reducer.cpp
-    benchmark_views.cpp
-    benchmark_xshape.cpp
+    # benchmark_container.cpp
+    # benchmark_increment_stepper.cpp
+    # benchmark_math.cpp
+    # benchmark_random.cpp
+    # benchmark_reducer.cpp
+    # benchmark_views.cpp
+    # benchmark_xshape.cpp
     main.cpp
 )
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -27,7 +27,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
     if (HAS_CPP14_FLAG)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -O3")
     else()
         message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
     endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -113,6 +113,7 @@ set(XTENSOR_BENCHMARK
     benchmark_container.cpp
     benchmark_increment_stepper.cpp
     benchmark_math.cpp
+    benchmark_random.cpp
     benchmark_reducer.cpp
     benchmark_views.cpp
     benchmark_xshape.cpp

--- a/benchmark/benchmark_builder.cpp
+++ b/benchmark/benchmark_builder.cpp
@@ -182,6 +182,16 @@ namespace xt
         }
     }
 
+    inline auto builder_ones_strided_assign(benchmark::State& state)
+    {
+        for (auto _ : state)
+        {
+            xt::xarray<double> res;
+            res.resize({200, 200});
+            strided_assign(res, xt::ones<double>({200, 200}), std::true_type{});
+            benchmark::DoNotOptimize(res.data());
+        }
+    }
 
     inline auto builder_ones_assign_iterator(benchmark::State& state)
     {
@@ -238,30 +248,31 @@ namespace xt
         for (auto _ : state)
         {
             xt::xarray<double> res(xt::dynamic_shape<std::size_t>{200, 200});
-            std::fill(res.begin(), res.end(), 1);
+            std::fill(res.storage().begin(), res.storage().end(), 1.0);
             benchmark::DoNotOptimize(res.storage().data());
         }
     }
 
-    BENCHMARK_TEMPLATE(builder_xarange, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_xarange, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_pure_xsimd, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_xsimd, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_xsimd_stepper, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_xarange_manual, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_xarange_manual, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_assign, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_assign, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_xarange, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_xarange, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_pure_xsimd, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_xsimd, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_xsimd_stepper, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_xarange_manual, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_xarange_manual, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_assign, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_assign, xtensor<double, 1>);
 
-    BENCHMARK_TEMPLATE(builder_arange_assign_iterator, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_arange_assign_iterator, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign_backward, xarray<double>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign_backward, xtensor<double, 1>);
-    BENCHMARK_TEMPLATE(builder_std_iota, xarray<double>);
-    BENCHMARK(builder_iota_vector);
+    // BENCHMARK_TEMPLATE(builder_arange_assign_iterator, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_arange_assign_iterator, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign_backward, xarray<double>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_arange_for_loop_iter_assign_backward, xtensor<double, 1>);
+    // BENCHMARK_TEMPLATE(builder_std_iota, xarray<double>);
+    // BENCHMARK(builder_iota_vector);
     BENCHMARK(builder_ones);
+    BENCHMARK(builder_ones_strided_assign);
     BENCHMARK(builder_ones_assign_iterator);
     BENCHMARK(builder_ones_expr);
     BENCHMARK(builder_ones_expr_fill);

--- a/benchmark/benchmark_random.cpp
+++ b/benchmark/benchmark_random.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef BENCHMARK_RANDOM_HPP
+#define BENCHMARK_RANDOM_HPP
+
+#include <benchmark/benchmark.h>
+
+#include "xtensor/xnoalias.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xrandom.hpp"
+
+namespace xt
+{
+    namespace random_bench
+    { 
+        void random_assign_xtensor(benchmark::State& state)
+        {
+            for (auto _ : state)
+            {
+                xtensor<double, 2> result = xt::random::rand<double>({20, 20});
+                benchmark::DoNotOptimize(result.data());
+            }
+        }
+
+        void random_assign_forloop(benchmark::State& state)
+        {
+            for (auto _ : state)
+            {
+                xtensor<double, 2> result;
+                result.resize({20, 20});
+                std::uniform_real_distribution<double> dist(0, 1);
+                auto& engine = xt::random::get_default_random_engine();
+                for (auto& el : result.storage())
+                {
+                    el = dist(engine);
+                }
+                benchmark::DoNotOptimize(result.data());
+            }
+        }
+
+        void random_assign_xarray(benchmark::State& state)
+        {
+            for (auto _ : state)
+            {
+                xarray<double> result = xt::random::rand<double>({20, 20});
+                benchmark::DoNotOptimize(result.data());
+            }
+        }
+
+        BENCHMARK(random_assign_xarray);
+        BENCHMARK(random_assign_xtensor);
+        BENCHMARK(random_assign_forloop);
+    }
+}
+
+#endif

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -149,17 +149,6 @@ namespace xt
         xexpression_assigner<tag>::assign_data(e1, e2, trivial);
     }
 
-    template <class E1, class E2, class = void>
-    struct has_assign_to : std::false_type
-    {
-    };
-
-    template <class E1, class E2>
-    struct has_assign_to<E1, E2, void_t<decltype(std::declval<const E2&>().assign_to(std::declval<E1&>()))>>
-        : std::true_type
-    {
-    };
-
     template <class E1, class E2>
     inline void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
     {

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -267,6 +267,12 @@ namespace xt
             static constexpr bool value = true;
         };
 
+        template <class T, class S>
+        struct use_strided_loop<xbroadcast<xscalar<T>, S>>
+        {
+            static constexpr bool value = true;
+        };
+
         template <class F, class R, class... CT>
         struct use_strided_loop<xfunction<F, R, CT...>>
         {
@@ -591,6 +597,12 @@ namespace xt
 
             template <class T>
             std::size_t operator()(const xt::xscalar<T>& /*el*/)
+            {
+                return m_cut;
+            }
+
+            template <class T, class SX>
+            std::size_t operator()(const xt::xbroadcast<xt::xscalar<T>, SX>& /*el*/)
             {
                 return m_cut;
             }

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -82,6 +82,7 @@ namespace xt
         using xexpression_type = std::decay_t<CT>;
 
         using value_type = typename xexpression_type::value_type;
+        using simd_value_type = typename xexpression_type::simd_value_type;
         using reference = typename xexpression_type::reference;
         using const_reference = typename xexpression_type::const_reference;
         using pointer = typename xexpression_type::pointer;

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -225,6 +225,12 @@ namespace xt
                 }
             }
 
+            template <class S, class SX>
+            inline S step_simd(const SX& I) const
+            {
+                return S(I[0]) + S(0, 1, 2, 3);
+            }
+
         private:
 
             value_type m_start;

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -212,6 +212,19 @@ namespace xt
                 return m_start + m_step * T(*first);
             }
 
+            template <class E>
+            inline void assign_to(xexpression<E>& e) const noexcept
+            {
+                auto& de = e.derived_cast();
+                value_type value = m_start;
+
+                for (auto& el : de.storage())
+                {
+                    el = value;
+                    value += m_step;
+                }
+            }
+
         private:
 
             value_type m_start;

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -117,6 +117,12 @@ namespace xt
         template <class E, class FE = F, class = std::enable_if_t<has_assign_to<E, FE>::value>>
         void assign_to(xexpression<E>& e) const noexcept;
 
+        template <class SX, class SS>
+        SX step_simd(const SS& I) const noexcept
+        {
+            return m_f.template step_simd<SX>(I);
+        }
+
     private:
 
         template <std::size_t dim>

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -114,6 +114,9 @@ namespace xt
         template <class O>
         const_stepper stepper_end(const O& shape, layout_type) const noexcept;
 
+        template <class E, class FE = F, class = std::enable_if_t<has_assign_to<E, FE>::value>>
+        void assign_to(xexpression<E>& e) const noexcept;
+
     private:
 
         template <std::size_t dim>
@@ -331,6 +334,14 @@ namespace xt
     {
         size_type offset = shape.size() - dimension();
         return const_stepper(this, offset, true);
+    }
+
+    template <class F, class R, class S>
+    template <class E, class, class>
+    inline void xgenerator<F, R, S>::assign_to(xexpression<E>& e) const noexcept
+    {
+        e.derived_cast().resize(m_shape);
+        m_f.assign_to(e);
     }
 
     template <class F, class R, class S>

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -198,6 +198,14 @@ namespace xt
         void to_begin();
         void to_end(layout_type l);
 
+        template <class S>
+        S step_simd()
+        {
+            S res = p_e->template step_simd<S>(m_index);            
+            m_index.back() += S::size;
+            return res;
+        }
+
     private:
 
         xexpression_type* p_e;

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -211,6 +211,9 @@ namespace xt
         };
         */
     }
+
+    template <class CT, class X>
+    class xbroadcast;
 }
 
 #endif

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1024,6 +1024,17 @@ namespace xt
     {
       return !(a == b);
     }
+
+    template <class E1, class E2, class = void>
+    struct has_assign_to : std::false_type
+    {
+    };
+
+    template <class E1, class E2>
+    struct has_assign_to<E1, E2, void_t<decltype(std::declval<const E2&>().assign_to(std::declval<E1&>()))>>
+        : std::true_type
+    {
+    };
 }
 
 #endif


### PR DESCRIPTION
This PR adds simd activation to the xt::broadcast mechanism used for broadcasting e.g. scalars in xt::ones, and thus allows for fast usage in expressions.

Furthermore, some first experimental steps are done to support SIMD in the xgenerators (if the the functor has a `step_simd` function).

