### PR TITLE
add resize / reshape to xfixed_adaptor

### DIFF
--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -419,6 +419,8 @@ namespace xt
         using temporary_type = typename semantic_base::temporary_type;
         using expression_tag = Tag;
 
+        constexpr static std::size_t N = S::size();
+
         xfixed_adaptor(storage_type&& data);
         xfixed_adaptor(const storage_type& data);
 
@@ -436,6 +438,19 @@ namespace xt
 
         template <class E>
         xfixed_adaptor& operator=(const xexpression<E>& e);
+
+        template <class ST = std::array<std::size_t, N>>
+        void resize(ST&& shape, bool force = false) const;
+        template <class ST = shape_type>
+        void resize(ST&& shape, layout_type l) const;
+        template <class ST = shape_type>
+        void resize(ST&& shape, const strides_type& strides) const;
+
+        template <class ST = std::array<std::size_t, N>>
+        void reshape(ST&& shape, layout_type layout = L) const;
+
+        template <class ST>
+        bool broadcast_shape(ST& s, bool reuse_cache = false) const;
 
         constexpr layout_type layout() const noexcept;
 
@@ -777,6 +792,65 @@ namespace xt
         return semantic_base::operator=(e);
     }
     //@}
+
+    /**
+     * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
+     * size throws an assert in debug mode.
+     */
+    template <class ET, class S, layout_type L, class Tag>
+    template <class ST>
+    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, bool) const
+    {
+        (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
+        XTENSOR_ASSERT(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size());
+    }
+
+    /**
+     * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
+     * size throws an assert in debug mode.
+     */
+    template <class ET, class S, layout_type L, class Tag>
+    template <class ST>
+    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, layout_type l) const
+    {
+        (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
+        (void)(l);
+        XTENSOR_ASSERT(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && L == l);
+    }
+
+    /**
+     * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
+     * size throws an assert in debug mode.
+     */
+    template <class ET, class S, layout_type L, class Tag>
+    template <class ST>
+    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, const strides_type& strides) const
+    {
+        (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
+        (void)(strides);
+        XTENSOR_ASSERT(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size());
+        XTENSOR_ASSERT(std::equal(strides.begin(), strides.end(), m_strides.begin()) && strides.size() == m_strides.size());
+    }
+
+    /**
+     * Note that the xfixed_container **cannot** be reshaped to a shape different from ``S``.
+     */
+    template <class ET, class S, layout_type L, class Tag>
+    template <class ST>
+    inline void xfixed_adaptor<ET, S, L, Tag>::reshape(ST&& shape, layout_type layout) const
+    {
+        if (!(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && layout == L))
+        {
+            throw std::runtime_error("Trying to reshape xtensor_fixed with different shape or layout.");
+        }
+    }
+
+    template <class ET, class S, layout_type L, class Tag>
+    template <class ST>
+    inline bool xfixed_adaptor<ET, S, L, Tag>::broadcast_shape(ST& shape, bool) const
+    {
+        return xt::broadcast_shape(m_shape, shape);
+    }
 
     template <class EC, class S, layout_type L, class Tag>
     inline auto xfixed_adaptor<EC, S, L, Tag>::storage_impl() noexcept -> storage_type&

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -16,6 +16,7 @@
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
+#include "xtensor/xnoalias.hpp"
 
 // On VS2015, when compiling in x86 mode, alignas(T) leads to C2718
 // when used for a function parameter, even indirectly. This means that
@@ -251,10 +252,22 @@ namespace xt
         truth = std::is_same<typename decltype(fx2)::shape_type, xshape<3, 2, 4, 10, 5>>::value;
         EXPECT_TRUE(truth);
 
-        // xtensor_fixed<char, xshape<   2, 1, 10, 5>> xc;
-        // auto fx3 = xa * xc;
-        // truth = std::is_same<typename decltype(fx3)::shape_type, xshape<2, 1, 10, 5>>::value;
-        // EXPECT_TRUE(truth);
+        xtensor_fixed<char, xshape<   2, 1, 10, 5>> xc;
+        auto fx3 = xa * xc;
+        truth = std::is_same<typename decltype(fx3)::shape_type, xshape<2, 1, 10, 5>>::value;
+        EXPECT_TRUE(truth);
+    }
+
+    TEST(xtensor_fixed, adaptor_function_assignment)
+    {
+        xt::xtensor<double, 4> a_Eps  = xt::zeros<double>({2, 2, 2, 2});
+        xt::xtensor<double, 4> a_Epsd = xt::zeros<double>({2, 2, 2, 2});
+        std::size_t e = 0, k = 1;
+        auto Eps  = xt::adapt(&a_Eps (e, k, 0, 0), xt::xshape<2, 2>());
+        auto Epsd = xt::adapt(&a_Epsd(e, k, 0, 0), xt::xshape<2, 2>());
+
+        xt::noalias(Eps) = Epsd * 123;
+        // Eps = Epsd * 123; <-- Enable after XTL release!
     }
 }
 


### PR DESCRIPTION
@tdegeus this fixes the issue #1144 for the version with `xt::noalias`. 

In order to fix the version without noalias, we'll have to do a release of `xtl` unfortunately.