### PR TITLE
Added accessors for xrange_adaptor members. Made internal methods static and private…

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -635,14 +635,14 @@ namespace xt
 
     private:
 
-        static auto normalize(const std::ptrdiff_t val,const std::size_t ssize)
+        static auto normalize(std::ptrdiff_t val,const std::size_t ssize)
         {
             std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
             val = (val >= 0) ? val : val + size;
             return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
         }
 
-        static auto get_stepped_range(const std::ptrdiff_t start,const std::ptrdiff_t stop,const std::ptrdiff_t step,const std::size_t ssize)
+        static auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop,const std::ptrdiff_t step,const std::size_t ssize)
         {
             std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
             start = (start >= 0) ? start : start + size;

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -635,16 +635,16 @@ namespace xt
 
     private:
 
-        static auto normalize(std::ptrdiff_t val,const std::size_t ssize)
+        static auto normalize(std::ptrdiff_t val, const std::size_t ssize)
         {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            const std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
             val = (val >= 0) ? val : val + size;
             return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
         }
 
-        static auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop,const std::ptrdiff_t step,const std::size_t ssize)
+        static auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, const std::ptrdiff_t step, const std::size_t ssize)
         {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            const std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
             start = (start >= 0) ? start : start + size;
             stop = (stop >= 0) ? stop : stop + size;
 

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -546,33 +546,6 @@ namespace xt
         {
         }
 
-        auto normalize(std::ptrdiff_t val, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            val = (val >= 0) ? val : val + size;
-            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
-        }
-
-        auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, std::ptrdiff_t step, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            start = (start >= 0) ? start : start + size;
-            stop = (stop >= 0) ? stop : stop + size;
-
-            if (step > 0)
-            {
-                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
-                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
-            }
-            else
-            {
-                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
-                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
-            }
-
-            return xstepped_range<std::ptrdiff_t>(start, stop, step);
-        }
-
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<std::is_integral<MI>::value &&
                                 std::is_integral<MA>::value &&
@@ -656,7 +629,38 @@ namespace xt
             return xall<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(size));
         }
 
+        A start() const { return m_start; }
+        B stop()  const { return m_stop;  }
+        C step()  const { return m_step;  }
+
     private:
+
+        static auto normalize(const std::ptrdiff_t val,const std::size_t ssize)
+        {
+            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            val = (val >= 0) ? val : val + size;
+            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
+        }
+
+        static auto get_stepped_range(const std::ptrdiff_t start,const std::ptrdiff_t stop,const std::ptrdiff_t step,const std::size_t ssize)
+        {
+            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            start = (start >= 0) ? start : start + size;
+            stop = (stop >= 0) ? stop : stop + size;
+
+            if (step > 0)
+            {
+                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
+                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
+            }
+            else
+            {
+                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
+                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
+            }
+
+            return xstepped_range<std::ptrdiff_t>(start, stop, step);
+        }
 
         A m_start;
         B m_stop;

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -1595,6 +1595,11 @@ namespace xt
             return m_array[idx];
         }
 
+        XTENSOR_FIXED_SHAPE_CONSTEXPR bool empty() const
+        {
+            return sizeof...(X) == 0; 
+        }
+
     private:
 
          XTENSOR_CONSTEXPR_ENHANCED_STATIC cast_type m_array = cast_type({X...});

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -168,7 +168,8 @@ namespace xt
 
             using xexpression_type = std::decay_t<CT>;
             using shape_type = typename xexpression_type::shape_type;
-            using index_type = xindex_type_t<shape_type>;
+            using inner_strides_type = get_strides_t<shape_type>;
+            using index_type = inner_strides_type;
             using size_type = typename xexpression_type::size_type;
             using value_type = typename xexpression_type::value_type;
             using reference = typename xexpression_type::reference;
@@ -201,7 +202,7 @@ namespace xt
         private:
 
             mutable CT* m_e;
-            shape_type m_strides;
+            inner_strides_type m_strides;
             mutable index_type m_index;
             size_type m_size;
             layout_type m_layout;
@@ -431,7 +432,6 @@ namespace xt
      * @name Data
      */
     //@{
-
     template <class CT, class S, layout_type L, class FST>
     inline auto xstrided_view_base<CT, S, L, FST>::operator()() -> reference
     {
@@ -794,7 +794,7 @@ namespace xt
         template <class CT>
         template <class FST>
         inline flat_expression_adaptor<CT>::flat_expression_adaptor(CT* e, FST&& strides, layout_type layout)
-            : m_e(e), m_strides(xtl::forward_sequence<shape_type, FST>(strides)), m_layout(layout)
+            : m_e(e), m_strides(xtl::forward_sequence<inner_strides_type, FST>(strides)), m_layout(layout)
         {
             resize_container(m_index, m_e->dimension());
             m_size = m_e->size();

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -1176,7 +1176,6 @@ namespace xt
     };
 #endif
 
-
     template <class S>
     struct get_strides_type
     {
@@ -1187,8 +1186,8 @@ namespace xt
     struct get_strides_type<fixed_shape<I...>>
     {
         // TODO we could compute the strides statically here.
-        //      But we'll need full constexpr support to have a
-        //      homogenous ``compute_strides`` method
+        //  But we'll need full constexpr support to have a
+        //  homogenous ``compute_strides`` method
         using type = std::array<std::ptrdiff_t, sizeof...(I)>;
     };
 

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -16,9 +16,10 @@
 
 #include "gtest/gtest.h"
 
-#include "xtensor/xfixed.hpp"
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xio.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xnoalias.hpp"
 #include "xtensor/xmanipulation.hpp"
@@ -273,6 +274,16 @@ namespace xt
 
         xt::noalias(Eps) = Epsd * 123;
         // Eps = Epsd * 123; <-- Enable after XTL release!
+    }
+
+    TEST(xtensor_fixed, print)
+    {
+        xtensor_fixed<char, xshape<2>> a = {0, 1};
+        xtensor_fixed<char, xshape<2>> b = {1, 1};
+
+        std::stringstream out;
+        out << a + b;
+        EXPECT_EQ("{1, 2}", out.str());
     }
 }
 


### PR DESCRIPTION
See issue #1397.
The primary goal of the patch is to add accessors to the 3 members of xrange_adaptor.
A a collateral "damage", I also converted the normalize and get_stepped_range as static private methods. All tests passed:
[==========] 879 tests from 71 test cases ran. (88 ms total)
[  PASSED  ] 879 tests.
