### PR TITLE
Include nlohmann_json in xio for mime bundle repr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmasked_value.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmasked_view.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmath.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xmime.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnoalias.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnorm.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnpy.hpp

--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -95,6 +95,7 @@ namespace xt
         class NAME                                                        \
         {                                                                 \
         public:                                                           \
+                                                                          \
             NAME(int value) : m_value(value)                              \
             {                                                             \
                 id();                                                     \
@@ -108,9 +109,12 @@ namespace xt
             {                                                             \
                 return m_value;                                           \
             }                                                             \
+                                                                          \
         private:                                                          \
+                                                                          \
             int m_value;                                                  \
         };                                                                \
+                                                                          \
         inline std::ostream& operator<<(std::ostream& out, const NAME& n) \
         {                                                                 \
             out.iword(NAME::id()) = n.value();                            \
@@ -125,7 +129,7 @@ namespace xt
          *
          * \code{.cpp}
          * using po = xt::print_options;
-         * xt::xarray<double> a = {{1, 2, 3}, {4, 5, 6}}; 
+         * xt::xarray<double> a = {{1, 2, 3}, {4, 5, 6}};
          * std::cout << po::line_width(100) << a << std::endl;
          * \endcode
          */
@@ -139,7 +143,7 @@ namespace xt
          *
          * \code{.cpp}
          * using po = xt::print_options;
-         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500}); 
+         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500});
          * std::cout << po::threshold(50) << a << std::endl;
          * \endcode
          */
@@ -153,7 +157,7 @@ namespace xt
          *
          * \code{.cpp}
          * using po = xt::print_options;
-         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500}); 
+         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500});
          * std::cout << po::edge_items(5) << a << std::endl;
          * \endcode
          */
@@ -167,7 +171,7 @@ namespace xt
          *
          * \code{.cpp}
          * using po = xt::print_options;
-         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500}); 
+         * xt::xarray<double> a = xt::rand::randn<double>({2000, 500});
          * std::cout << po::precision(5) << a << std::endl;
          * \endcode
          */
@@ -745,363 +749,10 @@ namespace xt
         return pretty_print(e, out);
     }
 }
+#endif
+
+// Backward compatibility: include xmime.hpp in xio.hpp by default.
 
 #ifdef __CLING__
-#include <nlohmann/json.hpp>
-
-namespace xt
-{
-
-    template <class P>
-    void compute_1d_row(std::stringstream& out, P& printer, const std::size_t& row_idx)
-    {
-        out << "<tr><td style='font-family:monospace;' title='" << row_idx << "'><pre>";
-        printer.print_next(out);
-        out << "</pre></td></tr>";
-    }
-
-    template <class P, class T>
-    void compute_1d_table(std::stringstream& out, P& printer, const T& expr,
-                          const std::size_t& edgeitems)
-    {
-        const auto& dim = expr.shape()[0];
-
-        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
-        if (edgeitems == 0 || 2 * edgeitems >= dim)
-        {
-            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
-            {
-                compute_1d_row(out, printer, row_idx);
-            }
-        }
-        else
-        {
-            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
-            {
-                compute_1d_row(out, printer, row_idx);
-            }
-            out << "<tr><td><center>...</center></td></tr>";
-            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
-            {
-                compute_1d_row(out, printer, row_idx);
-            }
-        }
-        out << "</tbody></table>";
-    }
-
-    template <class P>
-    void compute_2d_element(std::stringstream& out, P& printer, const std::string& idx_str,
-                            const std::size_t& row_idx, const std::size_t& column_idx)
-    {
-        out << "<td style='font-family:monospace;' title='("
-            << idx_str << row_idx << ", " << column_idx << ")'><pre>";
-        printer.print_next(out);
-        out << "</pre></td>";
-    }
-
-    template <class P, class T>
-    void compute_2d_row(std::stringstream& out, P& printer, const T& expr,
-                        const std::size_t& edgeitems, const std::string& idx_str,
-                        const std::size_t& row_idx)
-    {
-        const auto& dim = expr.shape()[expr.dimension() - 1];
-
-        out << "<tr>";
-        if (edgeitems == 0 || 2 * edgeitems >= dim)
-        {
-            for (std::size_t column_idx = 0; column_idx < dim; ++column_idx)
-            {
-                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
-            }
-        }
-        else
-        {
-            for (std::size_t column_idx = 0; column_idx < edgeitems; ++column_idx)
-            {
-                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
-            }
-            out << "<td><center>...</center></td>";
-            for (std::size_t column_idx = dim - edgeitems; column_idx < dim; ++column_idx)
-            {
-                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
-            }
-        }
-        out << "</tr>";
-    }
-
-    template <class P, class T, class I>
-    void compute_2d_table(std::stringstream& out, P& printer, const T& expr,
-                               const std::size_t& edgeitems, const std::vector<I>& idx)
-    {
-        const auto& dim = expr.shape()[expr.dimension() - 2];
-        std::string idx_str;
-        std::for_each(idx.cbegin(), idx.cend(), [&idx_str](const auto& i) {
-            idx_str += std::to_string(i) + ", ";
-        });
-
-        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
-        if (edgeitems == 0 || 2 * edgeitems >= dim)
-        {
-            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
-            {
-                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
-            }
-        }
-        else
-        {
-            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
-            {
-                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
-            }
-            out << "<tr>";
-            for (std::size_t column_idx = 0; column_idx < 2 * edgeitems + 1; ++column_idx)
-            {
-                out << "<td><center>...</center></td>";
-            }
-            out << "</tr>";
-            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
-            {
-                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
-            }
-        }
-        out << "</tbody></table>";
-    }
-
-    template <class P, class T, class I>
-    void compute_nd_row(std::stringstream& out, P& printer, const T& expr,
-                         const std::size_t& edgeitems, const std::vector<I>& idx)
-    {
-        out << "<tr><td>";
-        compute_nd_table_impl(out, printer, expr, edgeitems, idx);
-        out << "</td></tr>";
-    }
-
-    template <class P, class T, class I>
-    void compute_nd_table_impl(std::stringstream& out, P& printer, const T& expr,
-                               const std::size_t& edgeitems, const std::vector<I>& idx)
-    {
-        const auto& displayed_dimension = idx.size();
-        const auto& expr_dim = expr.dimension();
-        const auto& dim = expr.shape()[displayed_dimension];
-
-        if (expr_dim - displayed_dimension == 2)
-        {
-            return compute_2d_table(out, printer, expr, edgeitems, idx);
-        }
-
-        std::vector<I> idx2 = idx;
-        idx2.resize(displayed_dimension + 1);
-
-        out << "<table style='border-style:solid;border-width:1px;'>";
-        if (edgeitems == 0 || 2 * edgeitems >= dim)
-        {
-            for (std::size_t i = 0; i < dim; ++i)
-            {
-                idx2[displayed_dimension] = i;
-                compute_nd_row(out, printer, expr, edgeitems, idx2);
-            }
-        }
-        else
-        {
-            for (std::size_t i = 0; i < edgeitems; ++i)
-            {
-                idx2[displayed_dimension] = i;
-                compute_nd_row(out, printer, expr, edgeitems, idx2);
-            }
-            out << "<tr><td><center>...</center></td></tr>";
-            for (std::size_t i = dim - edgeitems; i < dim; ++i)
-            {
-                idx2[displayed_dimension] = i;
-                compute_nd_row(out, printer, expr, edgeitems, idx2);
-            }
-        }
-        out << "</table>";
-    }
-
-    template <class P, class T>
-    void compute_nd_table(std::stringstream& out, P& printer, const T& expr,
-                          const std::size_t& edgeitems)
-    {
-        if (expr.dimension() == 1)
-        {
-            compute_1d_table(out, printer, expr, edgeitems);
-        }
-        else
-        {
-            std::vector<std::size_t> empty_vector;
-            compute_nd_table_impl(out, printer, expr, edgeitems, empty_vector);
-        }
-    }
-
-    template <class E>
-    nlohmann::json mime_bundle_repr_impl(const E& expr)
-    {
-        std::stringstream out;
-
-        std::size_t edgeitems = 0;
-        std::size_t size = compute_size(expr.shape());
-        if (size > print_options::print_options().threshold)
-        {
-            edgeitems = print_options::print_options().edgeitems;
-        }
-
-        if (print_options::print_options().precision != -1)
-        {
-            out.precision(print_options::print_options().precision);
-        }
-
-        detail::printer<E> printer(out.precision());
-
-        xstrided_slice_vector slice_vector;
-        detail::recurser_run(printer, expr, slice_vector, edgeitems);
-        printer.init();
-
-        compute_nd_table(out, printer, expr, edgeitems);
-
-        auto bundle = nlohmann::json::object();
-        bundle["text/html"] = out.str();
-        return bundle;
-    }
-
-    template <class F, class CT>
-    class xfunctor_view;
-
-    template <class F, class CT>
-    nlohmann::json mime_bundle_repr(const xfunctor_view<F, CT>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class F, class... CT>
-    class xfunction;
-
-    template <class F, class... CT>
-    nlohmann::json mime_bundle_repr(const xfunction<F, CT...>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class EC, layout_type L, class SC, class Tag>
-    class xarray_container;
-
-    template <class EC, layout_type L, class SC, class Tag>
-    nlohmann::json mime_bundle_repr(const xarray_container<EC, L, SC, Tag>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class EC, std::size_t N, layout_type L, class Tag>
-    class xtensor_container;
-
-    template <class EC, std::size_t N, layout_type L, class Tag>
-    nlohmann::json mime_bundle_repr(const xtensor_container<EC, N, L, Tag>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class ET, class S, layout_type L, class Tag>
-    class xfixed_container;
-
-    template <class ET, class S, layout_type L, class Tag>
-    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, Tag>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class F, class CT, class X>
-    class xreducer;
-
-    template <class F, class CT, class X>
-    nlohmann::json mime_bundle_repr(const xreducer<F, CT, X>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class VE, class FE>
-    class xoptional_assembly;
-
-    template <class VE, class FE>
-    nlohmann::json mime_bundle_repr(const xoptional_assembly<VE, FE>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class VEC, class FEC>
-    class xoptional_assembly_adaptor;
-
-    template <class VEC, class FEC>
-    nlohmann::json mime_bundle_repr(const xoptional_assembly_adaptor<VEC, FEC>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class CT>
-    class xscalar;
-
-    template <class CT>
-    nlohmann::json mime_bundle_repr(const xscalar<CT>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class CT, class X>
-    class xbroadcast;
-
-    template <class CT, class X>
-    nlohmann::json mime_bundle_repr(const xbroadcast<CT, X>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class F, class R, class S>
-    class xgenerator;
-
-    template <class F, class R, class S>
-    nlohmann::json mime_bundle_repr(const xgenerator<F, R, S>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class CT, class... S>
-    class xview;
-
-    template <class CT, class... S>
-    nlohmann::json mime_bundle_repr(const xview<CT, S...>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class CT, class S, layout_type L, class FST>
-    class xstrided_view;
-
-    template <class CT, class S, layout_type L, class FST>
-    nlohmann::json mime_bundle_repr(const xstrided_view<CT, S, L, FST>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class CTD, class CTM>
-    class xmasked_view;
-
-    template <class CTD, class CTM>
-    nlohmann::json mime_bundle_repr(const xmasked_view<CTD, CTM>& expr)
-    {
-        return mime_bundle_repr_impl(expr);
-    }
-
-    template <class T, class B>
-    class xmasked_value;
-
-    template <class T, class B>
-    nlohmann::json mime_bundle_repr(const xmasked_value<T, B>& v)
-    {
-        auto bundle = nlohmann::json::object();
-        std::stringstream tmp;
-        tmp << v;
-        bundle["text/plain"] = tmp.str();
-        return bundle;
-    }
-}
-#endif  // __CLING__
-
+#include "xmime.hpp"
 #endif

--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -744,8 +744,13 @@ namespace xt
     {
         return pretty_print(e, out);
     }
+}
 
 #ifdef __CLING__
+#include <nlohmann/json.hpp>
+
+namespace xt
+{
 
     template <class P>
     void compute_1d_row(std::stringstream& out, P& printer, const std::size_t& row_idx)
@@ -929,7 +934,7 @@ namespace xt
     }
 
     template <class E>
-    xeus::xjson mime_bundle_repr_impl(const E& expr)
+    nlohmann::json mime_bundle_repr_impl(const E& expr)
     {
         std::stringstream out;
 
@@ -953,7 +958,7 @@ namespace xt
 
         compute_nd_table(out, printer, expr, edgeitems);
 
-        auto bundle = xeus::xjson::object();
+        auto bundle = nlohmann::json::object();
         bundle["text/html"] = out.str();
         return bundle;
     }
@@ -962,7 +967,7 @@ namespace xt
     class xfunctor_view;
 
     template <class F, class CT>
-    xeus::xjson mime_bundle_repr(const xfunctor_view<F, CT>& expr)
+    nlohmann::json mime_bundle_repr(const xfunctor_view<F, CT>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -971,7 +976,7 @@ namespace xt
     class xfunction;
 
     template <class F, class... CT>
-    xeus::xjson mime_bundle_repr(const xfunction<F, CT...>& expr)
+    nlohmann::json mime_bundle_repr(const xfunction<F, CT...>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -980,7 +985,7 @@ namespace xt
     class xarray_container;
 
     template <class EC, layout_type L, class SC, class Tag>
-    xeus::xjson mime_bundle_repr(const xarray_container<EC, L, SC, Tag>& expr)
+    nlohmann::json mime_bundle_repr(const xarray_container<EC, L, SC, Tag>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -989,7 +994,7 @@ namespace xt
     class xtensor_container;
 
     template <class EC, std::size_t N, layout_type L, class Tag>
-    xeus::xjson mime_bundle_repr(const xtensor_container<EC, N, L, Tag>& expr)
+    nlohmann::json mime_bundle_repr(const xtensor_container<EC, N, L, Tag>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -998,7 +1003,7 @@ namespace xt
     class xfixed_container;
 
     template <class ET, class S, layout_type L, class Tag>
-    xeus::xjson mime_bundle_repr(const xfixed_container<ET, S, L, Tag>& expr)
+    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, Tag>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1007,7 +1012,7 @@ namespace xt
     class xreducer;
 
     template <class F, class CT, class X>
-    xeus::xjson mime_bundle_repr(const xreducer<F, CT, X>& expr)
+    nlohmann::json mime_bundle_repr(const xreducer<F, CT, X>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1016,7 +1021,7 @@ namespace xt
     class xoptional_assembly;
 
     template <class VE, class FE>
-    xeus::xjson mime_bundle_repr(const xoptional_assembly<VE, FE>& expr)
+    nlohmann::json mime_bundle_repr(const xoptional_assembly<VE, FE>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1025,7 +1030,7 @@ namespace xt
     class xoptional_assembly_adaptor;
 
     template <class VEC, class FEC>
-    xeus::xjson mime_bundle_repr(const xoptional_assembly_adaptor<VEC, FEC>& expr)
+    nlohmann::json mime_bundle_repr(const xoptional_assembly_adaptor<VEC, FEC>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1034,7 +1039,7 @@ namespace xt
     class xscalar;
 
     template <class CT>
-    xeus::xjson mime_bundle_repr(const xscalar<CT>& expr)
+    nlohmann::json mime_bundle_repr(const xscalar<CT>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1043,7 +1048,7 @@ namespace xt
     class xbroadcast;
 
     template <class CT, class X>
-    xeus::xjson mime_bundle_repr(const xbroadcast<CT, X>& expr)
+    nlohmann::json mime_bundle_repr(const xbroadcast<CT, X>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1052,7 +1057,7 @@ namespace xt
     class xgenerator;
 
     template <class F, class R, class S>
-    xeus::xjson mime_bundle_repr(const xgenerator<F, R, S>& expr)
+    nlohmann::json mime_bundle_repr(const xgenerator<F, R, S>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1061,7 +1066,7 @@ namespace xt
     class xview;
 
     template <class CT, class... S>
-    xeus::xjson mime_bundle_repr(const xview<CT, S...>& expr)
+    nlohmann::json mime_bundle_repr(const xview<CT, S...>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1070,7 +1075,7 @@ namespace xt
     class xstrided_view;
 
     template <class CT, class S, layout_type L, class FST>
-    xeus::xjson mime_bundle_repr(const xstrided_view<CT, S, L, FST>& expr)
+    nlohmann::json mime_bundle_repr(const xstrided_view<CT, S, L, FST>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1079,7 +1084,7 @@ namespace xt
     class xmasked_view;
 
     template <class CTD, class CTM>
-    xeus::xjson mime_bundle_repr(const xmasked_view<CTD, CTM>& expr)
+    nlohmann::json mime_bundle_repr(const xmasked_view<CTD, CTM>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }
@@ -1088,16 +1093,15 @@ namespace xt
     class xmasked_value;
 
     template <class T, class B>
-    xeus::xjson mime_bundle_repr(const xmasked_value<T, B>& v)
+    nlohmann::json mime_bundle_repr(const xmasked_value<T, B>& v)
     {
-        auto bundle = xeus::xjson::object();
+        auto bundle = nlohmann::json::object();
         std::stringstream tmp;
         tmp << v;
         bundle["text/plain"] = tmp.str();
         return bundle;
     }
-
-#endif
 }
+#endif  // __CLING__
 
 #endif

--- a/include/xtensor/xjson.hpp
+++ b/include/xtensor/xjson.hpp
@@ -139,7 +139,7 @@ namespace xt
      * serialization of user-defined types. The method is picked up by
      * argument-dependent lookup.
      *
-     * Note: for converting a JSON object to a value, nlohmann_json requiress
+     * Note: for converting a JSON object to a value, nlohmann_json requires
      * the value type to be default constructible, which is typically not the
      * case for expressions with a view semantics. In this case, from_json can
      * be called directly.

--- a/include/xtensor/xmime.hpp
+++ b/include/xtensor/xmime.hpp
@@ -1,0 +1,376 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_MIME_HPP
+#define XTENSOR_MIME_HPP
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "xio.hpp"
+
+namespace xt
+{
+
+    template <class P>
+    void compute_1d_row(std::stringstream& out, P& printer, const std::size_t& row_idx)
+    {
+        out << "<tr><td style='font-family:monospace;' title='" << row_idx << "'><pre>";
+        printer.print_next(out);
+        out << "</pre></td></tr>";
+    }
+
+    template <class P, class T>
+    void compute_1d_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems)
+    {
+        const auto& dim = expr.shape()[0];
+
+        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+            out << "<tr><td><center>...</center></td></tr>";
+            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+        }
+        out << "</tbody></table>";
+    }
+
+    template <class P>
+    void compute_2d_element(std::stringstream& out, P& printer, const std::string& idx_str,
+                            const std::size_t& row_idx, const std::size_t& column_idx)
+    {
+        out << "<td style='font-family:monospace;' title='("
+            << idx_str << row_idx << ", " << column_idx << ")'><pre>";
+        printer.print_next(out);
+        out << "</pre></td>";
+    }
+
+    template <class P, class T>
+    void compute_2d_row(std::stringstream& out, P& printer, const T& expr,
+                        const std::size_t& edgeitems, const std::string& idx_str,
+                        const std::size_t& row_idx)
+    {
+        const auto& dim = expr.shape()[expr.dimension() - 1];
+
+        out << "<tr>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t column_idx = 0; column_idx < dim; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t column_idx = 0; column_idx < edgeitems; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+            out << "<td><center>...</center></td>";
+            for (std::size_t column_idx = dim - edgeitems; column_idx < dim; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+        }
+        out << "</tr>";
+    }
+
+    template <class P, class T, class I>
+    void compute_2d_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        const auto& dim = expr.shape()[expr.dimension() - 2];
+        std::string idx_str;
+        std::for_each(idx.cbegin(), idx.cend(), [&idx_str](const auto& i) {
+            idx_str += std::to_string(i) + ", ";
+        });
+
+        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+            out << "<tr>";
+            for (std::size_t column_idx = 0; column_idx < 2 * edgeitems + 1; ++column_idx)
+            {
+                out << "<td><center>...</center></td>";
+            }
+            out << "</tr>";
+            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+        }
+        out << "</tbody></table>";
+    }
+
+    template <class P, class T, class I>
+    void compute_nd_row(std::stringstream& out, P& printer, const T& expr,
+                        const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        out << "<tr><td>";
+        compute_nd_table_impl(out, printer, expr, edgeitems, idx);
+        out << "</td></tr>";
+    }
+
+    template <class P, class T, class I>
+    void compute_nd_table_impl(std::stringstream& out, P& printer, const T& expr,
+                               const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        const auto& displayed_dimension = idx.size();
+        const auto& expr_dim = expr.dimension();
+        const auto& dim = expr.shape()[displayed_dimension];
+
+        if (expr_dim - displayed_dimension == 2)
+        {
+            return compute_2d_table(out, printer, expr, edgeitems, idx);
+        }
+
+        std::vector<I> idx2 = idx;
+        idx2.resize(displayed_dimension + 1);
+
+        out << "<table style='border-style:solid;border-width:1px;'>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t i = 0; i < dim; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+        }
+        else
+        {
+            for (std::size_t i = 0; i < edgeitems; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+            out << "<tr><td><center>...</center></td></tr>";
+            for (std::size_t i = dim - edgeitems; i < dim; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+        }
+        out << "</table>";
+    }
+
+    template <class P, class T>
+    void compute_nd_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems)
+    {
+        if (expr.dimension() == 1)
+        {
+            compute_1d_table(out, printer, expr, edgeitems);
+        }
+        else
+        {
+            std::vector<std::size_t> empty_vector;
+            compute_nd_table_impl(out, printer, expr, edgeitems, empty_vector);
+        }
+    }
+
+    template <class E>
+    nlohmann::json mime_bundle_repr_impl(const E& expr)
+    {
+        std::stringstream out;
+
+        std::size_t edgeitems = 0;
+        std::size_t size = compute_size(expr.shape());
+        if (size > print_options::print_options().threshold)
+        {
+            edgeitems = print_options::print_options().edgeitems;
+        }
+
+        if (print_options::print_options().precision != -1)
+        {
+            out.precision(print_options::print_options().precision);
+        }
+
+        detail::printer<E> printer(out.precision());
+
+        xstrided_slice_vector slice_vector;
+        detail::recurser_run(printer, expr, slice_vector, edgeitems);
+        printer.init();
+
+        compute_nd_table(out, printer, expr, edgeitems);
+
+        auto bundle = nlohmann::json::object();
+        bundle["text/html"] = out.str();
+        return bundle;
+    }
+
+    template <class F, class CT>
+    class xfunctor_view;
+
+    template <class F, class CT>
+    nlohmann::json mime_bundle_repr(const xfunctor_view<F, CT>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class... CT>
+    class xfunction;
+
+    template <class F, class... CT>
+    nlohmann::json mime_bundle_repr(const xfunction<F, CT...>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class EC, layout_type L, class SC, class Tag>
+    class xarray_container;
+
+    template <class EC, layout_type L, class SC, class Tag>
+    nlohmann::json mime_bundle_repr(const xarray_container<EC, L, SC, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    class xtensor_container;
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    nlohmann::json mime_bundle_repr(const xtensor_container<EC, N, L, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class ET, class S, layout_type L, class Tag>
+    class xfixed_container;
+
+    template <class ET, class S, layout_type L, class Tag>
+    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class CT, class X>
+    class xreducer;
+
+    template <class F, class CT, class X>
+    nlohmann::json mime_bundle_repr(const xreducer<F, CT, X>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class VE, class FE>
+    class xoptional_assembly;
+
+    template <class VE, class FE>
+    nlohmann::json mime_bundle_repr(const xoptional_assembly<VE, FE>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class VEC, class FEC>
+    class xoptional_assembly_adaptor;
+
+    template <class VEC, class FEC>
+    nlohmann::json mime_bundle_repr(const xoptional_assembly_adaptor<VEC, FEC>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT>
+    class xscalar;
+
+    template <class CT>
+    nlohmann::json mime_bundle_repr(const xscalar<CT>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class X>
+    class xbroadcast;
+
+    template <class CT, class X>
+    nlohmann::json mime_bundle_repr(const xbroadcast<CT, X>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class R, class S>
+    class xgenerator;
+
+    template <class F, class R, class S>
+    nlohmann::json mime_bundle_repr(const xgenerator<F, R, S>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class... S>
+    class xview;
+
+    template <class CT, class... S>
+    nlohmann::json mime_bundle_repr(const xview<CT, S...>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    class xstrided_view;
+
+    template <class CT, class S, layout_type L, class FST>
+    nlohmann::json mime_bundle_repr(const xstrided_view<CT, S, L, FST>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CTD, class CTM>
+    class xmasked_view;
+
+    template <class CTD, class CTM>
+    nlohmann::json mime_bundle_repr(const xmasked_view<CTD, CTM>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class T, class B>
+    class xmasked_value;
+
+    template <class T, class B>
+    nlohmann::json mime_bundle_repr(const xmasked_value<T, B>& v)
+    {
+        auto bundle = nlohmann::json::object();
+        std::stringstream tmp;
+        tmp << v;
+        bundle["text/plain"] = tmp.str();
+        return bundle;
+    }
+}
+
+#endif
+


### PR DESCRIPTION
 - make use of `nlohmann::json` instead of `xeus::xjson`. nlohmann_json is already an optional dependency.
 - Separate mime bundle rendering in separate header, `xmime.hpp`
 - For backward compatibility, it `xmime.hpp` is included by `xio.hpp` if `__CLING__` is defined.