### PR TITLE
Added 'reshape' member to 'xgenerator' to make 'arange' more flexible

### DIFF
--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -22,6 +22,7 @@
 #include "xiterable.hpp"
 #include "xstrides.hpp"
 #include "xutils.hpp"
+#include "xstrided_view.hpp"
 
 namespace xt
 {
@@ -152,6 +153,9 @@ namespace xt
         template <class OR, class OF>
         rebind_t<OR, OF> build_generator(OF&& func) const;
 
+        template <class O = xt::dynamic_shape<typename shape_type::value_type>>
+        auto reshape(O&& shape) const;
+
     private:
 
         template <std::size_t dim>
@@ -173,7 +177,7 @@ namespace xt
      */
     //@{
     /**
-     * Constructs an xgenerator applying the specified function over the 
+     * Constructs an xgenerator applying the specified function over the
      * given shape.
      * @param f the function to apply
      * @param shape the shape of the xgenerator
@@ -390,6 +394,13 @@ namespace xt
     inline auto xgenerator<F, R, S>::build_generator(OF&& func) const -> rebind_t<OR, OF>
     {
         return rebind_t<OR, OF>(std::move(func), shape_type(m_shape));
+    }
+
+    template <class F, class R, class S>
+    template <class O>
+    inline auto xgenerator<F, R, S>::reshape(O&& shape) const
+    {
+        return reshape_view(*this, std::forward<xt::dynamic_shape<typename shape_type::value_type>>(shape));
     }
 
     template <class F, class R, class S>


### PR DESCRIPTION
I want to fix #1233. But honestly I'm too deep to even know if I'm working in the right direction. Can anybody help me in the right direction?

Currently 

```cpp
#include <xtensor/xarray.hpp>
#include <xtensor/xio.hpp>

int main()
{
  size_t n = 3;
  xt::xarray<size_t> a = xt::arange<size_t>(n*n).reshape({n,n});

  std::cout << a << std::endl;
}
```

fails to compile:

```bash
In file included from test.cpp:1:
In file included from ./xarray.hpp:18:
In file included from ./xbuffer_adaptor.hpp:20:
In file included from ./xstorage.hpp:21:
In file included from ./xtensor_simd.hpp:14:
./xutils.hpp:889:31: error: implicit instantiation of undefined template 'xt::rebind_container<long, std::initializer_list<unsigned long> >'
        using type = typename rebind_container<std::ptrdiff_t, S>::type;
                              ^
./xutils.hpp:902:5: note: in instantiation of template class 'xt::get_strides_type<std::initializer_list<unsigned long> >' requested here
    using get_strides_t = typename get_strides_type<C>::type;
    ^
./xstrided_view.hpp:631:9: note: in instantiation of template type alias 'get_strides_t' requested here
        get_strides_t<shape_type> strides;
        ^
./xgenerator.hpp:403:16: note: in instantiation of function template specialization 'xt::reshape_view<const
      xt::xgenerator<xt::detail::arange_generator<unsigned long, unsigned long>, unsigned long, std::__1::array<unsigned long, 1> > *,
      std::initializer_list<unsigned long> &>' requested here
        return reshape_view(this, shape);
               ^
test.cpp:7:50: note: in instantiation of function template specialization 'xt::xgenerator<xt::detail::arange_generator<unsigned long,
      unsigned long>, unsigned long, std::__1::array<unsigned long, 1> >::reshape<unsigned long>' requested here
  xt::xarray<size_t> a = xt::arange<size_t>(n*n).reshape({n,n});
                                                 ^
./xutils.hpp:77:12: note: template is declared here
    struct rebind_container;
           ^
```

