### PR TITLE
upgrade to xsimd 6.2.0, switch to trusty and fix appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ platform:
   - x86
 
 image:
-  - Visual Studio 2017
+  - Previous Visual Studio 2017
   - Visual Studio 2015
 
 environment:
@@ -16,8 +16,8 @@ init:
   - "ECHO %MINICONDA%"
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x64" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Previous Visual Studio 2017" if "%PLATFORM%" == "x64" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Previous Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - echo "%VCVARPATH% %VCARGUMENT%"
   - "%VCVARPATH% %VCARGUMENT%"
   - ps: if($env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: precise
+dist: trusty
 env:
 matrix:
   fast_finish: true
@@ -49,26 +49,17 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
           packages:
+            - g++-4.9
             - clang-3.6
-      env: COMPILER=clang CLANG=3.6 DISABLE_XSIMD=1
+      env: COMPILER=clang CLANG=3.6 
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
           packages:
-            - clang-3.7
-      env: COMPILER=clang CLANG=3.7 ENABLE_TBB=1 DISABLE_XSIMD=1
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
+            - g++-4.9
             - clang-3.8
       env: COMPILER=clang CLANG=3.8
     - os: linux
@@ -76,10 +67,40 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
+            - llvm-toolchain-trusty-3.9
           packages:
+            - g++-4.9
             - clang-3.9
       env: COMPILER=clang CLANG=3.9
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - g++-4.9
+            - clang-4.0
+      env: COMPILER=clang CLANG=4.0 DISABLE_XSIMD=1
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - g++-4.9
+            - clang-5.0
+      env: COMPILER=clang CLANG=5.0 ENABLE_TBB=1 DISABLE_XSIMD=1
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env: COMPILER=clang CLANG=6.0
     - os: osx
       osx_image: xcode8
       compiler: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 
 if(XTENSOR_USE_XSIMD)
     add_definitions(-DXTENSOR_USE_XSIMD)
-    find_package(xsimd 6.1.4 REQUIRED)
+    find_package(xsimd 6.2.0 REQUIRED)
     message(STATUS "Found xsimd: ${xsimd_INCLUDE_DIRS}/xsimd")
     target_link_libraries(xtensor INTERFACE xsimd)
 endif()


### PR DESCRIPTION
`llvm-toolchain-precise-x.y` have been recently [removed ](https://github.com/travis-ci/apt-source-safelist/commit/e9d632eb79c7b733b3bfe722356e892ab8e06059#diff-18834b11de5fbd14772e186aecd6c14b) from apt source safelist, so testing with clang on precise environment is no longer possible.

A solution would be to switch to trusty environment, but clang 3.6, 3.7 and 3.8 are not available in [apt source safelist](https://github.com/travis-ci/apt-source-safelist) on trusty environment, thus we would drop support for these compilers (I'm fine with that, we could remove a lot of workarounds for old clang)

For clang 3.9, 4.0 and 5.0 we face the issue described [here](https://github.com/QuantStack/xtensor/pull/384), however forcing the use of gcc 4.9 fixes the problem.

cc @SylvainCorlay @wolfv 