### PR TITLE
fixed reducer for 0D input

### DIFF
--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -1124,28 +1124,35 @@ namespace xt
     template <class F, class CT, class X>
     inline auto xreducer_stepper<F, CT, X>::aggregate(size_type dim) const -> reference
     {
-        size_type index = axis(dim);
-        size_type size = shape(index);
         reference res;
-        if (dim != m_reducer->m_axes.size() - 1)
+        if(m_reducer->m_e.shape().empty())
         {
-            res = aggregate(dim + 1);
-            for (size_type i = 1; i != size; ++i)
-            {
-                m_stepper.step(index);
-                res = m_reducer->m_merge(res, aggregate(dim + 1));
-            }
+            res = m_reducer->m_init(*m_stepper);
         }
         else
         {
-            res = m_reducer->m_init(*m_stepper);
-            for (size_type i = 1; i != size; ++i)
+            size_type index = axis(dim);
+            size_type size = shape(index);
+            if (dim != m_reducer->m_axes.size() - 1)
             {
-                m_stepper.step(index);
-                res = m_reducer->m_reduce(res, *m_stepper);
+                res = aggregate(dim + 1);
+                for (size_type i = 1; i != size; ++i)
+                {
+                    m_stepper.step(index);
+                    res = m_reducer->m_merge(res, aggregate(dim + 1));
+                }
             }
+            else
+            {
+                res = m_reducer->m_init(*m_stepper);
+                for (size_type i = 1; i != size; ++i)
+                {
+                    m_stepper.step(index);
+                    res = m_reducer->m_reduce(res, *m_stepper);
+                }
+            }
+            m_stepper.reset(index);
         }
-        m_stepper.reset(index);
         return res;
     }
 

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1396,6 +1396,11 @@ namespace xt
         #endif
         }
 
+        constexpr bool empty() const noexcept
+        {
+            return size() == size_type(0);
+        }
+
         constexpr size_type size() const noexcept
         {
             return N;

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -501,4 +501,15 @@ namespace xt
         auto resab = forward_normalize<std::array<std::size_t, 4>>(x, sab);
         EXPECT_EQ(resab, saa);
     }
+
+    TEST(xreducer, input_0d)
+    {
+        xt::xarray<double> a;
+        EXPECT_EQ(0., xt::amin(a)[0]);
+
+        using A = std::array<double, 2>;
+        xt::xarray<double> b(1.2);
+        EXPECT_EQ(b.dimension(), 0u);
+        EXPECT_EQ(minmax(b)(), (A{1.2, 1.2}));
+    }
 }


### PR DESCRIPTION
Fixes #1291.

The fix of `check_element_index` will be done in a separate PR because it requires another fix in the reducers that are unrelated to this bug.