### PR TITLE
fix view index remap issue

### DIFF
--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -1616,14 +1616,20 @@ namespace xt
         auto func2 = [](const auto& s) {
             return xt::value(s, 0);
         };
+
+        auto first_copy = first;
         for (size_type i = 0; i != m_e.dimension(); ++i)
         {
             size_type k = newaxis_skip<S...>(i);
-            std::advance(first, difference_type(k - i));
-            if (first != last)
+
+            // need to advance captured `first`
+            first = first_copy;
+            std::advance(first, k - xt::integral_count_before<S...>(i));
+
+            if (first < last)
             {
                 index[i] = k < sizeof...(S) ?
-                    apply<size_type>(k, func1, m_slices) : *first++;
+                    apply<size_type>(k, func1, m_slices) : *first;
             }
             else
             {

--- a/include/xtensor/xview_utils.hpp
+++ b/include/xtensor/xview_utils.hpp
@@ -36,7 +36,7 @@ namespace xt
     template <class... S>
     constexpr std::size_t newaxis_count();
 
-// number of newaxis types in the specified sequence of types before specified index
+    // number of newaxis types in the specified sequence of types before specified index
     template <class... S>
     constexpr std::size_t newaxis_count_before(std::size_t i);
 
@@ -44,7 +44,6 @@ namespace xt
     template <class... S>
     constexpr std::size_t newaxis_skip(std::size_t i);
 
-    // return slice evaluation and increment iterator
     template <class S, class It>
     inline disable_xslice<S, std::size_t> get_slice_value(const S& s, It&) noexcept
     {
@@ -54,7 +53,7 @@ namespace xt
     template <class S, class It>
     inline auto get_slice_value(const xslice<S>& slice, It& it) noexcept
     {
-        return slice.derived_cast()(typename S::size_type(*it++));
+        return slice.derived_cast()(typename S::size_type(*it));
     }
 
     /***********************

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -578,8 +578,13 @@ namespace xt
         std::array<std::size_t, 3> idx2 = {1, 2, 0};
         EXPECT_EQ(a(1, 2), view2.element(idx2.begin(), idx2.end()));
 
-        std::array<std::size_t, 3> idx3 = {1, 2};
+        std::array<std::size_t, 2> idx3 = {1, 2};
         EXPECT_EQ(a(1, 2), view3.element(idx3.begin(), idx3.end()));
+
+        xt::xarray<float> x5 = xt::ones<float>({1,4,16,16});
+        auto view7 = xt::view(x5, xt::all(), xt::newaxis(), xt::all(), xt::all(), xt::all());
+        std::array<std::size_t, 5> idx4 = {0, 0, 2, 14, 12};
+        EXPECT_EQ(view7.element(idx4.begin(), idx4.end()), 1);
     }
 
     TEST(xview, newaxis_iterating)
@@ -1158,7 +1163,7 @@ namespace xt
 
         EXPECT_EQ(va[0], a[3]);
         EXPECT_EQ(va[1], a[4]);
-        EXPECT_EQ(*va.end(), *a.end());
+        EXPECT_EQ(va.end(), a.end());
         EXPECT_TRUE(std::equal(a.begin() + 3, a.end(), va.begin()));
         EXPECT_EQ(a.size() - 3, va.size());
 
@@ -1206,8 +1211,6 @@ namespace xt
             ++rb_iter;
         }
         EXPECT_EQ(rb_iter, vbe.rend());
-
-
     }
 
     TEST(xview, data_offset)


### PR DESCRIPTION
The index computation is clearer when advancing the index in the loop instead of the accessor that's called from the lambda, and this also prevents issues with a view like `all, newaxis, all, all, all` where `advance` was called on every iteration with the newaxis offset.