### PR TITLE
refactoring of strided_view_base

### DIFF
--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -64,6 +64,9 @@ namespace xt
             using size_type = typename allocator_type::size_type;
             using difference_type = typename allocator_type::difference_type;
 
+            using data_type = CP;
+            using const_data_type = const CP;
+
             xbuffer_storage();
 
             template <class P>
@@ -72,14 +75,14 @@ namespace xt
             size_type size() const noexcept;
             void resize(size_type size);
 
-            pointer data() noexcept;
-            const_pointer data() const noexcept;
+            data_type data() noexcept;
+            const_data_type data() const noexcept;
 
             void swap(self_type& rhs) noexcept;
 
         private:
 
-            pointer p_data;
+            data_type p_data;
             size_type m_size;
         };
 
@@ -387,13 +390,13 @@ namespace xt
         }
 
         template <class CP, class A>
-        inline auto xbuffer_storage<CP, A>::data() noexcept -> pointer
+        inline auto xbuffer_storage<CP, A>::data() noexcept -> data_type
         {
             return p_data;
         }
 
         template <class CP, class A>
-        inline auto xbuffer_storage<CP, A>::data() const noexcept -> const_pointer
+        inline auto xbuffer_storage<CP, A>::data() const noexcept -> const_data_type
         {
             return p_data;
         }

--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -28,13 +28,14 @@ namespace xt
     struct xcontainer_inner_types<xdynamic_view<CT, S, L, FST>>
     {
         using xexpression_type = std::decay_t<CT>;
-        using undecay_expression = CT;
-        using reference = inner_reference_t<undecay_expression>;
+        using inner_closure_type = CT;
+        using reference = inner_reference_t<inner_closure_type>;
         using const_reference = typename xexpression_type::const_reference;
         using size_type = typename xexpression_type::size_type;
         using shape_type = std::decay_t<S>;
         using undecay_shape = S;
-        using inner_storage_type = FST;
+        using flat_storage = FST;
+        using inner_storage_type = typename FST::type;
         using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>>;
         static constexpr layout_type layout = L;
     };
@@ -91,7 +92,7 @@ namespace xt
         class xfake_slice;
     }
 
-    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = detail::flat_storage_type_t<CT>>
+    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = detail::flat_storage<CT>>
     class xdynamic_view : public xview_semantic<xdynamic_view<CT, S, L, FST>>,
                           public xiterable<xdynamic_view<CT, S, L, FST>>,
                           public extension::xdynamic_view_base_t<CT, S, L, FST>,
@@ -106,6 +107,7 @@ namespace xt
         using expression_tag = typename extension_base::expression_tag;
 
         using xexpression_type = typename base_type::xexpression_type;
+        using inner_closure_type = typename base_type::inner_closure_type;
         using base_type::is_const;
 
         using value_type = typename base_type::value_type;
@@ -144,11 +146,6 @@ namespace xt
 
         template <class CTA>
         xdynamic_view(CTA&& e, S&& shape, get_strides_t<S>&& strides, std::size_t offset, layout_type layout,
-                      slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept;
-
-        template <class CTA, class FLS>
-        xdynamic_view(CTA&& e, S&& shape, get_strides_t<S>&& strides, std::size_t offset, layout_type layout,
-                      FLS&& flatten_strides, layout_type flatten_layout,
                       slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept;
 
         template <class E>
@@ -225,7 +222,7 @@ namespace xt
         using const_container_iterator = typename storage_type::const_iterator;
 
         template <class E>
-        using rebind_t = xdynamic_view<E, S, L, detail::flat_storage_type_t<E>>;
+        using rebind_t = xdynamic_view<E, S, L, detail::flat_storage<E>>;
 
         template <class E>
         rebind_t<E> build_view(E&& e) const;
@@ -371,18 +368,6 @@ namespace xt
                                                        std::size_t offset, layout_type layout,
                                                        slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept
         : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides), offset, layout),
-          m_slices(std::move(slices)), m_adj_strides(std::move(adj_strides))
-    {
-    }
-
-    template <class CT, class S, layout_type L, class FST>
-    template <class CTA, class FLS>
-    inline xdynamic_view<CT, S, L, FST>::xdynamic_view(CTA&& e, S&& shape, get_strides_t<S>&& strides,
-                                                       std::size_t offset, layout_type layout,
-                                                       FLS&& flatten_strides, layout_type flatten_layout,
-                                                       slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept
-        : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides),
-                    offset, layout, std::forward<FLS>(flatten_strides), flatten_layout),
           m_slices(std::move(slices)), m_adj_strides(std::move(adj_strides))
     {
     }

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -72,11 +72,11 @@ namespace xt
         using self_type = xfunctor_applier_base<D>;
         using inner_types = xcontainer_inner_types<D>;
         using xexpression_type = typename inner_types::xexpression_type;
-        using undecay_expression = typename inner_types::undecay_expression;
+        using inner_closure_type = typename inner_types::inner_closure_type;
         using functor_type = typename inner_types::functor_type;
         using accessible_base = xaccessible<D>;
 
-        using extension_base = extension::xfunctor_view_base_t<functor_type, undecay_expression>;
+        using extension_base = extension::xfunctor_view_base_t<functor_type, inner_closure_type>;
         using expression_tag = typename extension_base::expression_tag;
 
         using value_type = typename functor_type::value_type;
@@ -139,7 +139,7 @@ namespace xt
         using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
         using const_reverse_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::const_reverse_iterator>;
 
-        explicit xfunctor_applier_base(undecay_expression) noexcept;
+        explicit xfunctor_applier_base(inner_closure_type) noexcept;
 
         template <class Func, class E>
         xfunctor_applier_base(Func&&, E&&) noexcept;
@@ -187,14 +187,14 @@ namespace xt
 
         template <class FCT = functor_type>
         auto data_element(size_type i)
-            -> decltype(std::declval<FCT>()(std::declval<undecay_expression>().data_element(i)))
+            -> decltype(std::declval<FCT>()(std::declval<inner_closure_type>().data_element(i)))
         {
             return m_functor(m_e.data_element(i));
         }
 
         template <class FCT = functor_type>
         auto data_element(size_type i) const
-            -> decltype(std::declval<FCT>()(std::declval<undecay_expression>().data_element(i)))
+            -> decltype(std::declval<FCT>()(std::declval<inner_closure_type>().data_element(i)))
         {
             return m_functor(m_e.data_element(i));
         }
@@ -204,14 +204,14 @@ namespace xt
         template <class align, class requested_type = typename xexpression_type::value_type,
                   std::size_t N = xsimd::simd_traits<requested_type>::size, class FCT = functor_type>
         auto load_simd(size_type i) const
-            -> decltype(std::declval<FCT>().template proxy_simd_load<align, requested_type, N>(std::declval<undecay_expression>(), i))
+            -> decltype(std::declval<FCT>().template proxy_simd_load<align, requested_type, N>(std::declval<inner_closure_type>(), i))
         {
             return m_functor.template proxy_simd_load<align, requested_type, N>(m_e, i);
         }
 
         template <class align, class simd, class FCT = functor_type>
         auto store_simd(size_type i, const simd& e)
-            -> decltype(std::declval<FCT>().template proxy_simd_store<align>(std::declval<undecay_expression>(), i, e))
+            -> decltype(std::declval<FCT>().template proxy_simd_store<align>(std::declval<inner_closure_type>(), i, e))
         {
             return m_functor.template proxy_simd_store<align>(m_e, i, e);
         }
@@ -299,7 +299,7 @@ namespace xt
 
     protected:
 
-        undecay_expression m_e;
+        inner_closure_type m_e;
         functor_type m_functor;
 
     private:
@@ -345,7 +345,7 @@ namespace xt
     struct xcontainer_inner_types<xfunctor_view<F, CT>>
     {
         using xexpression_type = std::decay_t<CT>;
-        using undecay_expression = CT;
+        using inner_closure_type = CT;
         using functor_type = std::decay_t<F>;
         using reference = typename functor_type::reference;
         using const_reference = typename functor_type::const_reference;
@@ -416,7 +416,7 @@ namespace xt
     struct xcontainer_inner_types<xfunctor_adaptor<F, CT>>
     {
         using xexpression_type = std::decay_t<CT>;
-        using undecay_expression = CT;
+        using inner_closure_type = CT;
         using functor_type = std::decay_t<F>;
         using reference = typename functor_type::reference;
         using const_reference = typename functor_type::const_reference;
@@ -597,7 +597,7 @@ namespace xt
      * @param e the underlying expression
      */
     template <class D>
-    inline xfunctor_applier_base<D>::xfunctor_applier_base(undecay_expression e) noexcept
+    inline xfunctor_applier_base<D>::xfunctor_applier_base(inner_closure_type e) noexcept
         : m_e(e), m_functor(functor_type())
     {
     }

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -483,10 +483,10 @@ namespace xt
             using uft = typename std::decay_t<CT>::flag_expression;
             using ucvt = typename std::decay_t<CT>::const_value_expression;
             using ucft = typename std::decay_t<CT>::const_flag_expression;
-            using value_expression = xdynamic_view<uvt, S, L, xt::detail::flat_storage_type_t<uvt>>;
-            using flag_expression = xdynamic_view<uft, S, L, xt::detail::flat_storage_type_t<uft>>;
-            using const_value_expression = xdynamic_view<ucvt, S, L, xt::detail::flat_storage_type_t<ucvt>>;
-            using const_flag_expression = xdynamic_view<ucft, S, L, xt::detail::flat_storage_type_t<ucft>>;
+            using value_expression = xdynamic_view<uvt, S, L, xt::detail::flat_storage<uvt>>;
+            using flag_expression = xdynamic_view<uft, S, L, xt::detail::flat_storage<uft>>;
+            using const_value_expression = xdynamic_view<ucvt, S, L, xt::detail::flat_storage<ucvt>>;
+            using const_flag_expression = xdynamic_view<ucft, S, L, xt::detail::flat_storage<ucft>>;
 
             value_expression value();
             const_value_expression value() const;
@@ -646,10 +646,10 @@ namespace xt
             using uft = typename std::decay_t<CT>::flag_expression;
             using ucvt = typename std::decay_t<CT>::const_value_expression;
             using ucft = typename std::decay_t<CT>::const_flag_expression;
-            using value_expression = xstrided_view<uvt, S, L, xt::detail::flat_storage_type_t<uvt>>;
-            using flag_expression = xstrided_view<uft, S, L, xt::detail::flat_storage_type_t<uft>>;
-            using const_value_expression = xstrided_view<ucvt, S, L, xt::detail::flat_storage_type_t<ucvt>>;
-            using const_flag_expression = xstrided_view<ucft, S, L, xt::detail::flat_storage_type_t<ucft>>;
+            using value_expression = xstrided_view<uvt, S, L, xt::detail::flat_storage<uvt>>;
+            using flag_expression = xstrided_view<uft, S, L, xt::detail::flat_storage<uft>>;
+            using const_value_expression = xstrided_view<ucvt, S, L, xt::detail::flat_storage<ucvt>>;
+            using const_flag_expression = xstrided_view<ucft, S, L, xt::detail::flat_storage<ucft>>;
 
             value_expression value();
             const_value_expression value() const;

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -360,6 +360,8 @@ namespace xt
         using size_type = typename storage_type::size_type;
         using difference_type = typename storage_type::difference_type;
 
+        using shape_type = typename xscalar<CT>::shape_type;
+
         xscalar_stepper(storage_type* c) noexcept;
 
         reference operator*() const noexcept;

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -60,13 +60,14 @@ namespace xt
     struct xcontainer_inner_types<xstrided_view<CT, S, L, FST>>
     {
         using xexpression_type = std::decay_t<CT>;
-        using undecay_expression = CT;
-        using reference = inner_reference_t<undecay_expression>;
+        using inner_closure_type = CT;
+        using reference = inner_reference_t<inner_closure_type>;
         using const_reference = typename xexpression_type::const_reference;
         using size_type = typename xexpression_type::size_type;
         using shape_type = std::decay_t<S>;
         using undecay_shape = S;
-        using inner_storage_type = FST;
+        using flat_storage = FST;
+        using inner_storage_type = typename FST::type;
         using temporary_type = temporary_type_t<typename xexpression_type::value_type, S, L>;
         static constexpr layout_type layout = L;
     };
@@ -107,7 +108,7 @@ namespace xt
      *
      * @sa strided_view, transpose
      */
-    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = typename detail::flat_storage_type<CT>::type>
+    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = detail::flat_storage<CT>>
     class xstrided_view : public xview_semantic<xstrided_view<CT, S, L, FST>>,
                           public xiterable<xstrided_view<CT, S, L, FST>>,
                           private xstrided_view_base<xstrided_view<CT, S, L, FST>>,
@@ -122,6 +123,7 @@ namespace xt
         using expression_tag = typename extension_base::expression_tag;
 
         using xexpression_type = typename base_type::xexpression_type;
+        using inner_closure_type = typename base_type::inner_closure_type;
         using base_type::is_const;
 
         using value_type = typename base_type::value_type;
@@ -158,10 +160,6 @@ namespace xt
 
         template <class CTA>
         xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset, layout_type layout) noexcept;
-
-        template <class CTA, class FLS>
-        xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset,
-                      layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept;
 
         xstrided_view(const xstrided_view& rhs) = default;
         xstrided_view& operator=(const xstrided_view& rhs);
@@ -225,7 +223,7 @@ namespace xt
         using const_container_iterator = typename storage_type::const_iterator;
 
         template <class E>
-        using rebind_t = xstrided_view<E, S, L, detail::flat_storage_type_t<E>>;
+        using rebind_t = xstrided_view<E, S, L, detail::flat_storage<E>>;
 
         template <class E>
         rebind_t<E> build_view(E&& e) const;
@@ -312,14 +310,6 @@ namespace xt
     template <class CTA>
     inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset, layout_type layout) noexcept
         : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides), offset, layout)
-    {
-    }
-
-    template <class CT, class S, layout_type L, class FST>
-    template <class CTA, class FLS>
-    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset,
-                                                       layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept
-        : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides), offset, layout, std::forward<FLS>(flatten_strides), flatten_layout)
     {
     }
     //@}

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -341,6 +341,7 @@ namespace xt
         using self_type = xview<CT, S...>;
         using inner_types = xcontainer_inner_types<self_type>;
         using xexpression_type = std::decay_t<CT>;
+        using inner_closure_type = CT;
         using semantic_base = xview_semantic<self_type>;
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
 

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -13,6 +13,7 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xmanipulation.hpp"
+#include "xtensor/xview.hpp"
 
 namespace xt
 {
@@ -103,6 +104,21 @@ namespace xt
         auto flat3 = ravel(a);
         EXPECT_EQ(flat, flat3);
     }
+
+    /*TEST(xstrided_view, flatten)
+    {
+        xtensor<double, 3> a = linspace<double>(1., 100., 100).reshape({2, 5, 10});
+        auto v = view(a, range(0, 2), range(0, 3), range(0, 3));
+        xtensor<double, 1> fl = flatten(v);
+        xtensor<double, 1> expected = {  1.,  2., 3., 11., 12., 13., 21., 22., 23.,
+                                        51., 52., 53, 61., 62., 63., 71., 72., 73. };
+
+        EXPECT_EQ(fl, expected);
+
+        auto v2 = strided_view(a, {range(0, 2), range(0, 3), range(0, 3)});
+        xtensor<double, 1> fl2 = flatten(v2);
+        EXPECT_EQ(fl2, expected);
+    }*/
 
     TEST(xstrided_view, split)
     {
@@ -240,12 +256,12 @@ namespace xt
         xarray<double> e = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
         xarray<double> t = xt::flip(e, 0);
         xarray<double> expected = {{7, 8, 9}, {4, 5, 6}, {1, 2, 3}};
-        ASSERT_EQ(expected, t);
+        EXPECT_EQ(expected, t);
 
         xindex idx = {0, 0};
-        ASSERT_EQ(7, t[idx]);
-        ASSERT_EQ(2, t(2, 1));
-        ASSERT_EQ(7, t.element(idx.begin(), idx.end()));
+        EXPECT_EQ(7, t[idx]);
+        EXPECT_EQ(2, t(2, 1));
+        EXPECT_EQ(7, t.element(idx.begin(), idx.end()));
 
         xarray<double> f = {{{0, 1, 2}, {3, 4, 5}}, {{6, 7, 8}, {9, 10, 11}}};
 
@@ -254,7 +270,7 @@ namespace xt
         {9, 10, 11}},
         {{0, 1, 2},
         {3, 4, 5}}};
-        ASSERT_EQ(expected_2, ft);
+        EXPECT_EQ(expected_2, ft);
     }
 
     TEST(xstrided_view, fliplr)
@@ -262,12 +278,12 @@ namespace xt
         xarray<double> e = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
         xarray<double> t = xt::flip(e, 1);
         xarray<double> expected = {{3, 2, 1}, {6, 5, 4}, {9, 8, 7}};
-        ASSERT_EQ(expected, t);
+        EXPECT_EQ(expected, t);
 
         xindex idx = {0, 0};
-        ASSERT_EQ(3, t[idx]);
-        ASSERT_EQ(8, t(2, 1));
-        ASSERT_EQ(3, t.element(idx.begin(), idx.end()));
+        EXPECT_EQ(3, t[idx]);
+        EXPECT_EQ(8, t(2, 1));
+        EXPECT_EQ(3, t.element(idx.begin(), idx.end()));
 
         xarray<double> f = {{{0, 1, 2}, {3, 4, 5}}, {{6, 7, 8}, {9, 10, 11}}};
 
@@ -278,7 +294,7 @@ namespace xt
             {{9, 10, 11},
             {6, 7, 8}}};
 
-        ASSERT_EQ(expected_2, ft);
+        EXPECT_EQ(expected_2, ft);
     }
 
     TEST(xstrided_view, rot90)
@@ -296,22 +312,22 @@ namespace xt
         axes = {56, 58};
         ASSERT_ANY_THROW(xt::rot90(e, axes));
 
-        ASSERT_EQ(e, xt::rot90<0>(e));
-        ASSERT_EQ(e, xt::rot90<4>(e));
-        ASSERT_EQ(e, xt::rot90<-4>(e));
+        EXPECT_EQ(e, xt::rot90<0>(e));
+        EXPECT_EQ(e, xt::rot90<4>(e));
+        EXPECT_EQ(e, xt::rot90<-4>(e));
 
         xarray<double> expected2 = {{2, 4}, {1, 3}};
-        ASSERT_EQ(expected2, xt::rot90(e2));
-        ASSERT_EQ(expected2, xt::rot90(e2, {-2, -1}));
+        EXPECT_EQ(expected2, xt::rot90(e2));
+        EXPECT_EQ(expected2, xt::rot90(e2, {-2, -1}));
 
         xarray<double> expected3 = {{9, 8, 7}, {6, 5, 4}, {3, 2, 1}};
-        ASSERT_EQ(expected3, xt::rot90<2>(e));
+        EXPECT_EQ(expected3, xt::rot90<2>(e));
 
         xarray<double> expected4 = {{3, 1}, {4, 2}};
-        ASSERT_EQ(expected4, xt::rot90<3>(e2));
-        ASSERT_EQ(expected4, xt::rot90<-1>(e2));
+        EXPECT_EQ(expected4, xt::rot90<3>(e2));
+        EXPECT_EQ(expected4, xt::rot90<-1>(e2));
 
         xarray<double> expected5 = {{{1, 3}, {0, 2}}, {{5, 7}, {4, 6}}};
-        ASSERT_EQ(expected5, xt::rot90(e3, {1, 2}));
+        EXPECT_EQ(expected5, xt::rot90(e3, {1, 2}));
     }
 }

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -496,7 +496,20 @@ namespace xt
         EXPECT_THROW(noalias(v) = b, broadcast_error);
     }
 
-    TEST(xstrided_view, view_on_view)
+    TEST(xstrided_view, strided_view_on_view)
+    {
+        xarray<int> a = xt::ones<int>({ 3, 4, 5 });
+        auto v1 = view(a, 1, all(), all());
+        auto vv1 = strided_view(v1, { 1, all() });
+        vv1 = vv1 * 5;
+        EXPECT_EQ(a(0, 0, 0), 1);
+        EXPECT_EQ(a(1, 1, 0), 5);
+        EXPECT_EQ(a(1, 1, 4), 5);
+        EXPECT_EQ(a(1, 2, 4), 1);
+        EXPECT_EQ(v1(1, 4), 5);
+    }
+
+    TEST(xstrided_view, strided_view_on_strided_view)
     {
         xarray<int> a = xt::ones<int>({ 3, 4, 5 });
         auto v1 = strided_view(a, { 1, all(), all() });


### PR DESCRIPTION
This does not fix #1454 yet. Additional work on the `flatten` function is required, actually it should not return a view but an `xtensor_adaptor`. This requires additional refactoring on `xbuffer_adaptor`.

This will be done in an upcoming PR, I need this one to get merged!