### PR TITLE
cmake: Remove warnings for gtest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 find_package(Threads)
 
-include_directories(${GTEST_INCLUDE_DIRS})
+include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
 
 set(COMMON_BASE
     main.cpp


### PR DESCRIPTION
Add flag SYSTEM to `include_directories` for gtest
This omits warnings generated in gtest code-base

Reference: https://cmake.org/cmake/help/latest/command/include_directories.html