### PR TITLE
Added `xt::pad`

### DIFF
--- a/docs/source/api/function_index.rst
+++ b/docs/source/api/function_index.rst
@@ -18,3 +18,4 @@ Functions and generators
    xsort
    xrandom
    xhistogram
+   xpad

--- a/docs/source/api/xpad.rst
+++ b/docs/source/api/xpad.rst
@@ -1,0 +1,22 @@
+.. Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+xpad
+====
+
+Defined in ``xtensor/xpad.hpp``
+
+.. doxygenenum:: xt::pad_mode
+   :project: xtensor
+
+.. doxygenfunction:: xt::pad(E&& , const std::vector<std::vector<S>>&, pad_mode, V)
+   :project: xtensor
+
+.. doxygenfunction:: xt::pad(E&& , const std::vector<S>&, pad_mode, V)
+   :project: xtensor
+
+.. doxygenfunction:: xt::pad(E&& , S, pad_mode, V)
+   :project: xtensor

--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -1,0 +1,172 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay,  Wolf Vollprecht and  *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_PAD_HPP
+#define XTENSOR_PAD_HPP
+
+#include "xarray.hpp"
+#include "xtensor.hpp"
+#include "xview.hpp"
+#include "xstrided_view.hpp"
+
+using namespace xt::placeholders;  // to enable _ syntax
+
+namespace xt
+{
+    /**
+     * @brief Defines different algorithms to be used in ``xt::pad``
+     */
+    enum class pad_mode
+    {
+        constant,
+        symmetric,
+        periodic
+    };
+
+    namespace detail
+    {
+        template <class S, class T>
+        inline bool check_pad_width(const std::vector<std::vector<S>>& pad_width, const T& shape)
+        {
+            if (pad_width.size() != shape.size())
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis:
+     * `{{before_1, after_1}, ..., {before_N, after_N}}`.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    const std::vector<std::vector<S>>& pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        XTENSOR_ASSERT(detail::check_pad_width(pad_width, e.shape()));
+
+        using size_type = typename std::decay_t<E>::size_type;
+        using value_type = typename std::decay_t<E>::value_type;
+
+        auto out = e;
+
+        for (size_type axis = 0; axis < e.shape().size(); ++axis)
+        {
+            size_type nb = static_cast<size_type>(pad_width[axis][0]);
+            size_type ne = static_cast<size_type>(pad_width[axis][1]);
+
+            if (mode == pad_mode::constant)
+            {
+                auto shape_bgn = out.shape();
+                auto shape_end = out.shape();
+                shape_bgn[axis] = nb;
+                shape_end[axis] = ne;
+                auto bgn = constant_value * xt::ones<value_type>(shape_bgn);
+                auto end = constant_value * xt::ones<value_type>(shape_end);
+                out = xt::concatenate(xt::xtuple(bgn, out, end), axis);
+            }
+            else
+            {
+                xt::xstrided_slice_vector sv_bgn(e.shape().size(), xt::all());
+                xt::xstrided_slice_vector sv_end(e.shape().size(), xt::all());
+
+                if (mode == pad_mode::periodic)
+                {
+                    XTENSOR_ASSERT(nb <= out.shape()[axis]);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis]);
+                    sv_bgn[axis] = xt::range(out.shape()[axis]-ne, out.shape()[axis]);
+                    sv_end[axis] = xt::range(0, nb);
+                }
+                else if (mode == pad_mode::symmetric)
+                {
+                    XTENSOR_ASSERT(nb <= out.shape()[axis]);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis]);
+                    sv_bgn[axis] = xt::range(nb, _, -1);
+                    if (ne == out.shape()[axis])
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis], _, -1);
+                    }
+                    else
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis], out.shape()[axis]-ne, -1);
+                    }
+                }
+
+                auto bgn = xt::strided_view(out, sv_bgn);
+                auto end = xt::strided_view(out, sv_end);
+
+                out = xt::concatenate(xt::xtuple(bgn, out, end), axis);
+            }
+        }
+
+        return out;
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis:
+     * `{before, after}`.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    const std::vector<S>& pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        std::vector<std::vector<S>> pw(e.shape().size(), pad_width);
+
+        return pad(e, pw, mode, constant_value);
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    S pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        std::vector<std::vector<S>> pw(e.shape().size(), {pad_width, pad_width});
+
+        return pad(e, pw, mode, constant_value);
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(XTENSOR_TESTS
     test_xfunctor_adaptor.cpp
     test_xfixed.cpp
     test_xhistogram.cpp
+    test_xpad.cpp
     test_xindex_view.cpp
     test_xinfo.cpp
     test_xiterator.cpp

--- a/test/test_xpad.cpp
+++ b/test/test_xpad.cpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <complex>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "xtensor/xpad.hpp"
+
+namespace xt
+{
+    TEST(xpad, constant)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                    {0, 0, 0, 0, 1, 2, 0, 0, 0},
+                                    {0, 0, 0, 3, 4, 5, 0, 0, 0},
+                                    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                    {0, 0, 0, 0, 0, 0, 0, 0, 0}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{2,2}, {3,3}}, xt::pad_mode::constant);
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, periodic)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{0, 1, 2, 0, 1, 2, 0, 1, 2},
+                                    {3, 4, 5, 3, 4, 5, 3, 4, 5},
+                                    {0, 1, 2, 0, 1, 2, 0, 1, 2},
+                                    {3, 4, 5, 3, 4, 5, 3, 4, 5},
+                                    {0, 1, 2, 0, 1, 2, 0, 1, 2},
+                                    {3, 4, 5, 3, 4, 5, 3, 4, 5}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{2,2}, {3,3}}, xt::pad_mode::periodic);
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, symmetric)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{5, 4, 3, 3, 4, 5, 5, 4, 3},
+                                    {2, 1, 0, 0, 1, 2, 2, 1, 0},
+                                    {2, 1, 0, 0, 1, 2, 2, 1, 0},
+                                    {5, 4, 3, 3, 4, 5, 5, 4, 3},
+                                    {5, 4, 3, 3, 4, 5, 5, 4, 3},
+                                    {2, 1, 0, 0, 1, 2, 2, 1, 0}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{2,2}, {3,3}}, xt::pad_mode::symmetric);
+
+        EXPECT_EQ(b, c);
+    }
+}


### PR DESCRIPTION
I have started to work on  `xt::pad`. Before I add more cases maybe you can share your feedback?

Example:

```cpp
#include "xtensor.hpp"
#include "xarray.hpp"
#include "xio.hpp"
#include "xpad.hpp"

int main()
{
  xt::xarray<size_t> a = xt::arange<size_t>(2*3).reshape({-1,3});

  auto b = xt::pad(a, {2,3}, xt::pad_mode::periodic);

  std::cout << a << std::endl;
  std::cout << b << std::endl;

  return 0;
}
```