### PR TITLE
Pass layout_type through to result iterator

### DIFF
--- a/include/xtensor/xsort.hpp
+++ b/include/xtensor/xsort.hpp
@@ -423,7 +423,7 @@ namespace xt
             std::copy(e.shape().cbegin() + std::ptrdiff_t(axis) + 1, e.shape().cend(), alt_shape.begin() + std::ptrdiff_t(axis));
 
             result_type result = result_type::from_shape(std::move(alt_shape));
-            auto result_iter = result.begin();
+            auto result_iter = result.template begin<L>();
 
             auto arg_func_lambda = [&result_iter, &cmp](auto begin, auto end) {
                 std::size_t idx = 0;


### PR DESCRIPTION
Related to #1331.

When using `argmax()` / `argmin()` with >2D arrays, I noticed that it was filling in the _result_ in a column major manner. A wild guess at passing through the new `layout_type` template arg to the result iterator seems to fix the issue for me.