### PR TITLE
Modify shuffle to use identical algorithms for any number of dimensions

### DIFF
--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -261,12 +261,13 @@ namespace xt
 
             if (de.dimension() == 1)
             {
+                using size_type = typename T::size_type;
                 auto first = de.storage().begin();
                 auto last = de.storage().end();
 
-                for (auto i = (last - first) - 1; i > 0; --i)
+                for (size_type i = (last - first) - 1; i > 0; --i)
                 {
-                    std::uniform_int_distribution<decltype(i)> dist(0, i);
+                    std::uniform_int_distribution<size_type> dist(0, i);
                     auto j = dist(engine);
                     using std::swap;
                     swap(first[i], first[j]);

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -262,8 +262,8 @@ namespace xt
             if (de.dimension() == 1)
             {
                 using size_type = typename T::size_type;
-                auto first = de.storage().begin();
-                auto last = de.storage().end();
+                auto first = de.begin();
+                auto last = de.end();
 
                 for (size_type i = (last - first) - 1; i > 0; --i)
                 {

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -261,7 +261,16 @@ namespace xt
 
             if (de.dimension() == 1)
             {
-                std::shuffle(de.storage().begin(), de.storage().end(), engine);
+                auto first = de.storage().begin();
+                auto last = de.storage().end();
+
+                for (auto i = (last - first) - 1; i > 0; --i)
+                {
+                    std::uniform_int_distribution<decltype(i)> dist(0, i);
+                    auto j = dist(engine);
+                    using std::swap;
+                    swap(first[i], first[j]);
+                }
             }
             else
             {

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -82,6 +82,15 @@ namespace xt
         xt::random::shuffle(a);
         EXPECT_FALSE(std::is_sorted(a.begin(), a.end()));
 
+        xarray<double> b = a;
+        b.resize({b.size(), 1});
+        xt::random::seed(42);
+        xt::random::shuffle(a);
+        xt::random::seed(42);
+        xt::random::shuffle(b);
+        b.resize({b.size()});
+        EXPECT_EQ(a, b);
+
         a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
         a.reshape({3, 4});
         auto ar = a;


### PR DESCRIPTION
For reasons unknown at the moment, `std::uniform_int_distribution` generates different sequences for linux and non-linux environments while `std::shuffle` generates identical permutations. In order to produce identical permutations for arrays of arbitrary rank the one-dimension specialization should execute an algorithm analogous to the multi-dimension specialization. This code should have little if any compromise on performance (as it should pretty much be what the STL implements).

Additions to the test code were made to compare the results of shuffling arrays with the same leading dimensions.