### PR TITLE
xtensor_forward.hpp cleanup

### DIFF
--- a/include/xtensor/xeval.hpp
+++ b/include/xtensor/xeval.hpp
@@ -10,6 +10,7 @@
 #define XTENSOR_EVAL_HPP
 
 #include "xtensor_forward.hpp"
+#include "xshape.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xlayout.hpp
+++ b/include/xtensor/xlayout.hpp
@@ -9,8 +9,10 @@
 #ifndef XTENSOR_LAYOUT_HPP
 #define XTENSOR_LAYOUT_HPP
 
+// Do not include anything else here.
+// xlayout.hpp is included in xtensor_forward.hpp
+// and we don't want to bring other headers to it.
 #include "xtensor_config.hpp"
-#include "xshape.hpp"
 
 namespace xt
 {
@@ -48,21 +50,6 @@ namespace xt
     constexpr layout_type compute_layout(Args... args) noexcept;
 
     constexpr layout_type default_assignable_layout(layout_type l) noexcept;
-
-    /**
-     * Compute a layout based on a layout and a shape type.
-     *
-     * The main functionality of this function is that it reduces vectors to
-     * ``layout_type::any`` so that assigning a row major 1D container to another
-     * row_major container becomes free.
-     */
-    template <layout_type L, class S>
-    struct select_layout
-    {
-        constexpr static std::ptrdiff_t static_dimension = xt::static_dimension<S>::value;
-        constexpr static bool is_any = static_dimension != -1 && static_dimension <= 1 && L != layout_type::dynamic;
-        constexpr static layout_type value = is_any ? layout_type::any : L;
-    };
 
     /******************
      * Implementation *

--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -15,6 +15,16 @@
 
 namespace xt
 {
+    namespace check_policy
+    {
+        struct none
+        {
+        };
+        struct full
+        {
+        };
+    }
+
     template <class E>
     auto transpose(E&& e) noexcept;
 

--- a/include/xtensor/xshape.hpp
+++ b/include/xtensor/xshape.hpp
@@ -18,7 +18,7 @@
 #include <iterator>
 #include <memory>
 
-#include "xexception.hpp"
+#include "xlayout.hpp"
 #include "xstorage.hpp"
 
 namespace xt
@@ -87,6 +87,21 @@ namespace xt
     struct static_dimension
     {
         static constexpr std::ptrdiff_t value = detail::static_dimension_impl<S>::value;
+    };
+
+    /**
+     * Compute a layout based on a layout and a shape type.
+     *
+     * The main functionality of this function is that it reduces vectors to
+     * ``layout_type::any`` so that assigning a row major 1D container to another
+     * row_major container becomes free.
+     */
+    template <layout_type L, class S>
+    struct select_layout
+    {
+        constexpr static std::ptrdiff_t static_dimension = xt::static_dimension<S>::value;
+        constexpr static bool is_any = static_dimension != -1 && static_dimension <= 1 && L != layout_type::dynamic;
+        constexpr static layout_type value = is_any ? layout_type::any : L;
     };
 
     /*************************************

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -23,7 +23,6 @@
 
 #ifndef XTENSOR_ALIGNMENT
     #ifdef XTENSOR_USE_XSIMD
-        #include <xsimd/xsimd.hpp>
         #define XTENSOR_ALIGNMENT XSIMD_DEFAULT_ALIGNMENT
     #else
         #define XTENSOR_ALIGNMENT 0

--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -43,7 +43,7 @@
 
 #ifndef XTENSOR_DEFAULT_SHAPE_CONTAINER
 #define XTENSOR_DEFAULT_SHAPE_CONTAINER(T, EA, SA) \
-    xt::svector<typename XTENSOR_DEFAULT_DATA_CONTAINER(T, EA)::size_type, 4, SA>
+    xt::svector<typename XTENSOR_DEFAULT_DATA_CONTAINER(T, EA)::size_type, 4, SA, true>
 #endif
 
 #ifndef XTENSOR_DEFAULT_ALLOCATOR

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -9,25 +9,42 @@
 #ifndef XTENSOR_FORWARD_HPP
 #define XTENSOR_FORWARD_HPP
 
+// This file contains forward declarations and
+// alias types to solve the problem of circular
+// includes. It should not contain anything else
+// and should not bring additional dependencies to
+// the files that include it. So:
+// - do NOT define classes of metafunctions here
+// - do NOT include other headers
+//
+// If you need to do so, something is probably
+// going wrong (either your change, or xtensor
+// needs to be refactored).
+
 #include <memory>
 #include <vector>
 
 #include <xtl/xoptional_sequence.hpp>
 
-#include "xexpression.hpp"
 #include "xlayout.hpp"
-#include "xshape.hpp"
-#include "xstorage.hpp"
 #include "xtensor_config.hpp"
-#include "xtensor_simd.hpp"
 
 namespace xt
 {
+    struct xtensor_expression_tag;
+    struct xoptional_expression_tag;
+
     template <class C>
     struct xcontainer_inner_types;
 
     template <class D>
     class xcontainer;
+
+    template <class T, class A>
+    class uvector;
+
+    template <class T, std::size_t N, class A, bool Init>
+    class svector;
 
     template <class EC,
               layout_type L = XTENSOR_DEFAULT_LAYOUT,
@@ -183,65 +200,6 @@ namespace xt
 
     template <class F, class... CT>
     class xfunction;
-
-    namespace check_policy
-    {
-        struct none
-        {
-        };
-        struct full
-        {
-        };
-    }
-
-    namespace evaluation_strategy
-    {
-        struct base
-        {
-        };
-        struct immediate : base
-        {
-        };
-        struct lazy : base
-        {
-        };
-        /*
-        struct cached
-        {
-        };
-        */
-    }
-
-    /***********************************
-     * temporary_type_t implementation *
-     ***********************************/
-
-    namespace detail
-    {
-        template <class S>
-        struct xtype_for_shape
-        {
-            template <class T, layout_type L>
-            using type = xarray<T, L>;
-        };
-
-        template <template <class, std::size_t> class S, class X, std::size_t N>
-        struct xtype_for_shape<S<X, N>>
-        {
-            template <class T, layout_type L>
-            using type = xtensor<T, N, L>;
-        };
-
-        template <template <std::size_t...> class S, std::size_t... X>
-        struct xtype_for_shape<S<X...>>
-        {
-            template <class T, layout_type L>
-            using type = xtensor_fixed<T, xshape<X...>, L>;
-        };
-
-        template <class T, class S, layout_type L>
-        using temporary_type_t = typename xtype_for_shape<S>::template type<T, L>;
-    }
 }
 
 #endif

--- a/include/xtensor/xtensor_simd.hpp
+++ b/include/xtensor/xtensor_simd.hpp
@@ -11,7 +11,6 @@
 
 #include <vector>
 
-#include "xstorage.hpp"
 #include "xutils.hpp"
 
 #ifdef XTENSOR_USE_XSIMD

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -6,6 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#ifdef _MSC_VER
+#define VS_SKIP_XFIXED 1
+#endif
+
 // xfixed leads to ICE in debug mode, this provides
 // an easy way to prevent compilation
 #ifndef VS_SKIP_XFIXED


### PR DESCRIPTION
This PRs removes includes and move some definitions to more appropriated files.