### PR TITLE
add xt::average / refactor strided view copy + move constructor

### DIFF
--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -1824,6 +1824,49 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
 
     /**
      * @ingroup red_functions
+     * @brief Average of elements over given axes using weights.
+     *
+     * Returns an \ref xreducer for the mean of elements over given
+     * \em axes.
+     * @param e an \ref xexpression
+     * @param axes the axes along which the mean is computed (optional)
+     * @return an \ref xexpression
+     *
+     * @sa mean
+     */
+    template <class E, class W>
+    inline auto average(E&& e, W&& weights, std::ptrdiff_t axis)
+    {
+        std::size_t ax = normalize_axis(e.dimension(), axis);
+
+        if (weights.dimension() != 1 && weights.size() != e.shape()[ax])
+        {
+            throw std::runtime_error("Weights need to have the same shape as expression at axis.");
+        }
+
+        auto div = sum(weights, xt::evaluation_strategy::immediate{})();
+
+        dynamic_shape<size_t> broadcast_shape(e.dimension(), 1);
+        broadcast_shape[ax] = weights.size();
+
+        return sum(std::forward<E>(e) * reshape_view(std::forward<W>(weights), std::move(broadcast_shape)), std::array<std::size_t, 1>({ax})) / std::move(div);
+    }
+
+    template <class E, class W>
+    inline auto average(E&& e, W&& weights)
+    {
+        if (weights.dimension() != e.dimension() || !std::equal(weights.shape().begin(), weights.shape().end(), e.shape().begin()))
+        {
+            throw std::runtime_error("Weights need to have the same shape as expression.");
+        }
+
+        auto div = sum(weights, xt::evaluation_strategy::immediate{})();
+        auto s = sum(std::forward<E>(e) * std::forward<W>(weights)) / std::move(div);
+        return s;
+    }
+
+    /**
+     * @ingroup red_functions
      * @brief Minimum and maximum among the elements of an array or expression.
      *
      * Returns an \ref xreducer for the minimum and maximum of an expression's elements.

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -22,6 +22,7 @@
 #include "xiterable.hpp"
 #include "xlayout.hpp"
 #include "xsemantic.hpp"
+#include "xstorage.hpp"
 #include "xstrided_view_base.hpp"
 
 namespace xt
@@ -120,6 +121,8 @@ namespace xt
         template <class CTA, class FLS>
         xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset,
                       layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept;
+
+        xstrided_view(const xstrided_view& rhs) = default;
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);
@@ -228,7 +231,7 @@ namespace xt
     using slice_vector = xstrided_slice_vector;
 
     template <layout_type L = layout_type::dynamic, class E, class S, class X>
-    auto strided_view(E&& e, S&& shape, X&& stride, std::size_t offset = 0, layout_type layout = layout_type::dynamic) noexcept;
+    auto strided_view(E&& e, S&& shape, X&& stride, std::size_t offset = 0, layout_type layout = L) noexcept;
 
     template <class E>
     auto strided_view(E&& e, const xstrided_slice_vector& slices);
@@ -734,7 +737,7 @@ namespace xt
         inline auto build_ravel_view(E&& e, S&& flatten_strides, layout_type l)
         {
             using shape_type = static_shape<std::size_t, 1>;
-            using view_type = xstrided_view<xclosure_t<E>, shape_type, layout_type::dynamic, detail::flat_expression_adaptor<xclosure_t<E>>>;
+            using view_type = xstrided_view<xclosure_t<E>, shape_type, layout_type::dynamic, detail::flat_expression_adaptor<std::remove_reference_t<E>>>;
 
             shape_type new_shape;
             get_strides_t<shape_type> new_strides;
@@ -1090,9 +1093,9 @@ namespace xt
     template <class E, class S>
     inline auto reshape_view(E&& e, S&& shape)
     {
-        using shape_type = S;
-
+        using shape_type = std::decay_t<S>;
         get_strides_t<shape_type> strides;
+
         xt::resize_container(strides, shape.size());
         compute_strides(shape, default_assignable_layout(std::decay_t<E>::static_layout), strides);
 
@@ -1114,9 +1117,9 @@ namespace xt
     template <class E, class S>
     inline auto reshape_view(E&& e, S&& shape, layout_type layout)
     {
-        using shape_type = S;
+        using shape_type = std::decay_t<S>;
+        get_strides_t<shape_type> strides;
 
-        shape_type strides;
         xt::resize_container(strides, shape.size());
         compute_strides(shape, layout, strides);
 

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -55,6 +55,10 @@ namespace xt
         xstrided_view_base(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset,
                            layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept;
 
+        xstrided_view_base(xstrided_view_base&& rhs);
+
+        xstrided_view_base(const xstrided_view_base& rhs);
+
         size_type size() const noexcept;
         size_type dimension() const noexcept;
         const shape_type& shape() const noexcept;
@@ -167,10 +171,15 @@ namespace xt
             using iterator = typename xexpression_type::iterator;
             using const_iterator = typename xexpression_type::const_iterator;
 
-            flat_expression_adaptor(CT& e);
+            explicit flat_expression_adaptor(CT* e);
 
             template <class FST>
-            flat_expression_adaptor(CT& e, FST&& strides, layout_type layout);
+            flat_expression_adaptor(CT* e, FST&& strides, layout_type layout);
+
+            void update_pointer(CT* ptr) const
+            {
+                m_e = ptr;
+            }
 
             size_type size() const;
             reference operator[](std::size_t idx);
@@ -185,7 +194,7 @@ namespace xt
 
         private:
 
-            CT& m_e;
+            mutable CT* m_e;
             shape_type m_strides;
             mutable index_type m_index;
             size_type m_size;
@@ -209,7 +218,7 @@ namespace xt
         template <class CT>
         struct flat_storage_type<CT, typename std::enable_if_t<!has_data_interface<std::decay_t<CT>>::value>>
         {
-            using type = flat_expression_adaptor<CT>;
+            using type = flat_expression_adaptor<std::remove_reference_t<CT>>;
         };
 
         template <class CT>
@@ -236,15 +245,15 @@ namespace xt
 
         // without data_interface
         template <class E, std::enable_if_t<!has_data_interface<std::decay_t<E>>::value>* = nullptr>
-        inline auto get_flat_storage(E& e) -> flat_expression_adaptor<E>
+        inline auto get_flat_storage(E& e) -> flat_expression_adaptor<std::remove_reference_t<E>>
         {
-            return flat_expression_adaptor<E>(e);
+            return flat_expression_adaptor<std::remove_reference_t<E>>(&e);
         }
 
         template <class E, class S>
-        inline auto get_flat_storage(E& e, S&& s, layout_type l) -> flat_expression_adaptor<E>
+        inline auto get_flat_storage(E& e, S&& s, layout_type l) -> flat_expression_adaptor<std::remove_reference_t<E>>
         {
-            return flat_expression_adaptor<E>(e, std::forward<S>(s), l);
+            return flat_expression_adaptor<std::remove_reference_t<E>>(&e, std::forward<S>(s), l);
         }
 
         template <class E, std::enable_if_t<!has_data_interface<std::decay_t<E>>::value>* = nullptr>
@@ -308,6 +317,47 @@ namespace xt
     {
         m_backstrides = xtl::make_sequence<backstrides_type>(m_shape.size(), 0);
         adapt_strides(m_shape, m_strides, m_backstrides);
+    }
+
+    namespace detail
+    {
+        template <class T, class S>
+        auto& copy_move_storage(T& expr, S& /*storage*/)
+        {
+            return expr.storage();
+        }
+
+        template <class T, class E>
+        auto copy_move_storage(T& expr, const detail::flat_expression_adaptor<E>& storage)
+        {
+            detail::flat_expression_adaptor<E> new_storage = storage; // copy storage
+            new_storage.update_pointer(&expr);
+            return new_storage;
+        }
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline xstrided_view_base<CT, S, L, FST>::xstrided_view_base(xstrided_view_base&& rhs)
+        : m_e(std::forward<CT>(rhs.m_e)),
+          m_storage(detail::copy_move_storage(m_e, rhs.m_storage)),
+          m_shape(std::move(rhs.m_shape)),
+          m_strides(std::move(rhs.m_strides)),
+          m_backstrides(std::move(rhs.m_backstrides)),
+          m_offset(std::move(rhs.m_offset)),
+          m_layout(std::move(rhs.m_layout))
+    {
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline xstrided_view_base<CT, S, L, FST>::xstrided_view_base(const xstrided_view_base& rhs)
+        : m_e(rhs.m_e),
+          m_storage(detail::copy_move_storage(m_e, rhs.m_storage)),
+          m_shape(rhs.m_shape),
+          m_strides(rhs.m_strides),
+          m_backstrides(rhs.m_backstrides),
+          m_offset(rhs.m_offset),
+          m_layout(rhs.m_layout)
+    {
     }
     //@}
 
@@ -722,25 +772,25 @@ namespace xt
     namespace detail
     {
         template <class CT>
-        inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT& e)
+        inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT* e)
             : m_e(e)
         {
-            resize_container(m_index, m_e.dimension());
-            resize_container(m_strides, m_e.dimension());
-            m_size = compute_size(m_e.shape());
+            resize_container(m_index, m_e->dimension());
+            resize_container(m_strides, m_e->dimension());
+            m_size = compute_size(m_e->shape());
             // Fallback to XTENSOR_DEFAULT_LAYOUT when the underlying layout is not
             // row-major or column major.
-            m_layout = default_assignable_layout(m_e.layout());
-            compute_strides(m_e.shape(), m_layout, m_strides);
+            m_layout = default_assignable_layout(m_e->layout());
+            compute_strides(m_e->shape(), m_layout, m_strides);
         }
 
         template <class CT>
         template <class FST>
-        inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT& e, FST&& strides, layout_type layout)
+        inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT* e, FST&& strides, layout_type layout)
             : m_e(e), m_strides(xtl::forward_sequence<shape_type>(strides)), m_layout(layout)
         {
-            resize_container(m_index, m_e.dimension());
-            m_size = e.size();
+            resize_container(m_index, m_e->dimension());
+            m_size = m_e->size();
         }
 
         template <class CT>
@@ -753,50 +803,50 @@ namespace xt
         inline auto flat_expression_adaptor<CT>::operator[](std::size_t idx) -> reference
         {
             m_index = detail::unravel_noexcept(idx, m_strides, m_layout);
-            return m_e.element(m_index.cbegin(), m_index.cend());
+            return m_e->element(m_index.cbegin(), m_index.cend());
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::operator[](std::size_t idx) const -> const_reference
         {
             m_index = detail::unravel_noexcept(idx, m_strides, m_layout);
-            return m_e.element(m_index.cbegin(), m_index.cend());
+            return m_e->element(m_index.cbegin(), m_index.cend());
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::begin() -> iterator
         {
-            return m_e.begin();
+            return m_e->begin();
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::end() -> iterator
         {
-            return m_e.end();
+            return m_e->end();
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::begin() const -> const_iterator
         {
-            return m_e.cbegin();
+            return m_e->cbegin();
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::end() const -> const_iterator
         {
-            return m_e.cend();
+            return m_e->cend();
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::cbegin() const -> const_iterator
         {
-            return m_e.cbegin();
+            return m_e->cbegin();
         }
 
         template <class CT>
         inline auto flat_expression_adaptor<CT>::cend() const ->const_iterator
         {
-            return m_e.cend();
+            return m_e->cend();
         }
     }
 

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -74,6 +74,8 @@ namespace xt
     template <std::size_t... I>
     bool resize_container(fixed_shape<I...>& a, std::size_t size);
 
+    std::size_t normalize_axis(std::size_t dim, std::ptrdiff_t axis);
+
     // gcc 4.9 is affected by C++14 defect CGW 1558
     // see http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1558
     template <class... T>
@@ -422,6 +424,15 @@ namespace xt
     inline bool resize_container(xt::fixed_shape<I...>&, std::size_t size)
     {
         return sizeof...(I) == size;
+    }
+
+    /*********************************
+     * normalize_axis implementation *
+     *********************************/
+
+    inline std::size_t normalize_axis(std::size_t dim, std::ptrdiff_t axis)
+    {
+        return axis < 0 ? static_cast<std::size_t>(static_cast<std::ptrdiff_t>(dim) + axis) : static_cast<std::size_t>(axis);
     }
 
     /******************

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -202,6 +202,23 @@ namespace xt
         EXPECT_EQ(mean(c)(), 1.5);
     }
 
+    TEST(xreducer, average)
+    {
+        xt::xtensor<float, 2> a = {{ 3, 4, 2, 1}, { 1, 1, 3, 2}};
+
+        auto avg_all = xt::average(a, xt::xarray<double>{{1, 2, 3, 4}, { 5, 6, 7, 8}});
+        auto avg0 = xt::average(a, xt::xarray<double>{3, 9}, 0);
+        auto avg1 = xt::average(a, xt::xarray<double>{1,2,3,4}, 1);
+
+        xtensor<double, 0> expect_all = 1.9166666666666667;
+        xtensor<double, 1> expect0 = {1.5, 1.75, 2.75, 1.75};
+        xtensor<double, 1> expect1 = {2.1, 2.0};
+
+        EXPECT_TRUE(allclose(avg_all, expect_all));
+        EXPECT_TRUE(all(equal(avg0, expect0)));
+        EXPECT_TRUE(all(equal(avg1, expect1)));
+    }
+
     TEST(xreducer, minmax)
     {
         using A = std::array<double, 2>;


### PR DESCRIPTION
I think we need shared xexpressions for xt::average with weights. 

That's why I had to start this stuff :)