### PR TITLE
Replace parens with braces to compile aggregate

### DIFF
--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -875,7 +875,7 @@ namespace xt
             template <class T>
             std::array<std::ptrdiff_t, 3> operator()(const T& /*t*/) const
             {
-                return std::array<std::ptrdiff_t, 3>({0, 0, 0});
+                return std::array<std::ptrdiff_t, 3>{{0, 0, 0}};
             }
 
             template <class A, class B, class C>


### PR DESCRIPTION
Fixes the following issue in clang:

```
In file included from /Users/ray_zhang/anaconda3/envs/idp3/include/xtensor/xarray.hpp:19:
In file included from /Users/ray_zhang/anaconda3/envs/idp3/include/xtensor/xcontainer.hpp:23:
In file included from /Users/ray_zhang/anaconda3/envs/idp3/include/xtensor/xmath.hpp:27:
In file included from /Users/ray_zhang/anaconda3/envs/idp3/include/xtensor/xstrided_view.hpp:26:
/Users/ray_zhang/anaconda3/envs/idp3/include/xtensor/xstrided_view_base.hpp:878:55: error: cannot compile this aggregate expression yet
                return std::array<std::ptrdiff_t, 3>({0, 0, 0});
```