### PR TITLE
Fixing valgrind notifications

### DIFF
--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -378,7 +378,6 @@ namespace xt
         inline auto xbuffer_owner_storage<CP, A>::operator=(self_type&& rhs) -> self_type&
         {
             swap(rhs);
-            rhs.m_moved_from = true;
             return *this;
         }
 

--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -482,7 +482,7 @@ namespace xt
                 // Allocate memory
                 m_word_size = std::size_t(atoi(&typestring[2]));
                 m_n_bytes = compute_size(shape) * m_word_size;
-                m_buffer = new char[m_n_bytes];
+                m_buffer = std::allocator<char>{}.allocate(m_n_bytes);
             }
 
             ~npy_file()

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1161,7 +1161,9 @@ namespace xt
         else
         {
             // If this wasn't grown from the inline copy, grow the allocated space.
-            new_alloc = reinterpret_cast<pointer>(realloc(this->m_begin, new_capacity * sizeof(T)));
+            new_alloc = m_allocator.allocate(new_capacity);
+            std::uninitialized_copy(m_begin, m_end, new_alloc);
+            m_allocator.deallocate(m_begin, std::size_t(m_capacity - m_begin));
         }
         XTENSOR_ASSERT(new_alloc);
 

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -63,8 +63,8 @@ namespace xt
     TEST(xarray_adaptor, pointer_acquire_ownership)
     {
         size_t size = 4;
-        int* data = new int[size];
-        int* data2 = new int[size];
+        int* data = std::allocator<int>{}.allocate(size);
+        int* data2 =  std::allocator<int>{}.allocate(size);;
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({2, 2});
 
@@ -97,9 +97,9 @@ namespace xt
     TEST(xarray_adaptor, acquire_ownership_assign)
     {
         size_t size = 1;
-        int* data1 = new int[1];
+        int* data1 = std::allocator<int>{}.allocate(1);
         data1[0] = 0;
-        int* data2 = new int[1];
+        int* data2 = std::allocator<int>{}.allocate(1);
         data2[0] = 1;
         int* data3 = nullptr;
         using shape_type = std::vector<vec_type::size_type>;
@@ -210,9 +210,9 @@ namespace xt
     TEST(xtensor_adaptor, pointer_acquire_ownership)
     {
         size_t size = 4;
-        int* data0 = new int[size];
-        int* data1 = new int[size];
-        int* data2 = new int[size];
+        int* data0 = std::allocator<int>{}.allocate(size);
+        int* data1 = std::allocator<int>{}.allocate(size);
+        int* data2 = std::allocator<int>{}.allocate(size);
 
         auto a0 = adapt(data0, size, acquire_ownership());
         a0(3) = 3;
@@ -234,8 +234,8 @@ namespace xt
     TEST(xtensor_adaptor, move_pointer_acquire_ownership)
     {
         size_t size = 4;
-        int* data = new int[size];
-        int* data2 = new int[size];
+        int* data = std::allocator<int>{}.allocate(size);
+        int* data2 = std::allocator<int>{}.allocate(size);
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
@@ -290,9 +290,9 @@ namespace xt
     TEST(xtensor_adaptor, acquire_ownership_assign)
     {
         size_t size = 1;
-        int* data1 = new int[1];
+        int* data1 = std::allocator<int>{}.allocate(size);
         data1[0] = 0;
-        int* data2 = new int[1];
+        int* data2 = std::allocator<int>{}.allocate(size);
         data2[0] = 1;
         int* data3 = nullptr;
         using shape_type = std::array<vec_type::size_type, 1>;

--- a/test/test_xbuffer_adaptor.cpp
+++ b/test/test_xbuffer_adaptor.cpp
@@ -12,12 +12,13 @@
 namespace xt
 {
     using buffer_adaptor = xbuffer_adaptor<double*>;
+    using allocator = std::allocator<double>;
     using owner_adaptor = xbuffer_adaptor<double*&, acquire_ownership>;
 
     TEST(xbuffer_adaptor, owner_destructor)
     {
         size_t size = 100;
-        double* data = new double[size];
+        double* data = allocator{}.allocate(size);
         owner_adaptor adapt(data, size);
         EXPECT_EQ(data, adapt.data());
     }
@@ -25,7 +26,7 @@ namespace xt
     TEST(xbuffer_adaptor, owner_move)
     {
         size_t size = 100;
-        double* data = new double[size];
+        double* data = allocator{}.allocate(size);
         owner_adaptor adapt(data, size);
 
         owner_adaptor adapt2(std::move(adapt));
@@ -37,12 +38,12 @@ namespace xt
     TEST(xbuffer_adaptor, owner_copy_assign)
     {
         size_t size1 = 100;
-        double* data1 = new double[size1];
+        double* data1 = allocator{}.allocate(size1);
         data1[0] = 2.5;
         owner_adaptor adapt1(data1, size1);
 
         size_t size2 = 200;
-        double* data2 = new double[size2];
+        double* data2 = allocator{}.allocate(size2);
         data2[0] = 1.2;
         owner_adaptor adapt2(data2, size2);
 
@@ -54,12 +55,12 @@ namespace xt
     TEST(xbuffer_adaptor, owner_move_assign)
     {
         size_t size1 = 100;
-        double* data1 = new double[size1];
+        double* data1 = allocator{}.allocate(size1);
         data1[0] = 2.5;
         owner_adaptor adapt1(data1, size1);
 
         size_t size2 = 200;
-        double* data2 = new double[size2];
+        double* data2 = allocator{}.allocate(size2);
         data2[0] = 1.2;
         owner_adaptor adapt2(data2, size2);
 
@@ -71,7 +72,7 @@ namespace xt
     TEST(xbuffer_adaptor, owner_resize)
     {
         size_t size1 = 100;
-        double* data1 = new double[size1];
+        double* data1 = allocator{}.allocate(size1);
         owner_adaptor adapt(data1, size1);
 
         size_t size2 = 50;
@@ -83,7 +84,7 @@ namespace xt
     TEST(xbuffer_adaptor, owner_iterating)
     {
         size_t size = 100;
-        double* data = new double[size];
+        double* data = allocator{}.allocate(size);
         owner_adaptor adapt(data, size);
 
         std::fill(adapt.begin(), adapt.end(), 1.2);

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -84,8 +84,8 @@ namespace xt
         EXPECT_EQ(masked_data(2, 1), 8.);
         EXPECT_EQ(masked_data(2, 2), 9.);
 
-#ifndef XTENSOR_ENABLE_ASSERT
-        masked_data(3, 3);
+#ifdef XTENSOR_ENABLE_ASSERT
+        EXPECT_ANY_THROW(masked_data(3, 3));
 #endif
     }
 
@@ -122,8 +122,8 @@ namespace xt
         EXPECT_EQ(masked_data.unchecked(2, 1), 8.);
         EXPECT_EQ(masked_data.unchecked(2, 2), 9.);
 
-#ifndef XTENSOR_ENABLE_ASSERT
-        masked_data.unchecked(3, 3);
+#ifdef XTENSOR_ENABLE_ASSERT
+        EXPECT_ANY_THROW(masked_data.unchecked(3, 3));
 #endif
     }
 

--- a/test/test_xoptional_assembly.cpp
+++ b/test/test_xoptional_assembly.cpp
@@ -347,6 +347,7 @@ namespace xt
         row_major_result<> rm;
         dyn_opt_ass_type vec;
         vec.resize(rm.m_shape, layout_type::row_major);
+        vec.fill(123);
         vec(1, 1, 0) = rm.m_assigner[1][1][0];
         vec.value()[0] = 4;
         size_t nb_iter = vec.size() / 2;

--- a/test/test_xoptional_assembly_adaptor.cpp
+++ b/test/test_xoptional_assembly_adaptor.cpp
@@ -254,6 +254,7 @@ namespace xt
         row_major_result<> rm;
         array_type a;
         a.resize(rm.m_shape, layout_type::row_major);
+        a.fill(0);
         a(1, 1, 0) = rm.m_assigner[1][1][0];
         a[0] = 4;
         flag_array_type fa(rm.m_shape, true);

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -831,7 +831,7 @@ namespace xt
     TEST(xview, to_scalar)
     {
         std::array<std::size_t, 3> sh{2,2,2};
-        xtensor<double, 3> a(sh);
+        xtensor<double, 3> a(sh, 123);
         xtensor_fixed<double, xshape<2, 2, 2>> af = a;
         xarray<double> b = a;
 


### PR DESCRIPTION
With these changes valgrind stops complaining.

The big ones: not using realloc in svector anymore. This might hit performance somewhat but I think it's better to have a clean valgrind output.

Use the std::allocator to allocate memory for the owning buffer. That one is a bit annoying but I think warranted for library functions. Otherwise you get an error because of a mismatch between `free` and `new ... []` where valgrind wants one to use the corresponding `delete[]` instead of `free` or whatever the allocator is using.

The workaround would be to write a shim allocator that calls dealloc with `delete[]`

There was also some tiny bugs in the tests as well as one memory leak with move assignment on owning buffers.