### PR TITLE
Allow argmax() and argmin() to specify the layout. QuantStack/xtensor-r#89

### DIFF
--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -393,15 +393,15 @@ namespace xt
             return idx;
         }
 
-        template <class E, class F>
+        template <layout_type L, class E, class F>
         inline xtensor<std::size_t, 0> arg_func_impl(const E& e, F&& f)
         {
-            return cmp_idx(e.template begin<XTENSOR_DEFAULT_LAYOUT>(),
-                           e.template end<XTENSOR_DEFAULT_LAYOUT>(), 1,
+            return cmp_idx(e.template begin<L>(),
+                           e.template end<L>(), 1,
                            std::forward<F>(f));
         }
 
-        template <class E, class F>
+        template <layout_type L, class E, class F>
         inline typename argfunc_result_type<E>::type
         arg_func_impl(const E& e, std::size_t axis, F&& cmp)
         {
@@ -412,7 +412,7 @@ namespace xt
 
             if (e.dimension() == 1)
             {
-                return arg_func_impl(e, std::forward<F>(cmp));
+                return arg_func_impl<L>(e, std::forward<F>(cmp));
             }
 
             result_shape_type alt_shape;
@@ -460,12 +460,12 @@ namespace xt
         }
     }
 
-    template <class E>
+    template <layout_type L = layout_type::row_major, class E>
     inline auto argmin(const xexpression<E>& e)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, std::less<value_type>());
+        return detail::arg_func_impl<L>(ed, std::less<value_type>());
     }
 
     /**
@@ -476,20 +476,20 @@ namespace xt
      *
      * @return returns xarray with positions of minimal value
      */
-    template <class E>
+    template <layout_type L = layout_type::row_major, class E>
     inline auto argmin(const xexpression<E>& e, std::size_t axis)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, axis, std::less<value_type>());
+        return detail::arg_func_impl<L>(ed, axis, std::less<value_type>());
     }
 
-    template <class E>
+    template <layout_type L = layout_type::row_major, class E>
     inline auto argmax(const xexpression<E>& e)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, std::greater<value_type>());
+        return detail::arg_func_impl<L>(ed, std::greater<value_type>());
     }
 
     /**
@@ -500,12 +500,12 @@ namespace xt
      *
      * @return returns xarray with positions of maximal value
      */
-    template <class E>
+    template <layout_type L = layout_type::row_major, class E>
     inline auto argmax(const xexpression<E>& e, std::size_t axis)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, axis, std::greater<value_type>());
+        return detail::arg_func_impl<L>(ed, axis, std::greater<value_type>());
     }
 
     /**

--- a/test/test_xsort.cpp
+++ b/test/test_xsort.cpp
@@ -107,9 +107,8 @@ namespace xt
         xarray<double> b = {1,3,4,-100};
         xarray<double, layout_type(int(XTENSOR_DEFAULT_LAYOUT) & 0x03)> ar = {{5, 3, 1}, {4, 4, 4}};
 
-        xarray<std::size_t> ex;
+        xarray<std::size_t> ex = 2ul;
 
-        ex = (XTENSOR_DEFAULT_LAYOUT == layout_type::row_major) ? 2ul : 4ul;
         EXPECT_EQ(ex, argmin(a));
 
         EXPECT_EQ(size_t(3), argmin(b)());
@@ -125,7 +124,6 @@ namespace xt
         EXPECT_EQ(ex, argmin(xa));
         EXPECT_EQ(ex_2, argmin(xa, 0));
         EXPECT_EQ(ex_3, argmin(xa, 1));
-
     }
 
     TEST(xsort, argmax)


### PR DESCRIPTION
See https://github.com/QuantStack/xtensor-r/issues/89

CC @SylvainCorlay 

This PR:

- Adds a layout template argument to `argmin()` and `argmax()`
- Defaults it to `row_major`

Question:

- For `argmin(const xexpression<E>& e)` this is definitely necessary. For `argmin(const xexpression<E>& e, std::size_t axis)` I do not think it is necessary, but have included it for consistency. It get's passed through when the dimension of `e` is `1`, but otherwise is not used. When the dimension is `1`, the layout probably doesn't matter, right? Making this potentially unnecessary. I can remove if needed.

I've recompiled `rray` with this and all seems well and it seems to work fine!