### PR TITLE
removing data interface from dynamic view

### DIFF
--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -195,7 +195,12 @@ namespace xt
 
         size_type data_offset() const noexcept;
 
-        using base_type::data;
+        // Explicitly deleting data methods so has_data_interface results
+        // to false instead of having compilers complaining about not being
+        // able to call the methods from the private base
+        value_type* data() noexcept = delete;
+        const value_type* data() const noexcept = delete;
+
         using base_type::storage;
         using base_type::expression;
         using base_type::broadcast_shape;

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -18,6 +18,7 @@
 #include "xtensor/xio.hpp"
 #include "xtensor/xrandom.hpp"
 #include "xtensor/xbuilder.hpp"
+#include "xtensor/xdynamic_view.hpp"
 #include "xtensor/xview.hpp"
 
 #include "files/xio_expected_results.hpp"
@@ -78,6 +79,17 @@ namespace xt
         std::stringstream out_4;
         out_4 << v_just_new_axis;
         EXPECT_EQ("{{1, 2, 3, 4}}", out_4.str());
+    }
+
+    TEST(xio, xdynamic_view)
+    {
+        xarray<int> e{{1, 2, 3, 4},
+                      {5, 6, 7, 8},
+                      {9, 10, 11, 12}};
+        auto v = xt::dynamic_view(e, { 1, keep(0, 2, 3)});
+        std::stringstream out;
+        out << v;
+        EXPECT_EQ("{5, 7, 8}", out.str());
     }
 
     TEST(xio, random_nan_inf)


### PR DESCRIPTION
These methods prevent the print of `dynamic_view`.