### PR TITLE
Test io on xfixed

### DIFF
--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1595,6 +1595,11 @@ namespace xt
             return m_array[idx];
         }
 
+        XTENSOR_FIXED_SHAPE_CONSTEXPR bool empty() const
+        {
+            return sizeof...(X) == 0; 
+        }
+
     private:
 
          XTENSOR_CONSTEXPR_ENHANCED_STATIC cast_type m_array = cast_type({X...});

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -168,7 +168,8 @@ namespace xt
 
             using xexpression_type = std::decay_t<CT>;
             using shape_type = typename xexpression_type::shape_type;
-            using index_type = xindex_type_t<shape_type>;
+            using inner_strides_type = get_strides_t<shape_type>;
+            using index_type = inner_strides_type;
             using size_type = typename xexpression_type::size_type;
             using value_type = typename xexpression_type::value_type;
             using reference = typename xexpression_type::reference;
@@ -201,7 +202,7 @@ namespace xt
         private:
 
             mutable CT* m_e;
-            shape_type m_strides;
+            inner_strides_type m_strides;
             mutable index_type m_index;
             size_type m_size;
             layout_type m_layout;
@@ -431,7 +432,6 @@ namespace xt
      * @name Data
      */
     //@{
-
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view_base<CT, S, L, FST>::operator()() -> reference
     {
@@ -794,7 +794,7 @@ namespace xt
         template <class CT>
         template <class FST>
         inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT* e, FST&& strides, layout_type layout)
-            : m_e(e), m_strides(xtl::forward_sequence<shape_type, FST>(strides)), m_layout(layout)
+            : m_e(e), m_strides(xtl::forward_sequence<inner_strides_type, FST>(strides)), m_layout(layout)
         {
             resize_container(m_index, m_e->dimension());
             m_size = m_e->size();

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1176,7 +1176,6 @@ namespace xt
     };
 #endif
 
-
     template <class S>
     struct get_strides_type
     {
@@ -1187,8 +1186,8 @@ namespace xt
     struct get_strides_type<fixed_shape<I...>>
     {
         // TODO we could compute the strides statically here.
-        //      But we'll need full constexpr support to have a
-        //      homogenous ``compute_strides`` method
+        //  But we'll need full constexpr support to have a
+        //  homogenous ``compute_strides`` method
         using type = std::array<std::ptrdiff_t, sizeof...(I)>;
     };
 

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -16,9 +16,10 @@
 
 #include "gtest/gtest.h"
 
-#include "xtensor/xfixed.hpp"
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xio.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xnoalias.hpp"
 #include "xtensor/xmanipulation.hpp"
@@ -273,6 +274,16 @@ namespace xt
 
         xt::noalias(Eps) = Epsd * 123;
         // Eps = Epsd * 123; <-- Enable after XTL release!
+    }
+
+    TEST(xtensor_fixed, print)
+    {
+        xtensor_fixed<char, xshape<2>> a = {0, 1};
+        xtensor_fixed<char, xshape<2>> b = {1, 1};
+
+        std::stringstream out;
+        out << a + b;
+        EXPECT_EQ("{1, 2}", out.str());
     }
 }
 


### PR DESCRIPTION
Fixes #1392.

This changes the signness of the `flat_expression_adaptor` storage and causes lots of sign conversion warnings. Needs some polish.
