### PR TITLE
[xcontainer/xstrides] Add negative reshaping axis

### DIFF
--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -106,11 +106,25 @@ namespace xt
      * Implementation *
      ******************/
 
+    namespace detail
+    {
+        template <class shape_type>
+        inline std::size_t compute_size_impl(const shape_type& shape, std::true_type /* is signed */) {
+            using size_type = std::decay_t<typename shape_type::value_type>;
+            return static_cast<std::size_t>(std::abs(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>())));
+        }
+
+        template <class shape_type>
+        inline std::size_t compute_size_impl(const shape_type& shape, std::false_type /* is not signed */) {
+            using size_type = std::decay_t<typename shape_type::value_type>;
+            return static_cast<std::size_t>(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>()));
+        }
+    }
+
     template <class shape_type>
     inline std::size_t compute_size(const shape_type& shape) noexcept
     {
-        using size_type = std::decay_t<typename shape_type::value_type>;
-        return static_cast<std::size_t>(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>()));
+        return detail::compute_size_impl(shape, std::is_signed<std::decay_t<typename std::decay_t<shape_type>::value_type>>());
     }
 
     namespace detail

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -226,6 +226,15 @@ namespace xt
             vec.resize(shape);
             vec.reshape(rm.m_shape, layout_type::row_major);
             compare_shape(vec, rm);
+            // --- new test
+            dynamic_shape<signed long long> signed_shape;
+            std::copy(rm.m_shape.begin(), rm.m_shape.end(), std::back_inserter(signed_shape));
+            // Will infer as sz
+            signed_shape[1] = -1;
+            vec.resize(shape);
+            vec.reshape(signed_shape, layout_type::row_major);
+            compare_shape(vec, rm);
+            // ---
             shape = rm.m_shape;
             shape.front() += 123;
             EXPECT_THROW(vec.reshape(shape), std::runtime_error);


### PR DESCRIPTION
Check negative reshape argument. As per numpy:

> One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.

This addresses: https://github.com/QuantStack/xtensor/issues/1115