### PR TITLE
Implemented share method

### DIFF
--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -25,6 +25,12 @@
 namespace xt
 {
 
+    template <class D>
+    class xexpression;
+
+    template <class D>
+    auto make_xshared(xexpression<D>&&);
+
     /***************************
      * xexpression declaration *
      ***************************/
@@ -54,7 +60,7 @@ namespace xt
 
     protected:
 
-        xexpression() = default;
+        xexpression();
         ~xexpression() = default;
 
         xexpression(const xexpression&) = default;
@@ -62,11 +68,23 @@ namespace xt
 
         xexpression(xexpression&&) = default;
         xexpression& operator=(xexpression&&) = default;
+
+    private:
+
+        std::shared_ptr<D> p_shared;
+
+        friend auto make_xshared<D>(xexpression<D>&&);
     };
 
     /******************************
      * xexpression implementation *
      ******************************/
+
+    template <class D>
+    inline xexpression<D>::xexpression()
+        : p_shared(nullptr)
+    {
+    }
 
     /**
      * @name Downcast functions
@@ -511,7 +529,7 @@ namespace xt
         static constexpr layout_type static_layout = E::static_layout;
         static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
 
-        explicit xshared_expression(std::shared_ptr<E>&& ptr);
+        explicit xshared_expression(const std::shared_ptr<E>& ptr);
         long use_count() const noexcept;
 
         template <class... Args>
@@ -643,8 +661,8 @@ namespace xt
      * @sa make_xshared
      */
     template <class E>
-    inline xshared_expression<E>::xshared_expression(std::shared_ptr<E>&& ptr)
-        : m_ptr(std::move(ptr))
+    inline xshared_expression<E>::xshared_expression(const std::shared_ptr<E>& ptr)
+        : m_ptr(ptr)
     {
     }
 
@@ -665,9 +683,39 @@ namespace xt
      * @return xshared expression
      */
     template <class E>
-    auto make_xshared(xexpression<E>&& expr)
+    inline auto make_xshared(xexpression<E>&& expr)
     {
-        return xshared_expression<E>(std::make_shared<E>(std::move(expr).derived_cast()));
+        if(expr.p_shared == nullptr)
+        {
+            expr.p_shared = std::make_shared<E>(std::move(expr).derived_cast());
+        }
+        return  xshared_expression<E>(expr.p_shared);
+    }
+
+    /**
+     * Helper function to create shared expression from any xexpression
+     *
+     * @param expr rvalue expression that will be shared
+     * @return xshared expression
+     * @sa make_xshared
+     */
+    template <class E>
+    inline auto share(xexpression<E>& expr)
+    {
+        return make_xshared(std::move(expr));
+    }
+
+    /**
+     * Helper function to create shared expression from any xexpression
+     *
+     * @param expr rvalue expression that will be shared
+     * @return xshared expression
+     * @sa make_xshared
+     */
+    template <class E>
+    inline auto share(xexpression<E>&& expr)
+    {
+        return make_xshared(std::move(expr));
     }
 
 #undef XTENSOR_FORWARD_METHOD

--- a/test/test_xexpression.cpp
+++ b/test/test_xexpression.cpp
@@ -41,27 +41,36 @@ namespace xt
         EXPECT_EQ(L, XTENSOR_DEFAULT_LAYOUT);
         EXPECT_EQ(contig, true);
 
-        EXPECT_EQ(sa.use_count(), 1);
-        auto cpysa = sa;
         EXPECT_EQ(sa.use_count(), 2);
+        auto cpysa = sa;
+        EXPECT_EQ(sa.use_count(), 3);
         
         std::stringstream buffer;
         buffer << sa;
         EXPECT_EQ(buffer.str(), "{{ 1.,  2.,  3.,  4.},\n { 5.,  6.,  7.,  8.}}");
     }
 
+    template <class E>
+    auto test_sum(E&& e)
+    {
+        return share(e) + share(e);
+    }
+
     TEST(xexpression, shared_xfunctions)
     {
         xarray<double> a = {{1,2,3,4}, {5,6,7,8}};
         xarray<double> ca = {{1,2,3,4}, {5,6,7,8}};
+        xarray<double> acopy(a);
 
         auto sa = make_xshared(std::move(a));
 
         auto expr1 = sa + sa;
         auto expr2 = a + a;
+        auto expr3 = test_sum(std::move(acopy));
 
-        EXPECT_EQ(sa.use_count(), 3);
+        EXPECT_EQ(sa.use_count(), 4);
         EXPECT_TRUE(all(equal(expr1, expr2)));
+        EXPECT_TRUE(all(equal(expr1, expr3)));
         std::stringstream buffer;
         buffer << expr1;
         EXPECT_EQ(buffer.str(), "{{  2.,   4.,   6.,   8.},\n { 10.,  12.,  14.,  16.}}");


### PR DESCRIPTION
With this PR, it is now possible to write things like:

```cpp
template <class E>
auto sin_plus_cos(xexpression<E>&& e)
{
    return xt::sin(xt::share(e)) + xt::cos(xt::share(e));

}
```