### PR TITLE
Improved CRTP base class detection

### DIFF
--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -102,6 +102,15 @@ namespace xt
     }
     //@}
 
+    /* is_crtp_base_of<B, E>
+    * Resembles std::is_base_of, but adresses the problem of whether _some_ instatntiation
+    * of a CRTP templated class B is a base of class E. A CRTP templated class is correctly
+    * templated with the most derived type in the CRTP hierarchy. Using this assumption,
+    * this implementation deals with either CRTP final classes (checks for inheritance
+    * with E as the CRTP parameter of B) or CRTP base classes (which are singly templated
+    * by the most derived class, and that's pulled out to use as a templete parameter for B).
+    */
+
     namespace detail
     {
         template <template<class> class B, class E>

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -104,19 +104,19 @@ namespace xt
 
     namespace detail
     {
-        template <class E, template<class> class B>
-        struct is_CRTP_base_impl : std::is_base_of< B<E>, E> {};
+        template <template<class> class B, class E>
+        struct is_crtp_base_of_impl : std::is_base_of<B<E>, E> {};
 
-        template <class E, template<class> class F, template<class> class B>
-        struct is_CRTP_base_impl<F<E>, B> :
-        xtl::disjunction< std::is_base_of< B<E>, F<E> >, std::is_base_of< B<F<E>>, F<E> > > {};
+        template <template<class> class B, class E, template<class> class F>
+        struct is_crtp_base_of_impl<B, F<E>> :
+        xtl::disjunction< std::is_base_of<B<E>, F<E>>, std::is_base_of<B<F<E>>, F<E>>> {};
     }
 
-    template <class E, template<class> class B>
-    using is_CRTP_base = detail::is_CRTP_base_impl<std::decay_t<E>, B>;
+    template <template<class> class B, class E>
+    using is_crtp_base_of = detail::is_crtp_base_of_impl<B, std::decay_t<E>>;
 
     template <class E>
-    using is_xexpression = is_CRTP_base<E, xexpression>;
+    using is_xexpression = is_crtp_base_of<xexpression, E>;
 
     template <class E, class R = void>
     using enable_xexpression = typename std::enable_if<is_xexpression<E>::value, R>::type;

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -104,19 +104,19 @@ namespace xt
 
     namespace detail
     {
-        template <class E>
-        struct is_xexpression_impl : std::is_base_of<xexpression<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
+        template <class E, template<class> class B>
+        struct is_CRTP_base_impl : std::is_base_of< B<E>, E> {};
 
-        template <class E>
-        struct is_xexpression_impl<xexpression<E>> : std::true_type
-        {
-        };
+        template <class E, template<class> class F, template<class> class B>
+        struct is_CRTP_base_impl<F<E>, B> :
+        xtl::disjunction< std::is_base_of< B<E>, F<E> >, std::is_base_of< B<F<E>>, F<E> > > {};
     }
 
+    template <class E, template<class> class B>
+    using is_CRTP_base = detail::is_CRTP_base_impl<std::decay_t<E>, B>;
+
     template <class E>
-    using is_xexpression = detail::is_xexpression_impl<E>;
+    using is_xexpression = is_CRTP_base<E, xexpression>;
 
     template <class E, class R = void>
     using enable_xexpression = typename std::enable_if<is_xexpression<E>::value, R>::type;
@@ -440,7 +440,7 @@ namespace xt
         XTENSOR_FORWARD_METHOD(storage_end);
         XTENSOR_FORWARD_METHOD(storage_cend);
         XTENSOR_FORWARD_METHOD(layout);
-        
+
         template <class T = E>
         std::enable_if_t<has_strides<T>::value, const inner_strides_type&>
         strides() const
@@ -489,15 +489,15 @@ namespace xt
         {
             return m_ptr->storage();
         }
-       
+
         template <class It>
         auto element(It first, It last) {
-            return m_ptr->element(first, last); 
+            return m_ptr->element(first, last);
         }
-        
+
         template <class It>
         auto element(It first, It last) const {
-            return m_ptr->element(first, last); 
+            return m_ptr->element(first, last);
         }
 
         template <class S>

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -276,12 +276,11 @@ namespace xt
         *  done because thie template is specialized in file xview.hpp. */
 
         template <class E>
-        struct is_xscalar_impl : is_CRTP_base<E, sxcalar>;
-        };
+        struct is_xscalar_impl : is_CRTP_base<E, xscalar> {};
     }
 
     template <class E>
-    using is_xscalar = is_xscalar_impl<E>;
+    using is_xscalar = detail::is_xscalar_impl<E>;
 
     namespace detail
     {

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -270,21 +270,8 @@ namespace xt
     };
 #undef DL
 
-    namespace detail
-    {
-        template <class E>
-        struct is_xscalar_impl : std::false_type
-        {
-        };
-
-        template <class E>
-        struct is_xscalar_impl<xscalar<E>> : std::true_type
-        {
-        };
-    }
-
     template <class E>
-    using is_xscalar = detail::is_xscalar_impl<E>;
+    using is_xscalar = is_CRTP_base<E, xscalar>;
 
     namespace detail
     {

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -270,8 +270,18 @@ namespace xt
     };
 #undef DL
 
+    namespace detail
+    {
+        /*Not congrouous with previous use of this idiom;
+        *  done because thie template is specialized in file xview.hpp. */
+
+        template <class E>
+        struct is_xscalar_impl : is_CRTP_base<E, sxcalar>;
+        };
+    }
+
     template <class E>
-    using is_xscalar = is_CRTP_base<E, xscalar>;
+    using is_xscalar = is_xscalar_impl<E>;
 
     namespace detail
     {

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -272,11 +272,15 @@ namespace xt
 
     namespace detail
     {
-        /*Not congrouous with previous use of this idiom;
-        *  done because thie template is specialized in file xview.hpp. */
+        template <class E>
+        struct is_xscalar_impl : std::false_type
+        {
+        };
 
         template <class E>
-        struct is_xscalar_impl : is_CRTP_base<E, xscalar> {};
+        struct is_xscalar_impl<xscalar<E>> : std::true_type
+        {
+        };
     }
 
     template <class E>

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -174,7 +174,7 @@ namespace xt
     };
 
     template <class E>
-    using has_container_semantics = is_CRTP_base<E, xcontainer_semantic>;
+    using has_container_semantics = is_crtp_base_of<xcontainer_semantic, E>;
 
     template <class E, class R = void>
     using enable_xcontainer_semantics = typename std::enable_if<has_container_semantics<E>::value, R>::type;
@@ -228,7 +228,7 @@ namespace xt
     };
 
     template <class E>
-    using has_view_semantics = is_CRTP_base<E, xview_semantic>;
+    using has_view_semantics = is_crtp_base_of<xview_semantic, E>;
 
     template <class E, class R = void>
     using enable_xview_semantics = typename std::enable_if<has_view_semantics<E>::value, R>::type;

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -173,21 +173,8 @@ namespace xt
         derived_type& operator=(const xexpression<E>&);
     };
 
-    namespace detail
-    {
-        template <class E>
-        struct has_container_semantics_impl : std::is_base_of<xcontainer_semantic<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
-
-        template <class E>
-        struct has_container_semantics_impl<xcontainer_semantic<E>> : std::true_type
-        {
-        };
-    }
-
     template <class E>
-    using has_container_semantics = detail::has_container_semantics_impl<E>;
+    using has_container_semantics = is_CRTP_base<E, xcontainer_semantic>;
 
     template <class E, class R = void>
     using enable_xcontainer_semantics = typename std::enable_if<has_container_semantics<E>::value, R>::type;
@@ -240,21 +227,8 @@ namespace xt
         derived_type& operator=(const xexpression<E>&);
     };
 
-    namespace detail
-    {
-        template <class E>
-        struct has_view_semantics_impl : std::is_base_of<xview_semantic<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
-
-        template <class E>
-        struct has_view_semantics_impl<xview_semantic<E>> : std::true_type
-        {
-        };
-    }
-
     template <class E>
-    using has_view_semantics = detail::has_view_semantics_impl<E>;
+    using has_view_semantics = is_CRTP_base<E, xview_semantic>;
 
     template <class E, class R = void>
     using enable_xview_semantics = typename std::enable_if<has_view_semantics<E>::value, R>::type;


### PR DESCRIPTION
### Introduction

The `master` branch, at the time of writing, offers type trait support for enabling or disabling certain classes in its `xexpression` hierarchy via SFINE (causing template substitution errors). This partially involves a _bare hands_ template meta-programming implementation, as the following problem is not addressed in the standard library:

**How does one detect if _any_ instantiation of a templated class is an ancestor of a given class?**


In our case, the templated class is always a CRTP class whose only template parameter takes the value of the most derived class in the hierarchy. For example, for the most universal CRPT class in the library, `xexpression`, we have the following code:

```
template <class E>
struct is_xexpression_impl : std::is_base_of<xexpression<std::decay_t<E>>, std::decay_t<E>> {};
```

This works perfectly if the only **yes** instances to be considered are final classes in the CRTP hierarchy, as the problem is then reduced to one with a canonical template parameter for the templated base. However, the library is not satisfied with this case, and provides a specialisation of this template:

```
template <class E>
struct is_xexpression_impl<xexpression<E>> : std::true_type {};
```

Which also captures **yes** instances in which the type is _exactly_ some instantiation of the the `xexpression` template. However, this still does not accommodate **yes** instances which are non-final descendants in the hierarchy.

Similar type support is offered in for several classes, re-using this idiom as boilerplate. It is used three times: in the `xexpression`, `xcontainer_semantic` and `xview_semantic` classes.

### A solution proposal

We propose a solution that works most generally under the following assumptions:

- The problem involves a _templated base candidate_ which is a non-final member of a CRTP hierarchy in which all non-final classes are singly templated with the most derived type in the hierarchy.

- A final CRTP class here is taken to mean a class that fills the CRTP parameter. We assume the final instances in the hierarchy all inherit from a non-final class in the hierarchy, and are themselves final in the sense that they are not sub-classed. The library violates this assumption as `xfunction_base `a final class of the `xconst_iterable` CRTP base (this class even provides its own private `derived_cast`!), but `xfunction_base` is an ancestor of `xfunction`. Thus this solution does not work for _templated base candidates_ that are `xconst_iterable` or its descendents.

A generic way to handle this situation if the following implementation, mimicking `std::is_base_of`, but with a template template parameter in place of a class parameter:

```
template <template<class> class B, class E>
struct is_crtp_base_of_impl : std::is_base_of<B<E>, E> {};

template <template<class> class B, class E, template<class> class F>
struct is_crtp_base_of_impl<B, F<E>> :
xtl::disjunction< std::is_base_of<B<E>, F<E>>, std::is_base_of<B<F<E>>, F<E>>> {};

template <template<class> class B, class E>
using is_crtp_base_of = is_crtp_base_of_impl<B, std::decay_t<E>>;
```
Then, for example, to use it for a specific CRTP class like `xexpression`, we do:

```
template <class E>
using is_xexpression = is_crtp_base_impl<xexpression, E>;
```

Note that the final alias removes reference and cv qualification from its argument so that the implementation does not have to. The general template definition then handles final classes that are not themselves templated by one class parameter in the same way that the original specification of the template did. However, now the specialization will pull out the class parameter from template arguments that are instantiations of a singly templated class. If the template argument is a non-final CRTP class, then it's parameter now serves as the canonical CRTP parameter, and only if this is the case will the first case of the disjunction signal a **yes** instance. If however the template argument happens to be a final CRTP class that is singly templated by a non-CRTP parameter, then the second case of the disjunction will cover the remaining CRTP final **yes** instances missed by the first case. Hence, this solution detects all **yes** instances stated in our assumptions, and further avoids the need for boilerplate by providing a template template argument!

### The Pull Request

In the PR, `is_crtp_base_of` has been added in the file `xexpression.hpp`, and the boilerplate use of the initial version of this idiom has been replaced for types `xexpression`, `xcontainer_semantic`, and `xview_semantic`.
