### PR TITLE
linspace can now be reshaped

### DIFF
--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -187,6 +187,16 @@ namespace xt
         ASSERT_EQ(m_assigned(3), at_3);
     }
 
+    TEST(xbuilder, linspace_reshape)
+    {
+        xarray<double> a = linspace<double>(20., 50.).reshape({5, 10});
+        EXPECT_EQ(a.dimension(), size_t(2));
+        decltype(a)::shape_type expected_shape = {5, 10};
+        EXPECT_EQ(a.shape(), expected_shape);
+        EXPECT_EQ(a(0, 0), 20.);
+        EXPECT_EQ(a(4, 9), 50.);
+    }
+
     TEST(xbuilder, linspace_1_point)
     {
         xt::xarray<double> a = linspace<double>(0., 0., 1, false);


### PR DESCRIPTION
Fixes #1482 

This does not add the `reshape` method to `xfunction` (this is not possible since it would lead to circular includes) but rather moves the cast inside the `arange_generator` so now `linspace` and `logspace` return `xgenerator` objects instead of `xfunction` objects.