### PR TITLE
Add tests for xoperation simdification

### DIFF
--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -93,7 +93,7 @@ namespace xt
 
         template <class V>
         struct has_simd_type
-            : std::integral_constant<bool, !std::is_same<V, xsimd::simd_type<V>>::value>
+            : std::integral_constant<bool, !std::is_same<V, xsimd::simd_type<V>>::value || std::is_same<bool, V>::value>
         {
         };
 
@@ -326,7 +326,11 @@ namespace xt
         template <class UT = self_type, class = typename std::enable_if<UT::only_scalar::value>::type>
         operator value_type() const;
 
-        template <class align, class requested_type = value_type,
+        using simd_request_type = xtl::mpl::eval_if_t<std::is_same<bool, value_type>, 
+                                                     common_value_type<std::decay_t<CT>...>,
+                                                     xt::meta_identity<value_type>>;
+
+        template <class align, class requested_type = simd_request_type,
                   std::size_t N = xsimd::simd_traits<requested_type>::size>
         simd_return_type<requested_type> load_simd(size_type i) const;
 

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -101,8 +101,8 @@ namespace xt
                 return xtl::select(cond, v1, v2);
             }
 
-            template <class B>
-            constexpr B simd_apply(const get_batch_bool<B>& t1,
+            template <class BB, class B>
+            constexpr B simd_apply(const BB& t1,
                                    const B& t2,
                                    const B& t3) const noexcept
             {

--- a/test/test_xoperation.cpp
+++ b/test/test_xoperation.cpp
@@ -305,6 +305,18 @@ namespace xt
         bool_container b_2 = equal(a, other);
         bool_container expected_2 = {1, 1, 1, 0, 0};
         EXPECT_EQ(expected_2, b_2);
+
+        auto expr = equal(a, a);
+        using assign_traits = xassign_traits<xarray<bool>, decltype(expr)>;
+
+#if XTENSOR_USE_XSIMD
+        EXPECT_TRUE(has_simd_interface<decltype(expr)>());
+
+        EXPECT_TRUE(assign_traits::convertible_types());
+        EXPECT_TRUE(assign_traits::simd_size());
+        EXPECT_FALSE(assign_traits::forbid_simd());
+        EXPECT_TRUE(assign_traits::simd_assign());
+#endif
     }
 
     TYPED_TEST(operation, not_equal)
@@ -478,7 +490,7 @@ namespace xt
 
     TYPED_TEST(operation, where)
     {
-        TypeParam a = { { 1, 2, 3 },{ 0, 1, 0 },{ 0, 4, 1 } };
+        TypeParam a = {{ 1, 2, 3 }, { 0, 1, 0 }, { 0, 4, 1 }};
         double b = 1.0;
         TypeParam res = where(a > b, b, a);
         TypeParam expected = { { 1, 1, 1 },{ 0, 1, 0 },{ 0, 1, 1 } };
@@ -487,8 +499,16 @@ namespace xt
 #ifdef XTENSOR_USE_XSIMD
         // This will fail to compile if simd is broken for conditional_ternary
         auto func = where(a > b, b, a);
+        EXPECT_TRUE(has_simd_interface<decltype(func)>());
         auto s = func.template load_simd<xsimd::aligned_mode>(0);
         (void)s;
+
+        using assign_traits = xassign_traits<TypeParam, decltype(func)>;
+
+        EXPECT_TRUE(assign_traits::convertible_types());
+        EXPECT_TRUE(assign_traits::simd_size());
+        EXPECT_FALSE(assign_traits::forbid_simd());
+        EXPECT_TRUE(assign_traits::simd_assign());
 #endif
     }
 


### PR DESCRIPTION
This tests wether `xt::where` and `xt::equal` are correctly SIMDized (currently they are not).