### PR TITLE
Config.cmake now invokes the find_dependency / find_package macro.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ message(STATUS "Building xtensor v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-find_package(xtl 0.4.16 REQUIRED)
+set(xtl_REQUIRED_VERSION 0.4.16)
+find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
 
 message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
 

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -15,6 +15,7 @@ From the master branch of xtensor
 - Make sure that you are in sync with the master branch of the upstream remote.
 - Update the `changelog <https://github.com/QuantStack/xtensor/blob/master/docs/source/changelog.rst>`_.
 - In file ``xtensor_config.hpp``, set the macros for ``XTENSOR_VERSION_MAJOR``, ``XTENSOR_VERSION_MINOR`` and ``XTENSOR_VERSION_PATCH`` to the desired values.
+- In file ``CMakeLists.txt``, update the version of the dependencies and the corresponding variables, e.g. ``xtl_REQUIRED_VERSION``.
 - In file ``environment.yml``, update the version of the dependencies including ``xtensor``.
 - In file ``README.md``, update the dependencies table.
 - Stage the changes (``git add``), commit the changes (``git commit``) and add a tag of the form ``Major.minor.patch``. It is important to not add any other content to the tag name.

--- a/xtensorConfig.cmake.in
+++ b/xtensorConfig.cmake.in
@@ -15,6 +15,9 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(xtl 0.4.14)
+
 if(NOT TARGET @PROJECT_NAME@)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
   get_target_property(@PROJECT_NAME@_INCLUDE_DIRS xtensor INTERFACE_INCLUDE_DIRECTORIES)

--- a/xtensorConfig.cmake.in
+++ b/xtensorConfig.cmake.in
@@ -16,7 +16,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(xtl 0.4.14)
+find_dependency(xtl @xtl_REQUIRED_VERSION@)
 
 if(NOT TARGET @PROJECT_NAME@)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Invoking `find_package(xtensor)` now also automatically invokes `find_package(xtl)` using the `find_dependency` macro in the export config file. In addition it adds far better diagnostics. Prior to this PR if you forgot to link against xtl you get a "can not find include file" compiler warning. With this change you already get an error on the initial CMake configuration run, i.e. before you are even able to compile the code.

Remember that future releases must also adjust the package version in the `xtensorConfig.cmake.in`. I know it adds boilerplate code, but the benefits outweigh this.