### PR TITLE
Added accessors for xrange_adaptor members. Made internal methods static and private.

### DIFF
--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -546,33 +546,6 @@ namespace xt
         {
         }
 
-        auto normalize(std::ptrdiff_t val, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            val = (val >= 0) ? val : val + size;
-            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
-        }
-
-        auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, std::ptrdiff_t step, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            start = (start >= 0) ? start : start + size;
-            stop = (stop >= 0) ? stop : stop + size;
-
-            if (step > 0)
-            {
-                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
-                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
-            }
-            else
-            {
-                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
-                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
-            }
-
-            return xstepped_range<std::ptrdiff_t>(start, stop, step);
-        }
-
         template <class MI = A, class MA = B, class STEP = C>
         inline std::enable_if_t<std::is_integral<MI>::value &&
                                 std::is_integral<MA>::value &&
@@ -656,7 +629,38 @@ namespace xt
             return xall<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(size));
         }
 
+        A start() const { return m_start; }
+        B stop()  const { return m_stop;  }
+        C step()  const { return m_step;  }
+
     private:
+
+        static auto normalize(std::ptrdiff_t val, const std::size_t ssize)
+        {
+            const std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            val = (val >= 0) ? val : val + size;
+            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
+        }
+
+        static auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, const std::ptrdiff_t step, const std::size_t ssize)
+        {
+            const std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            start = (start >= 0) ? start : start + size;
+            stop = (stop >= 0) ? stop : stop + size;
+
+            if (step > 0)
+            {
+                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
+                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
+            }
+            else
+            {
+                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
+                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
+            }
+
+            return xstepped_range<std::ptrdiff_t>(start, stop, step);
+        }
 
         A m_start;
         B m_stop;


### PR DESCRIPTION
See issue #1397.
The primary goal of the patch is to add accessors to the 3 members of xrange_adaptor.
A a collateral "damage", I also converted the normalize and get_stepped_range as static private methods. All tests passed:
[==========] 879 tests from 71 test cases ran. (88 ms total)
[ PASSED ] 879 tests.
xtensor-blas tested too.
This is one possible replacement for PR #1399, where some const are still there.