### PR TITLE
Add amax/amin to documentation

### DIFF
--- a/docs/source/api/reducing_functions.rst
+++ b/docs/source/api/reducing_functions.rst
@@ -27,6 +27,14 @@ Defined in ``xtensor/xmath.hpp``
 .. doxygenfunction:: diff(const xexpression<T>&, unsigned int, std::ptrdiff_t)
    :project: xtensor
 
+.. _amax-function-reference:
+.. doxygenfunction:: amax(E&&, X&&, EVS)
+   :project: xtensor
+
+.. _amin-function-reference:
+.. doxygenfunction:: amin(E&&, X&&, EVS)
+   :project: xtensor
+
 .. _trapz-function-reference:
 .. doxygenfunction:: trapz(const xexpression<T>&, double, std::ptrdiff_t)
    :project: xtensor

--- a/docs/source/api/xmath.rst
+++ b/docs/source/api/xmath.rst
@@ -256,6 +256,10 @@ Mathematical functions
 +----------------------------------------+---------------------------------------------------------------------+
 | :ref:`diff <diff-function-reference>`  | Calculate the n-th discrete difference along the given axis         |
 +----------------------------------------+---------------------------------------------------------------------+
+| :ref:`amax <amax-function-reference>`  | amax of elements over given axes                                    |
++----------------------------------------+---------------------------------------------------------------------+
+| :ref:`amin <amin-function-reference>`  | amin of elements over given axes                                    |
++----------------------------------------+---------------------------------------------------------------------+
 | :ref:`trapz <trapz-function-reference>`| Integrate along the given axis using the composite trapezoidal rule |
 +----------------------------------------+---------------------------------------------------------------------+
 | :ref:`norm_l0 <norm-l0-func-ref>`      | L0 pseudo-norm over given axes                                      |


### PR DESCRIPTION
I was looking through the code to see if there were any reducing min/max functions and found `amax` and `amin` in the code but not the documentation.