### PR TITLE
[xexpression] Add inspection into shared_expressions

### DIFF
--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -403,7 +403,8 @@ namespace xt
         XTENSOR_FORWARD_METHOD(storage_cbegin);
         XTENSOR_FORWARD_METHOD(storage_end);
         XTENSOR_FORWARD_METHOD(storage_cend);
-
+        XTENSOR_FORWARD_METHOD(layout);
+        
         template <class CE = E, class = std::enable_if_t<has_data_interface<CE>::value, int>>
         XTENSOR_FORWARD_METHOD(strides);
         template <class CE = E, class = std::enable_if_t<has_data_interface<CE>::value, int>>
@@ -412,6 +413,16 @@ namespace xt
         XTENSOR_FORWARD_METHOD(data_offset);
         template <class CE = E, class = std::enable_if_t<has_data_interface<CE>::value, int>>
         XTENSOR_FORWARD_METHOD(storage);
+       
+        template <class It>
+        auto element(It first, It last) {
+            return m_ptr->element(first, last); 
+        }
+        
+        template <class It>
+        auto element(It first, It last) const {
+            return m_ptr->element(first, last); 
+        }
 
         template <class S>
         bool broadcast_shape(S& shape, bool reuse_cache = false) const

--- a/test/test_xexpression.cpp
+++ b/test/test_xexpression.cpp
@@ -7,10 +7,12 @@
 ****************************************************************************/
 
 #include "gtest/gtest.h"
+#include <sstream>
 
 #include "xtensor/xarray.hpp"
 #include "xtensor/xexpression.hpp"
 #include "xtensor/xmath.hpp"
+#include "xtensor/xio.hpp"
 
 namespace xt
 {
@@ -42,6 +44,10 @@ namespace xt
         EXPECT_EQ(sa.use_count(), 1);
         auto cpysa = sa;
         EXPECT_EQ(sa.use_count(), 2);
+        
+        std::stringstream buffer;
+        buffer << sa;
+        EXPECT_EQ(buffer.str(), "{{ 1.,  2.,  3.,  4.},\n { 5.,  6.,  7.,  8.}}");
     }
 
     TEST(xexpression, shared_xfunctions)
@@ -56,6 +62,9 @@ namespace xt
 
         EXPECT_EQ(sa.use_count(), 3);
         EXPECT_TRUE(all(equal(expr1, expr2)));
+        std::stringstream buffer;
+        buffer << expr1;
+        EXPECT_EQ(buffer.str(), "{{  2.,   4.,   6.,   8.},\n { 10.,  12.,  14.,  16.}}");
     }
 
     TEST(xexpression, shared_expr_return)


### PR DESCRIPTION
Previously, `shared_xexpressions` cannot be evaluated, reproduced from [this issue](https://github.com/QuantStack/xtensor/issues/1018).

We needed to expose more forwarding methods for this to work, namely the `element()` function and the `layout` function.

I added tests in the `test_xexpression.cpp` to check that the results of output is correct.