### PR TITLE
add string specialization to lexical_cast

### DIFF
--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -50,6 +50,17 @@ namespace xt
         }
 
         template <>
+        inline std::string lexical_cast(const std::string& cell)
+        {
+            size_t first = cell.find_first_not_of(' ');
+            if(first == std::string::npos)
+                return cell;
+
+            size_t last = cell.find_last_not_of(' ');
+            return cell.substr(first, last==std::string::npos?cell.size():last+1);
+        }
+
+        template <>
         inline float lexical_cast<float>(const std::string& cell) { return std::stof(cell); }
 
         template <>

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -53,7 +53,7 @@ namespace xt
         inline std::string lexical_cast(const std::string& cell)
         {
             size_t first = cell.find_first_not_of(' ');
-            if(first == std::string::npos)
+            if (first == std::string::npos)
                 return cell;
 
             size_t last = cell.find_last_not_of(' ');


### PR DESCRIPTION
This fixes a bug when loading CSV files as strings (#1280 ). 