### PR TITLE
add missing parenthesis around std::min and std::max

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -511,7 +511,7 @@ namespace xt
         {
             std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
             val = (val >= 0) ? val : val + size;
-            return std::max(std::ptrdiff_t(0), std::min(size, val));
+            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
         }
 
         auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, std::ptrdiff_t step, std::size_t ssize) const
@@ -522,13 +522,13 @@ namespace xt
 
             if(step > 0)
             {
-                start = std::max(std::ptrdiff_t(0), std::min(size, start));
-                stop  = std::max(std::ptrdiff_t(0), std::min(size, stop));
+                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
+                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
             }
             else
             {
-                start = std::max(std::ptrdiff_t(-1), std::min(size - 1, start));
-                stop  = std::max(std::ptrdiff_t(-1), std::min(size - 1, stop));
+                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
+                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
             }
 
             return xstepped_range<std::ptrdiff_t>(start, stop, step);

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -1000,7 +1000,7 @@ namespace xt
     template <std::size_t N, class E>
     auto atleast_Nd(E&& e)
     {
-        xstrided_slice_vector sv(std::max(e.dimension(), N), all());
+        xstrided_slice_vector sv((std::max)(e.dimension(), N), all());
         if (e.dimension() < N)
         {
             std::size_t i = 0;


### PR DESCRIPTION
Add some missing parenthesis around `std::min` and `std::max` necessary to compile with
MSVC without the `NOMINMAX` definition, see https://github.com/QuantStack/xtensor/blob/0f636b08eb7618744867396e04dc7fda179cfb8d/docs/source/compilers.rst#visual-studio-and-min-and-max-macros.

