### PR TITLE
Apply #1038 also to GCC7

### DIFF
--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1413,7 +1413,7 @@ namespace xt
 
 
 // Workaround for rebind_container problems on GCC 8  with C++17 enabled
-#if defined(__GNUC__) && __GNUC__ > 7 && !defined(__clang__) && __cplusplus >= 201703L
+#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__) && __cplusplus >= 201703L
     template <class X, class T, std::size_t N>
     struct rebind_container<X, aligned_array<T, N>>
     {

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1155,7 +1155,7 @@ namespace xt
         using type = C<X, allocator>;
     };
 
-#if defined(__GNUC__) && __GNUC__ > 7 && !defined(__clang__) && __cplusplus >= 201703L
+#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__) && __cplusplus >= 201703L
     template <class X, class T, std::size_t N>
     struct rebind_container<X, std::array<T, N>>
     {


### PR DESCRIPTION
When compiling with GCC7 and C++17 we see the same issues at GCC8 w/ rebind_container. 


Tested w/ GCC7 C++17 and this changeset still works.