### PR TITLE
Propagate fixed shape

### DIFF
--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -88,14 +88,56 @@ namespace xt
             using type = xarray<R>;
         };
 
-        template <class T, std::size_t N, class R>
-        struct xaccumulator_return_type<xtensor<T, N>, R>
+        template <class T, layout_type L, class R>
+        struct xaccumulator_return_type<xarray<T, L>, R>
         {
-            using type = xtensor<R, N>;
+            using type = xarray<R, L>;
+        };
+
+        template <class T, std::size_t N, layout_type L, class R>
+        struct xaccumulator_return_type<xtensor<T, N, L>, R>
+        {
+            using type = xtensor<R, N, L>;
+        };
+
+        template <class T, std::size_t... I, layout_type L, class R>
+        struct xaccumulator_return_type<xtensor_fixed<T, xshape<I...>, L>, R>
+        {
+            using type = xtensor_fixed<R, xshape<I...>, L>;
         };
 
         template <class T, class R>
         using xaccumulator_return_type_t = typename xaccumulator_return_type<T, R>::type;
+
+        template <class T>
+        struct fixed_compute_size;
+
+        template <class T, class R>
+        struct xaccumulator_linear_return_type
+        {
+            using type = xtensor<R, 1>;
+        };
+
+        template <class T, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xarray<T, L>, R>
+        {
+            using type = xtensor<R, 1, L>;
+        };
+
+        template <class T, std::size_t N, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xtensor<T, N, L>, R>
+        {
+            using type = xtensor<R, 1, L>;
+        };
+
+        template <class T, std::size_t... I, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xtensor_fixed<T, xshape<I...>, L>, R>
+        {
+            using type = xtensor_fixed<R, xshape<fixed_compute_size<xshape<I...>>::value>, L>;
+        };
+
+        template <class T, class R>
+        using xaccumulator_linear_return_type_t = typename xaccumulator_linear_return_type<T, R>::type;
 
         template <class F, class E>
         inline auto accumulator_init_with_f(F&& f, E& e, std::size_t axis)
@@ -208,7 +250,7 @@ namespace xt
             using accumulate_functor = std::decay_t<decltype(std::get<0>(f))>;
             using T = typename accumulate_functor::result_type;
 
-            using result_type = xtensor<T, 1>;
+            using result_type = xaccumulator_linear_return_type_t<std::decay_t<E>, T>;
             std::size_t sz = e.size();
             auto result = result_type::from_shape({sz});
 

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -372,18 +372,35 @@ namespace xt
         }
     }
 
+    namespace detail
+    {
+        template <class E1, class E2>
+        bool resize_impl(xexpression<E1>& e1, const xexpression<E2>& e2, std::true_type)
+        {
+            using shape_type = typename E1::shape_type;
+            using size_type = typename E1::size_type;
+            const E2& de2 = e2.derived_cast();
+            size_type size = de2.dimension();
+            shape_type shape = xtl::make_sequence<shape_type>(size, size_type(0));
+            bool trivial_broadcast = de2.broadcast_shape(shape, true);
+            e1.derived_cast().resize(std::move(shape));
+            return trivial_broadcast;
+        }
+
+        template <class E1, class E2>
+        bool resize_impl(xexpression<E1>& e1, const xexpression<E2>& e2, std::false_type)
+        {
+            return true;
+        }
+    }
+
     template <class Tag>
     template <class E1, class E2>
     inline bool xexpression_assigner<Tag>::resize(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        using shape_type = typename E1::shape_type;
-        using size_type = typename E1::size_type;
-        const E2& de2 = e2.derived_cast();
-        size_type size = de2.dimension();
-        shape_type shape = xtl::make_sequence<shape_type>(size, size_type(0));
-        bool trivial_broadcast = de2.broadcast_shape(shape, true);
-        e1.derived_cast().resize(std::move(shape));
-        return trivial_broadcast;
+        return detail::resize_impl(e1, e2, 
+                                   std::integral_constant<bool,
+                                                          !xt::detail::is_fixed<typename E1::shape_type>::value>());
     }
 
     /********************************

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -372,35 +372,18 @@ namespace xt
         }
     }
 
-    namespace detail
-    {
-        template <class E1, class E2>
-        bool resize_impl(xexpression<E1>& e1, const xexpression<E2>& e2, std::true_type)
-        {
-            using shape_type = typename E1::shape_type;
-            using size_type = typename E1::size_type;
-            const E2& de2 = e2.derived_cast();
-            size_type size = de2.dimension();
-            shape_type shape = xtl::make_sequence<shape_type>(size, size_type(0));
-            bool trivial_broadcast = de2.broadcast_shape(shape, true);
-            e1.derived_cast().resize(std::move(shape));
-            return trivial_broadcast;
-        }
-
-        template <class E1, class E2>
-        bool resize_impl(xexpression<E1>& e1, const xexpression<E2>& e2, std::false_type)
-        {
-            return true;
-        }
-    }
-
     template <class Tag>
     template <class E1, class E2>
     inline bool xexpression_assigner<Tag>::resize(xexpression<E1>& e1, const xexpression<E2>& e2)
     {
-        return detail::resize_impl(e1, e2, 
-                                   std::integral_constant<bool,
-                                                          !xt::detail::is_fixed<typename E1::shape_type>::value>());
+        using index_type = xindex_type_t<typename E1::shape_type>;
+        using size_type = typename E1::size_type;
+        const E2& de2 = e2.derived_cast();
+        size_type size = de2.dimension();
+        index_type shape = xtl::make_sequence<index_type>(size, size_type(0));
+        bool trivial_broadcast = de2.broadcast_shape(shape, true);
+        e1.derived_cast().resize(std::move(shape));
+        return trivial_broadcast;
     }
 
     /********************************

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -30,7 +30,6 @@ namespace xt
     template <class D>
     struct xcontainer_iterable_types
     {
-        using shape_type = typename xcontainer_inner_types<D>::shape_type;
         using inner_shape_type = typename xcontainer_inner_types<D>::inner_shape_type;
         using storage_type = typename xcontainer_inner_types<D>::storage_type;
         using stepper = xstepper<D>;

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -30,6 +30,7 @@ namespace xt
     template <class D>
     struct xcontainer_iterable_types
     {
+        using shape_type = typename xcontainer_inner_types<D>::shape_type;
         using inner_shape_type = typename xcontainer_inner_types<D>::inner_shape_type;
         using storage_type = typename xcontainer_inner_types<D>::storage_type;
         using stepper = xstepper<D>;

--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -40,16 +40,24 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
+        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
     {
         return xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>(std::forward<T>(t));
     }
 
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
+        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
     {
         return xarray<typename I::value_type>(std::forward<T>(t));
+    }
+
+    template <class T, class I = std::decay_t<T>>
+    inline auto eval(T&& t)
+        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_fixed<typename I::shape_type>::value && !detail::is_array<typename I::shape_type>::value,
+                            xt::xtensor_fixed<typename I::value_type, typename I::shape_type>>
+    {
+        return xtensor_fixed<typename I::value_type, typename I::shape_type>(std::forward<T>(t));
     }
     /// @endcond
 }

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -44,6 +44,8 @@ namespace xt
     public:
 
         using cast_type = const_array<std::size_t, sizeof...(X)>;
+        using value_type = std::size_t;
+        using size_type = std::size_t;
 
         constexpr static std::size_t size()
         {
@@ -66,6 +68,12 @@ namespace std
     template <class T, size_t N>
     class tuple_size<xt::const_array<T, N>> :
         public integral_constant<size_t, N>
+    {
+    };
+
+    template <size_t... N>
+    class tuple_size<xt::fixed_shape<N...>> :
+        public integral_constant<size_t, sizeof...(N)>
     {
     };
 }
@@ -281,9 +289,9 @@ namespace xt
         using inner_strides_type = inner_shape_type;
         using backstrides_type = inner_shape_type;
         using inner_backstrides_type = backstrides_type;
-        using shape_type = std::array<typename inner_shape_type::value_type,
+        using shape_type = S;
+        using strides_type = std::array<typename inner_shape_type::value_type,
                                       std::tuple_size<inner_shape_type>::value>;
-        using strides_type = shape_type;
         using storage_type = aligned_array<ET, detail::fixed_compute_size<S>::value>;
         using temporary_type = xfixed_container<ET, S, L, Tag>;
         static constexpr layout_type layout = L;

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -41,6 +41,7 @@ namespace xt
         using derived_type = D;
 
         using iterable_types = xiterable_inner_types<D>;
+        using shape_type = typename iterable_types::shape_type;
         using inner_shape_type = typename iterable_types::inner_shape_type;
 
         using stepper = typename iterable_types::stepper;

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -41,7 +41,6 @@ namespace xt
         using derived_type = D;
 
         using iterable_types = xiterable_inner_types<D>;
-        using shape_type = typename iterable_types::shape_type;
         using inner_shape_type = typename iterable_types::inner_shape_type;
 
         using stepper = typename iterable_types::stepper;

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -77,6 +77,12 @@ namespace xt
         {
             using type = std::array<V, L>;
         };
+
+        template <std::size_t... I>
+        struct index_type_impl<fixed_shape<I...>>
+        {
+            using type = std::array<std::size_t, sizeof...(I)>;
+        };
     }
 
     template <class C>
@@ -380,25 +386,25 @@ namespace xt
     namespace detail
     {
         template <class C>
-        constexpr auto trivial_begin(C& c) noexcept
+        XTENSOR_CONSTEXPR_RETURN auto trivial_begin(C& c) noexcept
         {
             return c.storage_begin();
         }
 
         template <class C>
-        constexpr auto trivial_end(C& c) noexcept
+        XTENSOR_CONSTEXPR_RETURN auto trivial_end(C& c) noexcept
         {
             return c.storage_end();
         }
 
         template <class C>
-        constexpr auto trivial_begin(const C& c) noexcept
+        XTENSOR_CONSTEXPR_RETURN auto trivial_begin(const C& c) noexcept
         {
             return c.storage_begin();
         }
 
         template <class C>
-        constexpr auto trivial_end(const C& c) noexcept
+        XTENSOR_CONSTEXPR_RETURN auto trivial_end(const C& c) noexcept
         {
             return c.storage_end();
         }

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -178,7 +178,7 @@ namespace xt
         template <class T, class S, class E>
         inline auto randint(const S& shape, T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
@@ -213,7 +213,7 @@ namespace xt
         template <class T, class I, class E>
         inline auto randint(std::initializer_list<I> shape, T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
@@ -234,7 +234,7 @@ namespace xt
         template <class T, class I, std::size_t L, class E>
         inline auto randint(const I (&shape)[L], T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -43,6 +43,7 @@ namespace xt
     {
         using value_type = std::decay_t<CT>;
         using inner_shape_type = std::array<std::size_t, 0>;
+        using shape_type = inner_shape_type;
         using const_stepper = xscalar_stepper<true, CT>;
         using stepper = xscalar_stepper<false, CT>;
     };

--- a/include/xtensor/xshape.hpp
+++ b/include/xtensor/xshape.hpp
@@ -33,6 +33,33 @@ namespace xt
     class fixed_shape;
 
     using xindex = dynamic_shape<std::size_t>;
+}
+
+namespace xtl
+{
+    namespace detail
+    {
+        template <std::size_t... I>
+        struct sequence_builder<xt::fixed_shape<I...>>
+        {
+            using sequence_type = xt::fixed_shape<I...>;
+            using value_type = typename sequence_type::value_type;
+
+            inline static sequence_type make(std::size_t /*size*/)
+            {
+                return sequence_type{};
+            }
+
+            inline static sequence_type make(std::size_t /*size*/, value_type /*v*/)
+            {
+                return sequence_type{};
+            }
+        };
+    }
+}
+
+namespace xt
+{
 
     /*************************************
      * promote_shape and promote_strides *
@@ -61,6 +88,47 @@ namespace xt
         {
         };
 
+        // Broadcasting for fixed shapes
+        template <std::size_t IDX, std::size_t... X>
+        struct at
+        {
+            constexpr static std::size_t arr[sizeof...(X)] = {X...};
+            constexpr static std::size_t value = (IDX < sizeof...(X)) ? arr[IDX] : 0;
+        };
+
+        template <class S1, class S2>
+        struct broadcast_fixed_shape;
+
+        template <class IX, class A, class B>
+        struct broadcast_fixed_shape_impl;
+
+        template <std::size_t IX, class A, class B>
+        struct broadcast_fixed_shape_cmp_impl;
+
+        template <std::size_t IX, std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape_cmp_impl<IX, fixed_shape<I...>, fixed_shape<J...>>
+        {
+            static constexpr std::size_t index_diff = sizeof...(I) - sizeof...(J);
+            static constexpr std::size_t value = detail::at<IX, I...>::value == 1 && (IX - index_diff) < sizeof...(J) ? 
+                                                    detail::at<IX - index_diff, J...>::value :
+                                                    detail::at<IX, I...>::value;
+        };
+
+        template <std::size_t... IX, std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape_impl<std::index_sequence<IX...>, fixed_shape<I...>, fixed_shape<J...>>
+        {
+            using type = xt::fixed_shape<broadcast_fixed_shape_cmp_impl<IX, fixed_shape<I...>, fixed_shape<J...>>::value...>;
+        };
+
+        template <std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape<fixed_shape<I...>, fixed_shape<J...>>
+        {
+            using type = std::conditional_t<(sizeof...(I) > sizeof...(J)),
+                    typename broadcast_fixed_shape_impl<decltype(std::make_index_sequence<sizeof...(I)>()), fixed_shape<I...>, fixed_shape<J...>>::type,
+                    typename broadcast_fixed_shape_impl<decltype(std::make_index_sequence<sizeof...(J)>()), fixed_shape<J...>, fixed_shape<I...>>::type
+                >;
+        };
+
         // Simple is_array and only_array meta-functions
         template <class S>
         struct is_array
@@ -74,38 +142,94 @@ namespace xt
             static constexpr bool value = true;
         };
 
+        template <class S>
+        struct is_fixed
+        {
+            static constexpr bool value = false;
+        };
+
+        template <std::size_t... N>
+        struct is_fixed<fixed_shape<N...>>
+        {
+            static constexpr bool value = true;
+        };
+
         template <class... S>
-        using only_array = xtl::conjunction<is_array<S>...>;
+        using only_array = xtl::conjunction<xtl::disjunction<is_array<S>, is_fixed<S>>...>;
+
+        template <class... S>
+        using only_fixed = xtl::conjunction<is_fixed<S>...>;
 
         // The promote_index meta-function returns std::vector<promoted_value_type> in the
         // general case and an array of the promoted value type and maximal size if all
         // arguments are of type std::array
 
-        template <bool A, class... S>
-        struct promote_index_impl;
-
         template <class... S>
-        struct promote_index_impl<false, S...>
-        {
-            using type = dynamic_shape<typename std::common_type<typename S::value_type...>::type>;
-        };
-
-        template <class... S>
-        struct promote_index_impl<true, S...>
+        struct promote_array
         {
             using type = std::array<typename std::common_type<typename S::value_type...>::type, max_array_size<S...>::value>;
         };
 
         template <>
-        struct promote_index_impl<true>
+        struct promote_array<>
         {
             using type = std::array<std::size_t, 0>;
         };
 
         template <class... S>
+        struct broadcast_fixed;
+
+        template <class S1, class S2>
+        struct broadcast_fixed<S1, S2>
+        {
+            using type = typename broadcast_fixed_shape<S1, S2>::type;
+        };
+
+        template <class S1, class... S>
+        struct broadcast_fixed<S1, S...>
+        {
+            using type = typename broadcast_fixed_shape<S1, typename broadcast_fixed<S...>::type>::type;
+        };
+
+        template <bool all_index, bool all_array, class... S>
+        struct select_promote_index;
+
+        template <class... S>
+        struct select_promote_index<true, true, S...>
+        {
+            using type = typename broadcast_fixed<S...>::type;
+        };
+
+        template <class... S>
+        struct select_promote_index<false, true, S...>
+        {
+            using type = typename promote_array<S...>::type;
+        };
+
+        template <class... S>
+        struct select_promote_index<false, false, S...>
+        {
+            using type = dynamic_shape<typename std::common_type<typename S::value_type...>::type>;
+        };
+
+        template <class... S>
         struct promote_index
         {
-            using type = typename promote_index_impl<only_array<S...>::value, S...>::type;
+            using type = typename select_promote_index<only_fixed<S...>::value,
+                                                       only_array<S...>::value,
+                                                       S...>::type;
+        };
+
+        template <class T>
+        struct index_from_shape_impl
+        {
+            using type = T;
+        };
+
+        template <std::size_t... N>
+        struct index_from_shape_impl<fixed_shape<N...>>
+        {
+            using type = std::array<std::size_t, sizeof...(N)>;
         };
     }
 
@@ -114,6 +238,9 @@ namespace xt
 
     template <class... S>
     using promote_strides_t = typename detail::promote_index<S...>::type;
+
+    template <class S>
+    using index_from_shape_t = typename detail::index_from_shape_impl<S>::type;
 }
 
 #endif

--- a/include/xtensor/xshape.hpp
+++ b/include/xtensor/xshape.hpp
@@ -39,6 +39,9 @@ namespace xtl
 {
     namespace detail
     {
+        template <class S>
+        struct sequence_builder;
+
         template <std::size_t... I>
         struct sequence_builder<xt::fixed_shape<I...>>
         {
@@ -108,10 +111,16 @@ namespace xt
         template <std::size_t IX, std::size_t... I, std::size_t... J>
         struct broadcast_fixed_shape_cmp_impl<IX, fixed_shape<I...>, fixed_shape<J...>>
         {
-            static constexpr std::size_t index_diff = sizeof...(I) - sizeof...(J);
-            static constexpr std::size_t value = detail::at<IX, I...>::value == 1 && (IX - index_diff) < sizeof...(J) ? 
-                                                    detail::at<IX - index_diff, J...>::value :
-                                                    detail::at<IX, I...>::value;
+            static constexpr std::size_t JX = IX - (sizeof...(I) - sizeof...(J));
+
+            // we're statically checking if the broadcast shapes are either one on either of them or equal
+            static_assert(JX < sizeof...(J) ?
+                            detail::at<IX, I...>::value == 1 ||
+                            detail::at<JX, J...>::value == 1 ||
+                            detail::at<JX, J...>::value == detail::at<IX, I...>::value : true, "broadcast shapes do not match.");
+
+            static constexpr std::size_t value = (detail::at<IX, I...>::value == 1 && JX < sizeof...(J)) ?
+                                                    detail::at<JX, J...>::value : detail::at<IX, I...>::value;
         };
 
         template <std::size_t... IX, std::size_t... I, std::size_t... J>
@@ -154,11 +163,25 @@ namespace xt
             static constexpr bool value = true;
         };
 
+        template <class S>
+        struct is_scalar_shape
+        {
+            static constexpr bool value = false;
+        };
+
+        template <class T>
+        struct is_scalar_shape<std::array<T, 0>>
+        {
+            static constexpr bool value = true;
+        };
+
         template <class... S>
         using only_array = xtl::conjunction<xtl::disjunction<is_array<S>, is_fixed<S>>...>;
 
+        // test that at least one argument is a fixed shape. If yes, then either argument has to be fixed or scalar
         template <class... S>
-        using only_fixed = xtl::conjunction<is_fixed<S>...>;
+        using only_fixed = std::integral_constant<bool, xtl::disjunction<is_fixed<S>...>::value &&
+                                                        xtl::conjunction<xtl::disjunction<is_fixed<S>, is_scalar_shape<S>>...>::value>;
 
         // The promote_index meta-function returns std::vector<promoted_value_type> in the
         // general case and an array of the promoted value type and maximal size if all
@@ -176,19 +199,34 @@ namespace xt
             using type = std::array<std::size_t, 0>;
         };
 
+        template <class S>
+        struct filter_scalar
+        {
+            using type = S;
+        };
+
+        template <class T>
+        struct filter_scalar<std::array<T, 0>>
+        {
+            using type = fixed_shape<1>;
+        };
+
+        template <class S>
+        using filter_scalar_t = typename filter_scalar<S>::type;
+
         template <class... S>
         struct broadcast_fixed;
 
         template <class S1, class S2>
         struct broadcast_fixed<S1, S2>
         {
-            using type = typename broadcast_fixed_shape<S1, S2>::type;
+            using type = typename broadcast_fixed_shape<filter_scalar_t<S1>, filter_scalar_t<S2>>::type;
         };
 
         template <class S1, class... S>
         struct broadcast_fixed<S1, S...>
         {
-            using type = typename broadcast_fixed_shape<S1, typename broadcast_fixed<S...>::type>::type;
+            using type = typename broadcast_fixed_shape<filter_scalar_t<S1>, typename broadcast_fixed<S...>::type>::type;
         };
 
         template <bool all_index, bool all_array, class... S>
@@ -198,6 +236,13 @@ namespace xt
         struct select_promote_index<true, true, S...>
         {
             using type = typename broadcast_fixed<S...>::type;
+        };
+
+        template <>
+        struct select_promote_index<true, true>
+        {
+            // todo correct? used in xvectorize
+            using type = dynamic_shape<std::size_t>;
         };
 
         template <class... S>

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -40,6 +40,7 @@ namespace xt
     struct xiterable_inner_types<xstrided_view<CT, S, L, FST>>
     {
         using inner_shape_type = S;
+        using shape_type = S;
         using inner_strides_type = inner_shape_type;
         using inner_backstrides_type = inner_shape_type;
 

--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -22,6 +22,18 @@
     #endif
 #endif
 
+// Workaround for some missing constexpr functionality in MSVC 2015
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+#define XTENSOR_CONSTEXPR_ENHANCED const
+#define XTENSOR_CONSTEXPR_ENHANCED_STATIC const
+#define XTENSOR_CONSTEXPR_RETURN inline
+#else
+#define XTENSOR_CONSTEXPR_ENHANCED constexpr
+#define XTENSOR_CONSTEXPR_RETURN constexpr
+#define XTENSOR_CONSTEXPR_ENHANCED_STATIC constexpr static
+#define XTENSOR_HAS_CONSTEXPR_ENHANCED
+#endif
+
 #ifndef XTENSOR_DEFAULT_DATA_CONTAINER
 #define XTENSOR_DEFAULT_DATA_CONTAINER(T, A) uvector<T, A>
 #endif

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -68,6 +68,12 @@ namespace xt
     template <class T, std::size_t N>
     bool resize_container(std::array<T, N>& a, typename std::array<T, N>::size_type size);
 
+    template <std::size_t... I>
+    class fixed_shape;
+
+    template <std::size_t... I>
+    bool resize_container(fixed_shape<I...>& a, std::size_t size);
+
     // gcc 4.9 is affected by C++14 defect CGW 1558
     // see http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1558
     template <class... T>
@@ -410,6 +416,12 @@ namespace xt
     inline bool resize_container(std::array<T, N>& /*a*/, typename std::array<T, N>::size_type size)
     {
         return size == N;
+    }
+
+    template <std::size_t... I>
+    inline bool resize_container(xt::fixed_shape<I...>&, std::size_t size)
+    {
+        return sizeof...(I) == size;
     }
 
     /******************

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -468,6 +468,12 @@ namespace xt
         using type = std::array<I, L - integral_count<S...>() + newaxis_count<S...>()>;
     };
 
+    template <std::size_t... I, class... S>
+    struct xview_shape_type<fixed_shape<I...>, S...>
+    {
+        using type = std::array<std::size_t, sizeof...(I) - integral_count<S...>() + newaxis_count<S...>()>;
+    };
+
     namespace detail
     {
         template <class T>
@@ -486,6 +492,12 @@ namespace xt
         struct static_dimension<xt::const_array<T, N>>
         {
             static constexpr std::ptrdiff_t value = static_cast<std::ptrdiff_t>(N);
+        };
+
+        template <std::size_t... I>
+        struct static_dimension<xt::fixed_shape<I...>>
+        {
+            static constexpr std::ptrdiff_t value = sizeof...(I);
         };
 
         template <class CT, class... S>

--- a/test/test_xaccumulator.cpp
+++ b/test/test_xaccumulator.cpp
@@ -12,7 +12,8 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xmath.hpp"
-#include "xtensor/xio.hpp"
+#include "xtensor/xrandom.hpp"
+#include "xtensor/xfixed.hpp"
 
 namespace xt
 {
@@ -163,7 +164,6 @@ namespace xt
         EXPECT_EQ(expected, res);
     }
 
-
     TEST(xaccumulator, cumprod)
     {
         xarray<long> arg_0 = {{ 0, 1, 2},
@@ -188,5 +188,26 @@ namespace xt
                                    {  6, 42, 336},
                                    {  9, 90, 990}};
         EXPECT_TRUE(allclose(expected_1, res_1));
+    }
+
+    TEST(xaccumulator, xfixed)
+    {
+        xtensor_fixed<float, xshape<2, 4, 3>> a = xt::random::rand<float>({2, 4, 3});
+        auto res = cumsum(a, 1);
+
+        bool truth = std::is_same<decltype(res), xtensor_fixed<double, xshape<2, 4, 3>>>::value;
+        EXPECT_TRUE(truth);
+        xtensor_fixed<long, xshape<4, 3>> arg_0({{ 0, 1, 2},
+                                                 { 3, 4, 5},
+                                                 { 6, 7, 8},
+                                                 { 9,10,11}});
+        auto res_0 = cumprod(arg_0, 0);
+        xarray<long> expected_0 = {{  0,   1,   2},
+                                   {  0,   4,  10},
+                                   {  0,  28,  80},
+                                   {  0, 280, 880}};
+        EXPECT_TRUE(expected_0 == res_0);
+        truth = std::is_same<typename decltype(res_0)::shape_type, xshape<4, 3>>::value;
+        EXPECT_TRUE(truth);
     }
 }

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -824,8 +824,8 @@ namespace xt
         xarray<double> a = {{1, 2, 3, 4}, {0, 0, 0, 0}, {3, 0, 1, 0}};
         std::size_t as = count_nonzero(a)();
         std::size_t ase = count_nonzero(a, evaluation_strategy::immediate())();
-        EXPECT_EQ(as, 6);
-        EXPECT_EQ(ase, 6);
+        EXPECT_EQ(as, 6u);
+        EXPECT_EQ(ase, 6u);
 
         xarray<std::size_t> ea0 = {2, 1, 2, 1};
         xarray<std::size_t> ea1 = {4, 0, 2};

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -694,7 +694,7 @@ namespace xt
         using ds = xt::dynamic_shape<std::size_t>;
         std::iota(b.begin(), b.end(), 0);
         auto s1 = split(b, 3);
-        EXPECT_EQ(s1.size(), 3);
+        EXPECT_EQ(s1.size(), 3u);
         EXPECT_EQ(s1[0].shape(), ds({1, 3, 3}));
         EXPECT_EQ(s1[0](0, 0), b(0, 0, 0));
         EXPECT_EQ(s1[1](0, 0), b(1, 0, 0));
@@ -704,7 +704,7 @@ namespace xt
         EXPECT_THROW(split(b, 2), std::runtime_error);
 
         auto s2 = split(b, 1);
-        EXPECT_EQ(s2.size(), 1);
+        EXPECT_EQ(s2.size(), 1u);
         EXPECT_EQ(s2[0].shape(), ds({3, 3, 3}));
 
         auto s3 = split(b, 3, 1);

--- a/test/test_xtensor_semantic.cpp
+++ b/test/test_xtensor_semantic.cpp
@@ -75,7 +75,7 @@ namespace xt
     TEST(xtensor_semantic, broadcasting_single_element)
     {
         xtensor<int, 2> t = xt::zeros<int>({ 1, 1 });
-        EXPECT_EQ(t.backstrides().size(), 2);
+        EXPECT_EQ(t.backstrides().size(), 2u);
         EXPECT_EQ(t.backstrides()[0], 0u);
         EXPECT_EQ(t.backstrides()[1], 0u);
     }


### PR DESCRIPTION
With this PR we're able to:

- statically compute the extents of a reduction (if axes are supplied as a xshape (TODO add another typedef xaxes?)
- statically allocate memory for accumulators if accumulating over an xfixed
- statically broadcast xfunctions if all leaf nodes are fixed -- note: this might still be broken and WIP.

