### PR TITLE
Add more adapt functions

### DIFF
--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -367,13 +367,12 @@ namespace xt
     struct xcontainer_inner_types<xfixed_adaptor<EC, S, L, Tag>>
     {
         using storage_type = std::remove_reference_t<EC>;
+        using shape_type = S;
         using inner_shape_type = typename S::cast_type;
         using strides_type = get_strides_t<inner_shape_type>;
         using backstrides_type = strides_type;
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
-        using shape_type = std::array<typename inner_shape_type::value_type,
-                                      std::tuple_size<inner_shape_type>::value>;
         using temporary_type = xfixed_container<typename storage_type::value_type, S, L, Tag>;
         static constexpr layout_type layout = L;
     };

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1069,7 +1069,7 @@ namespace xt
         using type = C<X, allocator>;
     };
 
-#if defined(__GNUC__) && __GNUC__ > 7 && !defined(__clang__) && __cplusplus > 14
+#if defined(__GNUC__) && __GNUC__ > 7 && !defined(__clang__) && __cplusplus >= 201703L
     template <class X, class T, std::size_t N>
     struct rebind_container<X, std::array<T, N>>
     {

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -319,4 +319,54 @@ namespace xt
 
         delete[] data;
     }
+
+    TEST(xarray_adaptor, short_syntax)
+    {
+        std::vector<int> a({1,2,3,4,5,6,7,8});
+        auto xa = adapt(&a[1], std::vector<std::size_t>({3}));
+        xa(1) = 123;
+
+        EXPECT_EQ(a[2], 123);
+        EXPECT_EQ(xa(2), 4);
+    }
+
+    TEST(xtensor_adaptor, nice_syntax)
+    {
+        std::vector<int> a({1,2,3,4,5,6,7,8});
+#ifndef X_OLD_CLANG
+        auto xa = adapt(&a[0], {2, 4});
+        bool truthy = std::is_same<decltype(xa)::shape_type, std::array<std::size_t, 2>>::value;
+        EXPECT_TRUE(truthy);
+#else
+        auto xa = adapt(&a[0], {2, 4});
+        bool truthy = std::is_same<decltype(xa)::shape_type, xt::dynamic_shape<size_t>>::value;
+        EXPECT_TRUE(truthy);
+#endif
+        xa(0, 0) = 100;
+        xa(1, 3) = 1000;
+        EXPECT_EQ(a[0], 100);
+        EXPECT_EQ(a[7], 1000);
+    }
+
+    TEST(xtensor_fixed_adaptor, adapt)
+    {
+        std::vector<int> a({1,2,3,4,5,6,7,8});
+        auto xa = adapt(&a[0], xshape<2, 4>());
+        xa(0, 0) = 100;
+        xa(1, 3) = 1000;
+        EXPECT_EQ(a[0], 100);
+        EXPECT_EQ(a[7], 1000);
+        bool truthy = std::is_same<decltype(xa)::shape_type, xshape<2, 4>>::value;
+        EXPECT_TRUE(truthy);
+        const std::vector<int> b({5,5,19,5});
+        auto xb = adapt(&b[0], xshape<2, 2>());
+        if (XTENSOR_DEFAULT_LAYOUT == layout_type::row_major)
+        {
+            EXPECT_EQ(xb(1,0), 19);
+        }
+        else
+        {
+            EXPECT_EQ(xb(1,0), 5);
+        }
+    }
 }


### PR DESCRIPTION
This adds adapt overloads for 

- fixed shape type
- unowned pointer + shape (without the size parameter)

This can produce super charged views and is more similar to @tdegeus view implementation.

@tdegeus with this change you could write `xt::adapt(&arr(1, 2, 0, 0), xshape<3, 3>())` to get something as fast as the cppmat view.