### PR TITLE
print_options io manipulators

### DIFF
--- a/docs/source/api/xio.rst
+++ b/docs/source/api/xio.rst
@@ -39,8 +39,22 @@ With the following functions, the global print options can be set:
 .. doxygenfunction:: xt::print_options::set_threshold
    :project: xtensor
 
-.. doxygenfunction:: xt::print_options::set_edgeitems
+.. doxygenfunction:: xt::print_options::set_edge_items
    :project: xtensor
 
 .. doxygenfunction:: xt::print_options::set_precision
+   :project: xtensor
+
+On can also locally overwrite the print options with io manipulators:
+
+.. doxygenclass:: xt::print_options::line_width
+   :project: xtensor
+
+.. doxygenclass:: xt::print_options::threshold
+   :project: xtensor
+
+.. doxygenclass:: xt::print_options::edge_items
+   :project: xtensor
+
+.. doxygenclass:: xt::print_options::precision
    :project: xtensor

--- a/docs/source/histogram.rst
+++ b/docs/source/histogram.rst
@@ -12,7 +12,7 @@ Basic usage
 
 .. note::
 
-    .. code-block::
+    .. code-block:: cpp
 
         xt::histogram(a, bins[, weights][, density])
         xt::histogram_bin_edges(a, bins[, weights][, left, right][, bins][, mode])

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -183,7 +183,7 @@ namespace xt
         xt::xarray<double, layout_type::row_major> rn = xt::random::rand<double>({100, 100}, -10, 10);
 
         xt::print_options::set_line_width(150);
-        xt::print_options::set_edgeitems(10);
+        xt::print_options::set_edge_items(10);
         xt::print_options::set_precision(10);
         xt::print_options::set_threshold(100);
 
@@ -193,9 +193,31 @@ namespace xt
 
         // reset back to default
         xt::print_options::set_line_width(75);
-        xt::print_options::set_edgeitems(3);
+        xt::print_options::set_edge_items(3);
         xt::print_options::set_precision(-1);
         xt::print_options::set_threshold(1000);
+    }
+
+    namespace po = xt::print_options;
+
+    TEST(xio, local_options)
+    {
+        xt::random::seed(123);
+        xt::xarray<double, layout_type::row_major> rn = xt::random::rand<double>({100, 100}, -10, 10);
+
+        std::stringstream out;
+        out << po::line_width(150)
+            << po::edge_items(10)
+            << po::precision(10)
+            << po::threshold(100)
+            << rn;
+
+        EXPECT_EQ(print_options_result, out.str());
+
+        EXPECT_EQ(out.iword(po::edge_items::id()), long(0));
+        EXPECT_EQ(out.iword(po::line_width::id()), long(0));
+        EXPECT_EQ(out.iword(po::threshold::id()), long(0));
+        EXPECT_EQ(out.iword(po::precision::id()), long(0));
     }
 
     TEST(xio, three_d)


### PR DESCRIPTION
With this PR it is possible to locally overwrite print options "a la STL":

```cpp
using po = xt::print_options;
xt::xarray<double> a = xt::rand::rand<double>({2000, 2000});
std::cout << po::line_width(150)
          << po::edge_items(10)
          << po::precision(10)
          << po::threshold(100)
          << a
          << std::endl;
```