### PR TITLE
Set CMAKE_CXX_STANDARD instead of CMAKE_CXX_FLAGS

### DIFF
--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -249,12 +249,16 @@ namespace xt
             using type = xarray<T, L>;
         };
 
+#if defined(__GNUC__) && (__GNUC__ > 6)
+#if __cplusplus == 201703L 
         template <template <class, std::size_t, class, bool> class S, class X, std::size_t N, class A, bool Init>
         struct xtype_for_shape<S<X, N, A, Init>>
         {
             template <class T, layout_type L>
             using type = xarray<T, L>;
         };
+#endif // __cplusplus == 201703L
+#endif // __GNUC__ && (__GNUC__ > 6)
 
         template <template <class, std::size_t> class S, class X, std::size_t N>
         struct xtype_for_shape<S<X, N>>

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -249,6 +249,13 @@ namespace xt
             using type = xarray<T, L>;
         };
 
+        template <template <class, std::size_t, class, bool> class S, class X, std::size_t N, class A, bool Init>
+        struct xtype_for_shape<S<X, N, A, Init>>
+        {
+            template <class T, layout_type L>
+            using type = xarray<T, L>;
+        };
+
         template <template <class, std::size_t> class S, class X, std::size_t N>
         struct xtype_for_shape<S<X, N>>
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,10 +29,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
     if (CPP17)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+        set(CMAKE_CXX_STANDARD 17)
         message(STATUS "Building with -std=c++17")
     elseif (HAS_CPP14_FLAG)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+        set(CMAKE_CXX_STANDARD 14)
         message(STATUS "Building with -std=c++14")
     else()
         message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,8 +27,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
     CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
+    CHECK_CXX_COMPILER_FLAG("-std=c++17" HAS_CPP17_FLAG)
 
-    if (CPP17)
+    if (CPP17 AND HAS_CPP17_FLAG)
         set(CMAKE_CXX_STANDARD 17)
         message(STATUS "Building with -std=c++17")
     elseif (HAS_CPP14_FLAG)
@@ -37,6 +38,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     else()
         message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
     endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 if(MSVC)

--- a/test/test_xdatesupport.cpp
+++ b/test/test_xdatesupport.cpp
@@ -6,6 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#if defined(__GNUC__) && (__GNUC__ == 7) && (__cplusplus == 201703L)
+#warning "test_xdatesupport.cpp has been deactivated because it leads to internal compiler error"
+#else
+
 #include "gtest/gtest.h"
 
 #include <chrono>
@@ -83,3 +87,6 @@ namespace xt
         EXPECT_EQ(cmp_res, equal(tarr, arrpf));
     }
 }
+
+#endif // defined(__GNUC__) && (__GNUC__ == 7) && (__cplusplus == 201703L)
+


### PR DESCRIPTION
As in https://github.com/QuantStack/xtensor/pull/1329 and https://travis-ci.org/QuantStack/xtensor/jobs/477792952#L843.
`make` run command
`/usr/bin/g++-7  -DXTENSOR_USE_XSIMD -I/home/travis/build/QuantStack/xtensor/include -isystem /home/travis/miniconda/include  -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion -Wold-style-cast -Wunused-variable -std=c++17 -O3 -DNDEBUG   -std=gnu++14 -o CMakeFiles/test_xtensor_lib.dir/main.cpp.o -c /home/travis/build/QuantStack/xtensor/test/main.cpp`

There are both `-std=c++17` and `-std=gnu++14`. The latter override the former.