### PR TITLE
Update xeus-cling version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,5 @@ channels:
 dependencies:
   - xtensor=0.16.4
   - xtensor-blas=0.11.0
-  - xeus-cling=0.3.0
+  - xeus-cling=0.4.5
   - notebook


### PR DESCRIPTION
I guess `mime_bundle_repr` doesn't work in mybinder because of the version of xeus-cling, what do you think @SylvainCorlay ?