### PR TITLE
from_indices: enabled 1-d index arrays

### DIFF
--- a/docs/source/api/xarray.rst
+++ b/docs/source/api/xarray.rst
@@ -18,3 +18,6 @@ Defined in ``xtensor/xarray.hpp``
 
 .. doxygentypedef:: xt::xarray_optional
    :project: xtensor
+
+.. doxygentypedef:: xt::from_indices
+   :project: xtensor

--- a/docs/source/api/xtensor.rst
+++ b/docs/source/api/xtensor.rst
@@ -18,6 +18,3 @@ Defined in ``xtensor/xtensor.hpp``
 
 .. doxygentypedef:: xt::xtensor_optional
    :project: xtensor
-
-.. doxygentypedef:: xt::from_indices
-   :project: xtensor

--- a/include/xtensor/xarray.hpp
+++ b/include/xtensor/xarray.hpp
@@ -590,6 +590,48 @@ namespace xt
     {
         return m_storage;
     }
+
+    /**
+     * Converts `std::vector<index_type>` (returned e.g. from `xt::argwhere`) to `xarray`.
+     * @param vector of indices
+     * @return `xt::xarray<typename index_type::value_type>` (e.g. `xt::xarray<size_t>`)
+     */
+    template <class T>
+    inline auto from_indices(const std::vector<T> &idx)
+    {
+        using return_type = xarray<typename T::value_type>;
+        using size_type = typename return_type::size_type;
+
+        if (idx.size() == 0)
+        {
+            return_type out = empty<typename T::value_type>({size_type(0), size_type(0)});
+            return out;
+        }
+
+        if (idx[0].size() == 1)
+        {
+            return_type out = empty<typename T::value_type>({idx.size()});
+
+            for (size_type i = 0; i < out.shape()[0]; ++i)
+            {
+                out(i) = idx[i][0];
+            }
+
+            return out;
+        }
+
+        return_type out = empty<typename T::value_type>({idx.size(), idx[0].size()});
+
+        for (size_type i = 0; i < out.shape()[0]; ++i)
+        {
+            for (size_type j = 0; j < out.shape()[1]; ++j)
+            {
+                out(i, j) = idx[i][j];
+            }
+        }
+
+        return out;
+    };
 }
 
 #endif

--- a/include/xtensor/xtensor.hpp
+++ b/include/xtensor/xtensor.hpp
@@ -518,36 +518,6 @@ namespace xt
     {
         return m_storage;
     }
-
-    /**
-     * Converts `std::vector<index_type>` (returned e.g. from `xt::argwhere`) to `xtensor`.
-     * @param vector of indices
-     * @return `xt::tensor<typename index_type::value_type, 2>` (e.g. `xt::tensor<size_t, 2>`)
-     */
-    template <class T>
-    inline auto from_indices(const std::vector<T> &idx)
-    {
-        using return_type = xtensor<typename T::value_type, 2>;
-        using size_type = typename return_type::size_type;
-
-        if (idx.size() == 0)
-        {
-            return_type out = empty<typename T::value_type>({size_type(0), size_type(0)});
-            return out;
-        }
-
-        return_type out = empty<typename T::value_type>({idx.size(), idx[0].size()});
-
-        for (size_type i = 0; i < out.shape()[0]; ++i)
-        {
-            for (size_type j = 0; j < out.shape()[1]; ++j)
-            {
-                out(i, j) = idx[i][j];
-            }
-        }
-
-        return out;
-    };
 }
 
 #endif


### PR DESCRIPTION
Returns 1-d indices when relevant. E.g.

```cpp
#define XTENSOR_ENABLE_ASSERT 1

#include <xtensor/xtensor.hpp>
#include <xtensor/xarray.hpp>
#include <xtensor/xrandom.hpp>
#include <xtensor/xmath.hpp>
#include <xtensor/xio.hpp>

int main()
{
  xt::xtensor<double,1> A = xt::random::randn<double>({100});

  xt::xtensor<size_t,1> idx = xt::from_indices(xt::argwhere(A<.1));

  std::cout << idx << std::endl;
}
```

Now gives a 1-d array:

```none
{ 0,  2,  4,  6,  9, 11, 12, 14, 16, 17, 18, 19, 21, 22, 24, 26, 27, 28,
 29, 30, 34, 41, 42, 44, 46, 48, 54, 56, 58, 59, 61, 62, 63, 65, 67, 70,
 71, 72, 79, 81, 84, 86, 88, 90, 93, 94, 96, 99}
```