### PR TITLE
make functor adaptor stepper work for proxy specializations

### DIFF
--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -549,8 +549,10 @@ namespace xt
 
         using functor_type = F;
 
+        using proxy_inner = xproxy_inner_types<decltype(std::declval<F>()(*std::declval<ST>()))>;
+        using proxy = typename proxy_inner::proxy;
         using value_type = typename functor_type::value_type;
-        using reference = apply_cv_t<typename ST::reference, value_type>;
+        using reference = typename proxy_inner::reference;
         using pointer = std::remove_reference_t<reference>*;
         using size_type = typename ST::size_type;
         using difference_type = typename ST::difference_type;

--- a/include/xtensor/xoptional_assembly_storage.hpp
+++ b/include/xtensor/xoptional_assembly_storage.hpp
@@ -246,8 +246,8 @@ namespace xt
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::operator=(self_type&& rhs) -> self_type&
     {
-        m_value = std::move(rhs.m_value);
-        m_has_value = std::move(rhs.m_has_value);
+        m_value = std::forward<VE>(rhs.m_value);
+        m_has_value = std::forward<FE>(rhs.m_has_value);
         return *this;
     }
 

--- a/include/xtensor/xoptional_assembly_storage.hpp
+++ b/include/xtensor/xoptional_assembly_storage.hpp
@@ -239,7 +239,7 @@ namespace xt
 
     template <class VE, class FE>
     inline xoptional_assembly_storage<VE, FE>::xoptional_assembly_storage(self_type&& rhs)
-        : m_value(std::move(rhs.m_value)), m_has_value(std::move(rhs.m_has_value))
+        : m_value(std::forward<VE>(rhs.m_value)), m_has_value(std::forward<FE>(rhs.m_has_value))
     {
     }
 


### PR DESCRIPTION
@JohanMabille I have to use forward in the move constructor because otherwise lvalue references are wrongfully casted to rvalues.