### PR TITLE
warnings removed

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -1192,8 +1192,10 @@ namespace xt
     inline xkeep_slice<T>::operator xkeep_slice<S>() const noexcept
     {
         xkeep_slice<S> ret;
-        ret.m_raw_indices.resize(size());
-        ret.m_indices.resize(size());
+        using us_type = typename container_type::size_type;
+        us_type sz = static_cast<us_type>(size());
+        ret.m_raw_indices.resize(sz);
+        ret.m_indices.resize(sz);
         std::transform(m_raw_indices.cbegin(), m_raw_indices.cend(), ret.m_raw_indices.begin(),
                        [](const T& val) { return static_cast<S>(val); });
         std::transform(m_indices.cbegin(), m_indices.cend(), ret.m_indices.begin(),

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -397,25 +397,25 @@ namespace xt
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view<CT, S, L, FST>::storage_begin() -> storage_iterator
     {
-        return this->storage().begin() + data_offset();
+        return this->storage().begin() + static_cast<std::ptrdiff_t>(data_offset());
     }
 
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view<CT, S, L, FST>::storage_end() -> storage_iterator
     {
-        return this->storage().begin() + data_offset() + size();
+        return this->storage().begin() + static_cast<std::ptrdiff_t>(data_offset() + size());
     }
 
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view<CT, S, L, FST>::storage_cbegin() const -> const_storage_iterator
     {
-        return this->storage().cbegin() + data_offset();
+        return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset());
     }
 
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view<CT, S, L, FST>::storage_cend() const -> const_storage_iterator
     {
-        return this->storage().cbegin() + data_offset() + size();
+        return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset() + size());
     }
 
     /***************

--- a/test/files/cppy_source/test_extended_broadcast_view.cppy
+++ b/test/files/cppy_source/test_extended_broadcast_view.cppy
@@ -39,7 +39,7 @@ namespace xt
         auto av3 = xt::strided_view(py_a, {_r|-1|-4|-1, _r|-3|1|-2});
         EXPECT_EQ(av3, py_av3);
         auto av4 = xt::strided_view(py_a, {_r|-3|-5, _r|-3|10});
-        EXPECT_EQ(av4.size(), 0);
+        EXPECT_EQ(av4.size(), size_t(0));
         // py_av5 = a[-5:-2, -3:10]
         auto av5 = xt::strided_view(py_a, {_r|-5|-2, _r|-3|10});
         EXPECT_EQ(av5, py_av5);

--- a/test/files/cppy_source/test_extended_xhistogram.cppy
+++ b/test/files/cppy_source/test_extended_xhistogram.cppy
@@ -39,9 +39,9 @@ namespace xt
 
         auto prob = xt::histogram(py_a, bin_edges, true);
 
-        EXPECT_EQ(bin_edges, py_bin_edges);
+        EXPECT_EQ(xt::cast<double>(bin_edges), py_bin_edges);
 
-        EXPECT_EQ(count, py_count);
+        EXPECT_EQ(count, xt::cast<double>(py_count));
 
         EXPECT_EQ(prob, py_prob);
     }

--- a/test/test_extended_broadcast_view.cpp
+++ b/test/test_extended_broadcast_view.cpp
@@ -58,7 +58,7 @@ namespace xt
         auto av3 = xt::strided_view(py_a, {_r|-1|-4|-1, _r|-3|1|-2});
         EXPECT_EQ(av3, py_av3);
         auto av4 = xt::strided_view(py_a, {_r|-3|-5, _r|-3|10});
-        EXPECT_EQ(av4.size(), 0);
+        EXPECT_EQ(av4.size(), size_t(0));
         // py_av5 = a[-5:-2, -3:10]
         xarray<double> py_av5 = {{ 4., 5., 6.},
                                  {11.,12.,13.},

--- a/test/test_extended_xhistogram.cpp
+++ b/test/test_extended_xhistogram.cpp
@@ -94,9 +94,9 @@ namespace xt
 
         auto prob = xt::histogram(py_a, bin_edges, true);
 
-        EXPECT_EQ(bin_edges, py_bin_edges);
+        EXPECT_EQ(xt::cast<double>(bin_edges), py_bin_edges);
 
-        EXPECT_EQ(count, py_count);
+        EXPECT_EQ(count, xt::cast<double>(py_count));
 
         EXPECT_EQ(prob, py_prob);
     }

--- a/test/test_xdynamic_view.cpp
+++ b/test/test_xdynamic_view.cpp
@@ -208,7 +208,7 @@ namespace xt
         xkeep_slice<std::ptrdiff_t> ks({ 2, 3, -1 });
         ks.normalize(6);
         xkeep_slice<std::size_t> ku(ks);
-        EXPECT_EQ(ku.size(), 3);
+        EXPECT_EQ(ku.size(), std::size_t(3));
         EXPECT_FALSE(ku.contains(0));
         EXPECT_FALSE(ku.contains(1));
         EXPECT_TRUE(ku.contains(2));
@@ -219,7 +219,7 @@ namespace xt
         xdrop_slice<std::ptrdiff_t> ds({ 2, 3, -1 });
         ds.normalize(6);
         xdrop_slice<std::size_t> du(ds);
-        EXPECT_EQ(du.size(), 3);
+        EXPECT_EQ(du.size(), std::size_t(3));
         EXPECT_TRUE(du.contains(0));
         EXPECT_TRUE(du.contains(1));
         EXPECT_FALSE(du.contains(2));

--- a/test/test_xexpression.cpp
+++ b/test/test_xexpression.cpp
@@ -29,7 +29,7 @@ namespace xt
 
         auto sa = make_xshared(std::move(a));
 
-        EXPECT_EQ(sa.dimension(), 2);
+        EXPECT_EQ(sa.dimension(), std::size_t(2));
         EXPECT_EQ(sa.shape(), ca.shape());
         EXPECT_EQ(sa.strides(), ca.strides());
         EXPECT_EQ(sa(1, 3), ca(1, 3));

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -118,7 +118,7 @@ namespace xt
         EXPECT_EQ(sc[1], 3u);
         EXPECT_EQ(sc[2], 12u);
 
-        std::array<std::size_t, 3> ts1 = {1, 5, 3}, tt1;
+        std::array<std::ptrdiff_t, 3> ts1 = {1, 5, 3}, tt1;
 
         auto sc2 = get_strides<layout_type::column_major, const_array<ptrdiff_t, 3>>(xshape<1, 5, 3>());
         compute_strides(ts1, layout_type::column_major, tt1);

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -23,7 +23,7 @@ namespace xt
         {
             xt::xtensor<double,1> count = xt::histogram(data, std::size_t(2));
 
-            EXPECT_EQ(count.size(), 2 );
+            EXPECT_EQ(count.size(), std::size_t(2) );
             EXPECT_EQ(count[0]    , 2.);
             EXPECT_EQ(count[1]    , 2.);
         }
@@ -33,7 +33,7 @@ namespace xt
                 xt::histogram_bin_edges(data, std::size_t(2), xt::histogram_algorithm::uniform)
             );
 
-            EXPECT_EQ(count.size(), 2 );
+            EXPECT_EQ(count.size(), std::size_t(2));
             EXPECT_EQ(count[0]    , 2.);
             EXPECT_EQ(count[1]    , 2.);
         }
@@ -51,7 +51,7 @@ namespace xt
         EXPECT_EQ(bc2, expc * 3);
 
         auto bc3 = bincount(data, 10);
-        EXPECT_EQ(bc3.size(), 10);
+        EXPECT_EQ(bc3.size(), std::size_t(10));
         EXPECT_EQ(bc3(3), expc(3));
     }
 }

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -120,7 +120,7 @@ namespace xt
         EXPECT_EQ(s2[0].shape(), ds({3, 3, 3}));
 
         auto s3 = split(b, 3, 1);
-        EXPECT_EQ(s3.size(), 3);
+        EXPECT_EQ(s3.size(), std::size_t(3));
         EXPECT_EQ(s3[0].shape(), ds({3, 1, 3}));
 
         EXPECT_EQ(s3[0](0, 1), b(0, 0, 1));
@@ -216,17 +216,17 @@ namespace xt
         arr_t edb = {1, 0, 0, 1};
 
         EXPECT_EQ(trim_zeros(a), ea);
-        EXPECT_EQ(trim_zeros(b).size(), 0);
+        EXPECT_EQ(trim_zeros(b).size(), std::size_t(0));
         EXPECT_EQ(trim_zeros(c), ec);
         EXPECT_EQ(trim_zeros(d), ed);
 
         EXPECT_EQ(trim_zeros(a, "f"), eaf);
-        EXPECT_EQ(trim_zeros(b, "f").size(), 0);
+        EXPECT_EQ(trim_zeros(b, "f").size(), std::size_t(0));
         EXPECT_EQ(trim_zeros(c, "f"), ecf);
         EXPECT_EQ(trim_zeros(d, "f"), edf);
 
         EXPECT_EQ(trim_zeros(a, "b"), eab);
-        EXPECT_EQ(trim_zeros(b, "b").size(), 0);
+        EXPECT_EQ(trim_zeros(b, "b").size(), std::size_t(0));
         EXPECT_EQ(trim_zeros(c, "b"), ecb);
         EXPECT_EQ(trim_zeros(d, "b"), edb);
     }

--- a/test/test_xoptional_assembly_storage.cpp
+++ b/test/test_xoptional_assembly_storage.cpp
@@ -38,7 +38,7 @@ namespace xt
         storage_type v = {56, 2, 3, 5};
         flag_storage_type f = {false, true, true, true};
         auto stor = optional_assembly_storage(v, f);
-        ASSERT_EQ(stor.size(), 4);
+        ASSERT_EQ(stor.size(), std::size_t(4));
     }
 
     TEST(xoptional_assembly_storage, resize)
@@ -46,11 +46,11 @@ namespace xt
         storage_type v = {56, 2, 3, 5};
         flag_storage_type f = {false, true, true, true};
         auto stor = optional_assembly_storage(v, f);
-        ASSERT_EQ(stor.size(), 4);
-        stor.resize(5);
-        ASSERT_EQ(stor.size(), 5);
-        stor.resize(2);
-        ASSERT_EQ(stor.size(), 2);
+        ASSERT_EQ(stor.size(), std::size_t(4));
+        stor.resize(std::size_t(5));
+        ASSERT_EQ(stor.size(), std::size_t(5));
+        stor.resize(std::size_t(2));
+        ASSERT_EQ(stor.size(), std::size_t(2));
     }
 
     TEST(xoptional_assembly_storage, access)
@@ -163,8 +163,8 @@ namespace xt
         auto stor2 = optional_assembly_storage(v2, f2);
 
         stor2.swap(stor1);
-        ASSERT_EQ(stor1.size(), 0);
-        ASSERT_EQ(stor2.size(), 4);
+        ASSERT_EQ(stor1.size(), size_t(0));
+        ASSERT_EQ(stor2.size(), size_t(4));
     }
 
     TEST(xoptional_assembly_storage, operators)

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -141,7 +141,7 @@ namespace xt
     {
         xtensor<double, 2> m = {{1, 2}, {3, 4}};
         xarray<double> res = xt::sum(m, {0});
-        EXPECT_EQ(res.dimension(), 1);
+        EXPECT_EQ(res.dimension(), std::size_t(1));
         EXPECT_EQ(res(0), 4.0);
         EXPECT_EQ(res(1), 6.0);
     }
@@ -399,7 +399,7 @@ namespace xt
         auto b_gd_2 = sum(b, {0, 2}, evaluation_strategy::immediate());
         EXPECT_EQ(a_lz, a_gd_2);
         EXPECT_EQ(b_gd_2, a_gd_2);
-        EXPECT_EQ(a_gd_2.dimension(), 1);
+        EXPECT_EQ(a_gd_2.dimension(), std::size_t(1));
 
     #ifndef X_OLD_CLANG
         // EXPECT_TRUE(is_arr(a_gd_1.shape()));

--- a/test/test_xshape.cpp
+++ b/test/test_xshape.cpp
@@ -75,25 +75,25 @@ namespace xt
 
         vector_type c(10, 2);
         EXPECT_EQ(size_t(10), c.size());
-        EXPECT_EQ(2, c[2]);
+        EXPECT_EQ(size_t(2), c[2]);
 
         std::vector<std::size_t> src(10, std::size_t(1));
         vector_type d(src.cbegin(), src.cend());
         EXPECT_EQ(size_t(10), d.size());
-        EXPECT_EQ(1, d[2]);
+        EXPECT_EQ(size_t(1), d[2]);
 
         vector_type e(src);
         EXPECT_EQ(size_t(10), d.size());
-        EXPECT_EQ(1, d[2]);
+        EXPECT_EQ(size_t(1), d[2]);
         
         vector_type f = { 1, 2, 3, 4 };
         EXPECT_EQ(size_t(4), f.size());
-        EXPECT_EQ(3, f[2]);
+        EXPECT_EQ(size_t(3), f[2]);
 
         svector<std::size_t, 8> ov = { 1, 2, 3, 4, 5, 6, 7, 8 };
         vector_type g(ov);
         EXPECT_EQ(size_t(8), g.size());
-        EXPECT_EQ(3, g[2]);
+        EXPECT_EQ(size_t(3), g[2]);
     }
 
     TEST(svector, assign)
@@ -103,21 +103,21 @@ namespace xt
         vector_type src1(10, 2);
         a = src1;
         EXPECT_EQ(size_t(10), a.size());
-        EXPECT_EQ(2, a[2]);
+        EXPECT_EQ(size_t(2), a[2]);
 
         std::vector<size_t> src2(5, 1);
         a = src2;
         EXPECT_EQ(size_t(5), a.size());
-        EXPECT_EQ(1, a[2]);
+        EXPECT_EQ(size_t(1), a[2]);
 
         a = { 1, 2, 3, 4 };
         EXPECT_EQ(size_t(4), a.size());
-        EXPECT_EQ(3, a[2]);
+        EXPECT_EQ(size_t(3), a[2]);
 
         svector<std::size_t, 4> src3(10, 1);
         a = src3;
         EXPECT_EQ(size_t(10), a.size());
-        EXPECT_EQ(1, a[2]);
+        EXPECT_EQ(size_t(1), a[2]);
     }
 
     TEST(svector, resize)
@@ -137,18 +137,18 @@ namespace xt
     TEST(svector, access)
     {
         vector_type a(10);
-        a[0] = 1;
-        EXPECT_EQ(1, a[0]);
-        a[3] = 3;
-        EXPECT_EQ(3, a[3]);
-        a[5] = 2;
-        EXPECT_EQ(2, a[5]);
+        a[0] = size_t(1);
+        EXPECT_EQ(size_t(1), a[0]);
+        a[3] = size_t(3);
+        EXPECT_EQ(size_t(3), a[3]);
+        a[5] = size_t(2);
+        EXPECT_EQ(size_t(2), a[5]);
 
-        a.front() = 0;
-        EXPECT_EQ(0, a[0]);
+        a.front() = size_t(0);
+        EXPECT_EQ(size_t(0), a[0]);
 
-        a.back() = 1;
-        EXPECT_EQ(1, a[9]);
+        a.back() = size_t(1);
+        EXPECT_EQ(size_t(1), a[9]);
     }
 
     TEST(svector, iterator)
@@ -166,10 +166,10 @@ namespace xt
         fixed_shape<3, 4, 5> af;
         using cast_type = typename fixed_shape<3, 4, 5>::cast_type;
         cast_type a = af;
-        EXPECT_EQ(a[0], 3);
-        EXPECT_EQ(a[2], 5);
-        EXPECT_EQ(a.back(), 5);
-        EXPECT_EQ(a.front(), 3);
-        EXPECT_EQ(a.size(), 3);
+        EXPECT_EQ(a[0], size_t(3));
+        EXPECT_EQ(a[2], size_t(5));
+        EXPECT_EQ(a.back(), size_t(5));
+        EXPECT_EQ(a.front(), size_t(3));
+        EXPECT_EQ(a.size(), size_t(3));
     }
 }

--- a/test/test_xsort.cpp
+++ b/test/test_xsort.cpp
@@ -112,8 +112,8 @@ namespace xt
         ex = (XTENSOR_DEFAULT_LAYOUT == layout_type::row_major) ? 2ul : 4ul;
         EXPECT_EQ(ex, argmin(a));
 
-        EXPECT_EQ(3, argmin(b)());
-        EXPECT_EQ(3, argmin(b, 0)());
+        EXPECT_EQ(size_t(3), argmin(b)());
+        EXPECT_EQ(size_t(3), argmin(b, 0)());
 
         xarray<std::size_t> ex_2 = {1, 0, 0};
         EXPECT_EQ(ex_2, argmin(a, 0));
@@ -176,28 +176,28 @@ namespace xt
             auto m0_idx = a_s0(3, 2, 3);
             auto it0 = std::min_element(va_s0.begin(), va_s0.end());
             auto c0_idx = std::distance(va_s0.begin(), it0);
-            EXPECT_EQ(c0_idx, m0_idx);
+            EXPECT_EQ(static_cast<size_t>(c0_idx), m0_idx);
 
             auto a_s1 = argmin(a, 1);
             auto va_s1 = view(a, 3, xt::all(), 2, 3);
             auto m1_idx = a_s1(3, 2, 3);
             auto it1 = std::min_element(va_s1.begin(), va_s1.end());
             auto c1_idx = std::distance(va_s1.begin(), it1);
-            EXPECT_EQ(c1_idx, m1_idx);
+            EXPECT_EQ(static_cast<size_t>(c1_idx), m1_idx);
 
             auto a_s2 = argmin(a, 2);
             auto va_s2 = view(a, 3, 2, xt::all(), 3);
             auto m2_idx = a_s2(3, 2, 3);
             auto it2 = std::min_element(va_s2.begin(), va_s2.end());
             auto c2_idx = std::distance(va_s2.begin(), it2);
-            EXPECT_EQ(c2_idx, m2_idx);
+            EXPECT_EQ(static_cast<size_t>(c2_idx), m2_idx);
 
             auto a_s3 = argmin(a, 3);
             auto va_s3 = view(a, 3, 2, 3, xt::all());
             auto m3_idx = a_s3(3, 2, 3);
             auto it3 = std::min_element(va_s3.begin(), va_s3.end());
             auto c3_idx = std::distance(va_s3.begin(), it3);
-            EXPECT_EQ(c3_idx, m3_idx);
+            EXPECT_EQ(static_cast<size_t>(c3_idx), m3_idx);
         }
     }
 

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -464,7 +464,7 @@ namespace xt
         t b = xt::ones<int>({ 5, 5, 5 });
         auto v2 = strided_view(b, { xt::ellipsis(), 1, 1, 1 });
         EXPECT_EQ(v2(), 1);
-        EXPECT_EQ(v2.shape().size(), 0);
+        EXPECT_EQ(v2.shape().size(), size_t(0));
 
         auto v3 = strided_view(b, { xt::ellipsis(), 1, xt::all(), 1 });
         dynamic_shape<std::size_t> v3_s{ 5 };

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -1036,7 +1036,7 @@ namespace xt
             out_view = in_view;
         }
 
-        EXPECT_EQ(output(0, 5, 5, 2), 1);
+        EXPECT_EQ(output(0, 5, 5, 2), 1.f);
     }
 
     TEST(xview, where_operation)
@@ -1049,10 +1049,10 @@ namespace xt
         EXPECT_EQ(idx[0], exp_idx);
 
         auto idx2 = xt::where(col > size_t(0));
-        EXPECT_EQ(idx2.size(), 2);
-        exp_idx[0] = 1;
+        EXPECT_EQ(idx2.size(), std::size_t(2));
+        exp_idx[0] = std::size_t(1);
         EXPECT_EQ(idx2[0], exp_idx);
-        exp_idx[0] = 2;
+        exp_idx[0] = std::size_t(2);
         EXPECT_EQ(idx2[1], exp_idx);
     }
 
@@ -1124,11 +1124,11 @@ namespace xt
         EXPECT_EQ(vae.back(), b[4]);
         EXPECT_EQ(*vae.end(), *(a.end() - 2));
         EXPECT_TRUE(std::equal(a.begin() + 3, a.end() - 1, vae.begin()));
-        EXPECT_EQ(2, vae.size());
+        EXPECT_EQ(std::size_t(2), vae.size());
 
         auto r_iter = vae.rbegin();
-        EXPECT_EQ(std::distance(a.rbegin(), a.rend()), a.size());
-        EXPECT_EQ(std::distance(r_iter, vae.rend()), vae.size());
+        EXPECT_EQ(static_cast<std::size_t>(std::distance(a.rbegin(), a.rend())), a.size());
+        EXPECT_EQ(static_cast<std::size_t>(std::distance(r_iter, vae.rend())), vae.size());
 
         for (std::size_t i = 0; i < vae.size(); ++i)
         {
@@ -1142,11 +1142,11 @@ namespace xt
         EXPECT_EQ(vbe.back(), b[4]);
         EXPECT_EQ(*vbe.end(), *(a.end() - 2));
         EXPECT_TRUE(std::equal(a.begin() + 3, a.end() - 1, vbe.begin()));
-        EXPECT_EQ(2, vbe.size());
+        EXPECT_EQ(std::size_t(2), vbe.size());
 
         auto rb_iter = vbe.rbegin();
-        EXPECT_EQ(std::distance(a.rbegin(), a.rend()), a.size());
-        EXPECT_EQ(std::distance(rb_iter, vbe.rend()), vbe.size());
+        EXPECT_EQ(static_cast<std::size_t>(std::distance(a.rbegin(), a.rend())), a.size());
+        EXPECT_EQ(static_cast<std::size_t>(std::distance(rb_iter, vbe.rend())), vbe.size());
 
         for (std::size_t i = 0; i < vbe.size(); ++i)
         {
@@ -1168,13 +1168,13 @@ namespace xt
         EXPECT_EQ(do1, dos);
         EXPECT_EQ(ax.storage()[do1], ax(1, 1, 1, 0, 0, 0));
         auto doe = ax.strides()[0] * 1 + ax.strides()[1] * 1 + ax.strides()[2] * 1;
-        EXPECT_EQ(doe, do1);
+        EXPECT_EQ(static_cast<std::size_t>(doe), do1);
 
         auto do2 = xt::view(ax, 1, 2, newaxis(), range(1, 2), range(2, 2, 4), all()).data_offset();
         auto dos2 = xt::strided_view(ax, {1, 2, newaxis(), range(1, 2), range(2, 2, 4), all()}).data_offset();
         EXPECT_EQ(do2, dos2);
         auto doe2 = ax.strides()[0] * 1 + ax.strides()[1] * 2 + ax.strides()[2] * 1 + ax.strides()[3] * 2;
-        EXPECT_EQ(doe2, do2);
+        EXPECT_EQ(static_cast<std::size_t>(doe2), do2);
     }
 
     TEST(xview, view_simd_test)


### PR DESCRIPTION
Remaining warnings are the normal_distribution member not initialized and the conversion due to operator/.