### PR TITLE
Proposal: default layout-type for `unravel_from_strides` and `unravel_index`

### DIFF
--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -61,10 +61,10 @@ namespace xt
      *****************/
 
     template <class S>
-    S unravel_from_strides(typename S::value_type index, const S& strides, layout_type l);
+    S unravel_from_strides(typename S::value_type index, const S& strides, layout_type l=layout_type::row_major);
 
     template <class S>
-    get_strides_t<S> unravel_index(typename S::value_type index, const S& shape, layout_type l);
+    get_strides_t<S> unravel_index(typename S::value_type index, const S& shape, layout_type l=layout_type::row_major);
 
     /***********************
      * broadcast functions *


### PR DESCRIPTION
I think that these defaults make sense as the rest of `xtensor` also abides to these defaults.