### PR TITLE
Fix issue with has_simd_interface

### DIFF
--- a/include/xtensor/xtensor_simd.hpp
+++ b/include/xtensor/xtensor_simd.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "xstorage.hpp"
+#include "xutils.hpp"
 
 #ifdef XTENSOR_USE_XSIMD
 
@@ -165,6 +166,17 @@ namespace xt
 
     template <class A1, class A2>
     using driven_align_mode_t = typename detail::driven_align_mode_impl<A1, A2>::type;
+
+    template <class E, class = void>
+    struct has_simd_interface : std::false_type
+    {
+    };
+
+    template <class E>
+    struct has_simd_interface<E, void_t<decltype(std::declval<E>().template load_simd<aligned_mode>(typename E::size_type(0)))>>
+        : std::true_type
+    {
+    };
 }
 
 #endif

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -672,17 +672,6 @@ namespace xt
     {
     };
 
-    template <class E, class = void>
-    struct has_simd_interface : std::false_type
-    {
-    };
-
-    template <class E>
-    struct has_simd_interface<E, void_t<decltype(std::declval<E>().template load_simd<aligned_mode>(typename E::size_type(0)))>>
-        : std::true_type
-    {
-    };
-
     /******************
      * enable_if_type *
      ******************/


### PR DESCRIPTION
When including xutils.hpp,  we were getting an error ```aligned_mode is not declared in this scope```