### PR TITLE
Disabled tests generating wrong code with MSVC

### DIFF
--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -382,7 +382,6 @@ namespace xt
         EXPECT_EQ(func, res5);
     }
 
-
     TEST(xfunction, all_iterators)
     {
         xt::xarray<double> x = xt::random::rand<double>({5, 5, 5});
@@ -391,11 +390,18 @@ namespace xt
         auto f1 = 2.0 * x;
         auto f2 = x * 2.0 * x;
         iterator_tester(f1);
+// For an unknown reason, MSVC is cannot correctly generate
+// storage_cbegin() for a function of function. Moreover,
+// a simple SFINAE deduction like has_storage_iterator
+// harcoded and tested here fails (while it builds fine in any
+// empty project)
+#ifndef _MSC_VER
         iterator_tester(f2);
         iterator_tester(x * y * 3.0);
         iterator_tester(5.0 + x * y * 3.0);
         iterator_tester(x * y * z);
         iterator_tester(x / y / z);
+#endif
     }
 
     TEST(xfunction, xfunction_in_xfunction)


### PR DESCRIPTION
SFINAE is somehow broken on MSVC when `xutils.hpp` is included, fixing it needs further investigations.