### PR TITLE
Avoid signed integer overflow in integer printer

### DIFF
--- a/include/xtensor/xio.hpp
+++ b/include/xtensor/xio.hpp
@@ -440,7 +440,7 @@ namespace xt
             void init()
             {
                 m_it = m_cache.cbegin();
-                m_width = 1 + std::streamsize(std::log10(m_max)) + m_sign;
+                m_width = 1 + std::streamsize((m_max > 0) ? std::log10(m_max) : 0) + m_sign;
             }
 
             std::ostream& print_next(std::ostream& out)


### PR DESCRIPTION
The following code triggers signed integer overflow:
```cpp
xtensor_fixed<int, xshape<1>> v({0});
std::cout << v;
```

In `detail::recurser_run`, the 0-D expression above will call `detail::printer<int>::update(0)`:
https://github.com/QuantStack/xtensor/blob/master/include/xtensor/xio.hpp#L262

This leaves the default initalized [`m_max = 0`](https://github.com/QuantStack/xtensor/blob/master/include/xtensor/xio.hpp#L478). Thus, [`printer<int>::init()`](https://github.com/QuantStack/xtensor/blob/master/include/xtensor/xio.hpp#L443) contains
```cpp
std::streamsize(std::log10(0))
```
Since `std::streamsize` is signed integer, this translates to `std::streamsize(-HUGE_VAL)`. 

Looking at other invocations of `std::log10`, it seems they guard, either explicitly or by class invariant, against this case.

Some asides:
- Unless I'm missing any other uses of the value `m_max`, we could probably get away with setting `m_max = 1` in the default in-class initializer (since `std::streamsize(std::log10(1)) == 0` anyway), but this approach is more consistent with the other specializations.
- I only caught this while using the clang-6 undefined behavior sanitizer in some code that used `xtensor_fixed` to evaluate the zeros of a polynomial. In view of that not sure if it makes sense to add a unit test, as I don't think printing a single zero would have caught the error unless you were checking the `FE_` exceptions too. 