### PR TITLE
shared pointer adaptor

### DIFF
--- a/docs/source/missing.rst
+++ b/docs/source/missing.rst
@@ -84,7 +84,7 @@ of the two expressions while the last one holds a reference on at least one of t
          { true, false }};
 
     xoptional_assembly<xarray<double>, xarray<bool>>
-    assembly(v, vh);
+    assembly(v, hv);
     std::cout << assembly << std::endl;
 
 outputs:

--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -457,7 +457,7 @@ namespace xt
      *
      * std::cout << shared_buf.use_count() << std::endl;
      * {
-     *     auto obj = adapt_smart_ptr(shared_buf.get()->buf.data(),
+     *     auto obj = adapt_smart_ptr(shared_buf.get()->m_buf.data(),
      *                                {2, 4}, shared_buf);
      *     // Use count increased to 2
      *     std::cout << shared_buf.use_count() << std::endl;

--- a/include/xtensor/xadapt.hpp
+++ b/include/xtensor/xadapt.hpp
@@ -400,6 +400,98 @@ namespace xt
         return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 #endif
+
+#ifndef X_OLD_CLANG
+    /**
+     * Adapt a smart pointer to a typed memory block (unique_ptr or shared_ptr)
+     *
+     * \code{.cpp}
+     * #include <xtensor/xadapt.hpp>
+     * #include <xtensor/xio.hpp>
+     *
+     * std::shared_ptr<double> sptr(new double[8], std::default_delete<double[]>());
+     * sptr.get()[2] = 321.;
+     * auto xptr = adapt_smart_ptr(sptr, {4, 2});
+     * xptr(1, 3) = 123.;
+     * std::cout << xptr;
+     * \endcode
+     *
+     * @param smart_ptr<T[]> a smart pointer to a memory block of T[]
+     * @param shape The desired shape
+     *
+     * @return xtensor_adaptor for memory
+     */
+    template <class P, class I, std::size_t N>
+    auto adapt_smart_ptr(P&& smart_ptr, const I(&shape)[N])
+    {
+        using buffer_adaptor = xbuffer_adaptor<decltype(smart_ptr.get()), smart_ownership,
+                                               std::decay_t<P>>;
+        std::array<std::size_t, N> fshape = xtl::forward_sequence<std::array<std::size_t, N>, decltype(shape)>(shape);
+        return xtensor_adaptor<buffer_adaptor, N>(
+            buffer_adaptor(smart_ptr.get(), compute_size(fshape),
+            std::forward<P>(smart_ptr)),
+            std::move(fshape)
+        );
+    }
+
+    /**
+     * Adapt a smart pointer (shared_ptr or unique_ptr)
+     *
+     * This function allows to automatically adapt a shared or unique pointer to
+     * a given shape and operate naturally on it. Memory will be automatically
+     * handled by the smart pointer implementation.
+     *
+     * \code{.cpp}
+     * #include <xtensor/xadapt.hpp>
+     * #include <xtensor/xio.hpp>
+     *
+     * struct Buffer {
+     *     Buffer(std::vector<double>& buf) : m_buf(buf) {}
+     *     ~Buffer() { std::cout << "deleted" << std::endl; }
+     *     std::vector<double> m_buf;
+     * };
+     *
+     * auto data = std::vector<double>{1,2,3,4,5,6,7,8};
+     * auto shared_buf = std::make_shared<Buffer>(data);
+     * auto unique_buf = std::make_unique<Buffer>(data);
+     *
+     * std::cout << shared_buf.use_count() << std::endl;
+     * {
+     *     auto obj = adapt_smart_ptr(shared_buf.get()->buf.data(),
+     *                                {2, 4}, shared_buf);
+     *     // Use count increased to 2
+     *     std::cout << shared_buf.use_count() << std::endl;
+     *     std::cout << obj << std::endl;
+     * }
+     * // Use count reset to 1
+     * std::cout << shared_buf.use_count() << std::endl;
+     *
+     * {
+     *     auto obj = adapt_smart_ptr(unique_buf.get()->buf.data(),
+     *                                {2, 4}, std::move(unique_buf));
+     *     std::cout << obj << std::endl;
+     * }
+     * \endcode
+     *
+     * @param A pointer to a typed data block (e.g. double*)
+     * @param shape The desired shape
+     * @param A smart pointer to move or copy, in order to manage memory
+     *
+     * @return xtensor_adaptor on the memory
+     */
+    template <class P, class I, std::size_t N, class D>
+    auto adapt_smart_ptr(P&& data_ptr, const I(&shape)[N], D&& smart_ptr)
+    {
+        using buffer_adaptor = xbuffer_adaptor<P, smart_ownership,
+                                               std::decay_t<D>>;
+        std::array<std::size_t, N> fshape = xtl::forward_sequence<std::array<std::size_t, N>, decltype(shape)>(shape);
+
+        return xtensor_adaptor<buffer_adaptor, N>(
+            buffer_adaptor(data_ptr, compute_size(fshape), std::forward<D>(smart_ptr)),
+            std::move(fshape)
+        );
+    }
+#endif
 }
 
 #endif

--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -29,6 +29,8 @@ namespace xt
     {
     };
 
+    using smart_ownership = no_ownership;
+
     struct acquire_ownership
     {
     };
@@ -49,6 +51,7 @@ namespace xt
 
             using self_type = xbuffer_storage<CP, A>;
             using allocator_type = A;
+            using destructor_type = allocator_type;
             using value_type = typename allocator_type::value_type;
             using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
                                   typename allocator_type::const_reference,
@@ -80,6 +83,46 @@ namespace xt
             size_type m_size;
         };
 
+        template <class CP, class D>
+        class xbuffer_smart_pointer
+        {
+        public:
+
+            using self_type = xbuffer_storage<CP, D>;
+            using destructor_type = D;
+            using value_type = std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<CP>>>;
+            using allocator_type = std::allocator<value_type>;
+            using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
+                                  typename allocator_type::const_reference,
+                                  typename allocator_type::reference>;
+            using const_reference = typename allocator_type::const_reference;
+            using pointer = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
+                                  typename allocator_type::const_pointer,
+                                  typename allocator_type::pointer>;
+            using const_pointer = typename allocator_type::const_pointer;
+            using size_type = typename allocator_type::size_type;
+            using difference_type = typename allocator_type::difference_type;
+
+            xbuffer_smart_pointer();
+
+            template <class P, class DT>
+            xbuffer_smart_pointer(P&& data_ptr, size_type size, DT&& destruct);
+
+            size_type size() const noexcept;
+            void resize(size_type size);
+
+            pointer data() noexcept;
+            const_pointer data() const noexcept;
+
+            void swap(self_type& rhs) noexcept;
+
+        private:
+
+            pointer p_data;
+            size_type m_size;
+            destructor_type m_destruct;
+        };
+
         template <class CP, class A>
         class xbuffer_owner_storage
         {
@@ -87,6 +130,7 @@ namespace xt
 
             using self_type = xbuffer_owner_storage<CP, A>;
             using allocator_type = A;
+            using destructor_type = allocator_type;
             using value_type = typename allocator_type::value_type;
             using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
                                   typename allocator_type::const_reference,
@@ -130,16 +174,42 @@ namespace xt
             allocator_type m_allocator;
         };
 
+        template <class E, class = void>
+        struct is_lambda_type : std::false_type
+        {
+        };
+
+        // check if operator() is available
+        template <class E>
+        struct is_lambda_type<E, void_t<decltype(&E::operator())>>
+            : std::true_type
+        {
+        };
+
         template <class CP, class A, class O>
         struct get_buffer_storage
         {
-            using type = xbuffer_storage<CP, A>;
+            using type = xtl::mpl::eval_if_t<is_lambda_type<A>,
+                                             meta_identity<xbuffer_smart_pointer<CP, A>>,
+                                             meta_identity<xbuffer_storage<CP, A>>>;
         };
 
         template <class CP, class A>
         struct get_buffer_storage<CP, A, acquire_ownership>
         {
             using type = xbuffer_owner_storage<CP, A>;
+        };
+
+        template <class CP, class T>
+        struct get_buffer_storage<CP, std::shared_ptr<T>, no_ownership>
+        {
+            using type = xbuffer_smart_pointer<CP, std::shared_ptr<T>>;
+        };
+
+        template <class CP, class T>
+        struct get_buffer_storage<CP, std::unique_ptr<T>, no_ownership>
+        {
+            using type = xbuffer_smart_pointer<CP, std::unique_ptr<T>>;
         };
 
         template <class CP, class A, class O>
@@ -154,6 +224,7 @@ namespace xt
         using base_type = detail::buffer_storage_t<CP, A, O>;
         using self_type = xbuffer_adaptor<CP, O, A>;
         using allocator_type = typename base_type::allocator_type;
+        using destructor_type = typename base_type::destructor_type;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;
         using const_reference = typename base_type::const_reference;
@@ -171,8 +242,8 @@ namespace xt
 
         xbuffer_adaptor() = default;
 
-        template <class P>
-        xbuffer_adaptor(P&& data, size_type size, const allocator_type& alloc = allocator_type());
+        template <class P, class AT = allocator_type>
+        xbuffer_adaptor(P&& data, size_type size, AT&& alloc = allocator_type());
 
         ~xbuffer_adaptor() = default;
 
@@ -428,14 +499,63 @@ namespace xt
         }
     }
 
+    /****************************************
+     * xbuffer_smart_pointer implementation *
+     ****************************************/
+
+    namespace detail
+    {
+        template <class CP, class D>
+        template <class P, class DT>
+        xbuffer_smart_pointer<CP, D>::xbuffer_smart_pointer(P&& data_ptr, size_type size, DT&& destruct)
+            : p_data(data_ptr), m_size(size), m_destruct(std::forward<DT>(destruct))
+        {
+        }
+
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::size() const noexcept -> size_type
+        {
+            return m_size;
+        }
+
+        template <class CP, class D>
+        void xbuffer_smart_pointer<CP, D>::resize(size_type size)
+        {
+            if (m_size != size)
+            {
+                throw std::runtime_error("xbuffer_storage not resizable");
+            }
+        }
+
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::data() noexcept -> pointer
+        {
+            return p_data;
+        }
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::data() const noexcept -> const_pointer
+        {
+            return p_data;
+        }
+
+        template <class CP, class D>
+        void xbuffer_smart_pointer<CP, D>::swap(self_type& rhs) noexcept
+        {
+            using std::swap;
+            swap(p_data, rhs.p_data);
+            swap(m_size, rhs.m_size);
+            swap(m_destruct, rhs.m_destruct);
+        }
+    }
+
     /**********************************
      * xbuffer_adaptor implementation *
      **********************************/
 
     template <class CP, class O, class A>
-    template <class P>
-    inline xbuffer_adaptor<CP, O, A>::xbuffer_adaptor(P&& data, size_type size, const allocator_type& alloc)
-        : base_type(std::forward<P>(data), size, alloc)
+    template <class P, class AT>
+    inline xbuffer_adaptor<CP, O, A>::xbuffer_adaptor(P&& data, size_type size, AT&& alloc)
+        : base_type(std::forward<P>(data), size, std::forward<AT>(alloc))
     {
     }
 

--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -206,7 +206,7 @@ namespace xt
         template <class CP, class A, class O>
         struct get_buffer_storage
         {
-            using type = xtl::mpl::eval_if_t</*std::true_type,*/is_lambda_type<A>,
+            using type = xtl::mpl::eval_if_t<is_lambda_type<A>,
                                              self_type<xbuffer_smart_pointer<CP, A>>,
                                              self_type<xbuffer_storage<CP, A>>>;
         };

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -39,12 +39,6 @@ namespace xt
 
     namespace detail
     {
-        // need to have a copy of meta_identity here for MSVC
-        template <class T>
-        struct meta_identity
-        {
-            using type = T;
-        };
 
         /********************
          * common_size_type *
@@ -238,7 +232,7 @@ namespace xt
         using tuple_type = std::tuple<CT...>;
 
         // Added indirection for MSVC 2017 bug with the operator value_type()
-        using value_type = typename detail::meta_identity<decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
+        using value_type = typename meta_identity<decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
         using reference = value_type;
         using const_reference = value_type;
         using pointer = value_type*;

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -39,6 +39,12 @@ namespace xt
 
     namespace detail
     {
+        // need to have a copy of meta_identity here for MSVC
+        template <class T>
+        struct meta_identity
+        {
+            using type = T;
+        };
 
         /********************
          * common_size_type *
@@ -132,12 +138,6 @@ namespace xt
         struct has_simd_type
             : std::integral_constant<bool, !std::is_same<V, xsimd::simd_type<V>>::value>
         {
-        };
-
-        template <class T>
-        struct meta_identity
-        {
-            using type = T;
         };
 
         // This meta struct checks wether SIMD should be activated for our 

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -113,6 +113,16 @@ namespace xt
     template <class T, class R>
     using disable_integral_t = std::enable_if_t<!std::is_integral<T>::value, R>;
 
+    /********************************
+     * meta identity implementation *
+     ********************************/
+
+    template <class T>
+    struct meta_identity
+    {
+        using type = T;
+    };
+
     /*******************************
      * remove_class implementation *
      *******************************/

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -34,12 +34,10 @@
 #define VS_X86_WORKAROUND 1
 #endif
 
-// MSVC 2015 seems to be unable to deal with the amount of constexpr's in our code,
-// which is why it is disabled in the following tests.
 // test_fixed removed from MSVC x86 because of recurring ICE.
 // Will be enabled again when the compiler is fixed
 
-#if (_MSC_VER >= 1910 && !defined(DISABLE_VS2017)) || !defined(_MSC_VER)
+#if (_MSC_VER < 1910 && _WIN64) || (_MSC_VER >= 1910 && !defined(DISABLE_VS2017)) || !defined(_MSC_VER)
 
 namespace xt
 {

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -34,10 +34,12 @@
 #define VS_X86_WORKAROUND 1
 #endif
 
+// MSVC 2015 seems to be unable to deal with the amount of constexpr's in our code,
+// which is why it is disabled in the following tests.
 // test_fixed removed from MSVC x86 because of recurring ICE.
 // Will be enabled again when the compiler is fixed
 
-#if (_MSC_VER < 1910 && _WIN64) || (_MSC_VER >= 1910 && !defined(DISABLE_VS2017)) || !defined(_MSC_VER)
+#if (_MSC_VER >= 1910 && !defined(DISABLE_VS2017)) || !defined(_MSC_VER)
 
 namespace xt
 {


### PR DESCRIPTION
This PR allows for adaptors on shared pointers. Lifetimes of custom wrappers can be extended by copying into lambdas, as detailed in the docs.