### PR TITLE
add using to custom type printer

### DIFF
--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -536,6 +536,8 @@ namespace xt
 
             void update(const_reference val)
             {
+                using ::operator<<;
+
                 std::stringstream buf;
                 buf << val;
                 std::string s = buf.str();

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -12,6 +12,16 @@
 #include <algorithm>
 #include <sstream>
 #include <limits>
+#include <chrono>
+
+using day_duration     = std::chrono::duration<long long, std::ratio<3600 * 24>>;
+using iwanttobeprinted = std::chrono::time_point<std::chrono::system_clock, day_duration>;
+
+std::ostream& operator<<(std::ostream& os, const iwanttobeprinted&)
+{
+    os << "thankyousomuch";
+    return os;
+}
 
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
@@ -275,5 +285,13 @@ namespace xt
         out << von;
         std::string exp = "{1, 1, 1, 1, 1}";
         EXPECT_EQ(exp, out.str());
+    }
+
+    TEST(xio, outside_operator_overload)
+    {
+        // Just check compilation
+        auto arr = xarray<iwanttobeprinted>::from_shape({5});
+        std::stringstream out;
+        out << arr;
     }
 }


### PR DESCRIPTION
This adds the ability to use `operator<<` defined outside the namespace of `xt`.