### PR TITLE
[xnpy] Add `signed char` to deserialization format

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -103,6 +103,7 @@ namespace xt
             if (std::is_same<T, long double>::value) return 'f';
 
             if (std::is_same<T, char>::value) return 'i';
+            if (std::is_same<T, signed char>::value) return 'i';
             if (std::is_same<T, short>::value) return 'i';
             if (std::is_same<T, int>::value) return 'i';
             if (std::is_same<T, long>::value) return 'i';


### PR DESCRIPTION
`signed int` and `int` are the same datatype, but upon doing `std::is_same<char, signed_char>::value`, we can see that it is not. Therefore, we need to add `signed char` as a member into `xnpy`'s deserialization step.

Why do we need `signed char`? Because `std::int8_t` aliases to `signed char` and people may use `int8_t` as a data type in a xtensor array in the future.