### PR TITLE
fix warnings for braces on old clang

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -65,11 +65,11 @@ namespace xt
         {
             XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, C>()
             {
-                return {
+                return xrange_adaptor<A, B, C>({
                     get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
                     get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
                     get_tuph_or_val(rng[2], std::is_same<C, xtuph>())
-                };
+                });
             }
 
             ptrdiff_t rng[3];// = { 0, 0, 0 };
@@ -80,11 +80,11 @@ namespace xt
         {
             XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, xt::placeholders::xtuph>()
             {
-                return {
+                return xrange_adaptor<A, B, xt::placeholders::xtuph>({
                     get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
                     get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
                     xtuph()
-                };
+                });
             }
 
             ptrdiff_t rng[3];  // = { 0, 0, 0 };
@@ -93,7 +93,7 @@ namespace xt
         template <class... OA>
         XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const std::ptrdiff_t& t)
         {
-            auto nrng = rangemaker<OA..., ptrdiff_t>{rng.rng[0], rng.rng[1], rng.rng[2]};
+            auto nrng = rangemaker<OA..., ptrdiff_t>({rng.rng[0], rng.rng[1], rng.rng[2]});
             nrng.rng[sizeof...(OA)] = t;
             return nrng;
         }
@@ -101,13 +101,13 @@ namespace xt
         template <class... OA>
         XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const xt::placeholders::xtuph& /*t*/)
         {
-            auto nrng = rangemaker<OA..., xt::placeholders::xtuph>{rng.rng[0], rng.rng[1], rng.rng[2]};
+            auto nrng = rangemaker<OA..., xt::placeholders::xtuph>({rng.rng[0], rng.rng[1], rng.rng[2]});
             return nrng;
         }
 
 
         XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
-        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r{0, 0, 0};
+        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r({0, 0, 0});
         XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
         XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
         XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -107,7 +107,7 @@ namespace xt
 
 
         XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
-        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r({0, 0, 0});
+        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r = rangemaker<>({0, 0, 0});
         XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
         XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
         XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -875,14 +875,14 @@ namespace xt
             template <class T>
             std::array<std::ptrdiff_t, 3> operator()(const T& /*t*/) const
             {
-                return{ 0, 0, 0 };
+                return std::array<std::ptrdiff_t, 3>({0, 0, 0});
             }
 
             template <class A, class B, class C>
             std::array<std::ptrdiff_t, 3> operator()(const xrange_adaptor<A, B, C>& range) const
             {
                 auto sl = range.get(static_cast<std::size_t>(m_shape[idx]));
-                return{ sl(0), sl.size(), sl.step_size() };
+                return std::array<std::ptrdiff_t, 3>({sl(0), sl.size(), sl.step_size()});
             }
         };
 

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1022,12 +1022,12 @@ namespace xt
     {
         xt::xtensor<size_t, 2> I = {{0, 0}, {1, 1}, {2, 2}};
         auto col = xt::view(I, xt::all(), 0);
-        auto idx = xt::where(xt::equal(col, 0));
+        auto idx = xt::where(xt::equal(col, size_t(0)));
 
         std::array<std::size_t, 1> exp_idx = {0};
         EXPECT_EQ(idx[0], exp_idx);
 
-        auto idx2 = xt::where(col > 0);
+        auto idx2 = xt::where(col > size_t(0));
         EXPECT_EQ(idx2.size(), 2);
         exp_idx[0] = 1;
         EXPECT_EQ(idx2[0], exp_idx);


### PR DESCRIPTION
@tdegeus these were the two places where you pointed me in your issue about warnings for older versions on clang on OS X.

Hope that catches all!? 

