### PR TITLE
Change struct -> class in xiterator_adaptor

### DIFF
--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -210,7 +210,7 @@ namespace xt
      ***************************/
 
     template <class I, class CI>
-    struct xiterator_adaptor;
+    class xiterator_adaptor;
 
     /**
      * Returns a flatten view of the given expression. No copy is made.


### PR DESCRIPTION
See: https://github.com/QuantStack/xtensor/issues/1517#issuecomment-482578195

This fixes the following warnings upon compilation:

```
In file included from /Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xoperation.hpp:22:
/Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xmanipulation.hpp:213:5: warning: struct template 'xiterator_adaptor' was previously declared as a class template [-Wmismatched-tags]
    struct xiterator_adaptor;
    ^
/Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xbuffer_adaptor.hpp:431:11: note: previous use is here
    class xiterator_adaptor : public xbuffer_adaptor_base<xiterator_adaptor<I, CI>>
          ^
/Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xmanipulation.hpp:213:5: note: did you mean class here?
    struct xiterator_adaptor;
    ^~~~~~
    class
1 warning generated.
```