### PR TITLE
remove const from closure type in xfunction

### DIFF
--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -240,7 +240,7 @@ namespace xt
             using functor_type = build_functor_type_t<expression_tag, F, E...>;
             using type = select_xfunction_expression_t<expression_tag,
                 functor_type,
-                const_xclosure_t<E>...>;
+                xclosure_t<E>...>;
         };
 
         template <template <class...> class F, class... E>

--- a/test/test_xnpy.cpp
+++ b/test/test_xnpy.cpp
@@ -107,4 +107,13 @@ namespace xt
         EXPECT_TRUE(compare_binary_files(filename, compare_name));
         std::remove(filename.c_str());
     }
+
+    TEST(xnpy, xfunction_cast)
+    {
+        // compilation test, cf: https://github.com/QuantStack/xtensor/issues/1070
+        auto dc = cast<char>(load_npy<double>("files/xnpy_files/double.npy"));
+        EXPECT_EQ(dc(0, 0), 0);
+        xarray<char> adc = dc;
+        EXPECT_EQ(adc(0, 0), 0);
+    }
 }


### PR DESCRIPTION
This fixes #1070 

Another way of fixing this would be to not add a const to value types...

This was the only place where we're using const_closure.