### PR TITLE
add has_linear_assign function to dynamic_view

### DIFF
--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -35,7 +35,7 @@ namespace xt
         using shape_type = std::decay_t<S>;
         using undecay_shape = S;
         using inner_storage_type = FST;
-        using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>>;
+        using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>, xexpression_type::static_layout>;
         static constexpr layout_type layout = L;
     };
 
@@ -204,7 +204,9 @@ namespace xt
         using base_type::storage;
         using base_type::expression;
         using base_type::broadcast_shape;
-        using base_type::has_linear_assign;
+
+        template <class O>
+        bool has_linear_assign(const O& str) const noexcept;
 
         template <class T>
         void fill(const T& value);
@@ -434,6 +436,13 @@ namespace xt
         offset_type offset = base_type::compute_index(args...);
         offset = adjust_offset(offset, args...);
         return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class O>
+    inline bool xdynamic_view<CT, S, L, FST>::has_linear_assign(const O&) const noexcept
+    {
+        return false;
     }
 
     template <class CT, class S, layout_type L, class FST>

--- a/test/test_xdynamic_view.cpp
+++ b/test/test_xdynamic_view.cpp
@@ -260,4 +260,18 @@ namespace xt
         auto res  = xt::xarray<float>(xt::dynamic_view(v, {xt::keep(0)}));
         EXPECT_EQ(res(1), array(2, 1));
     }
+
+    TEST(xdynamic_view, assignment)
+    {
+        xt::xarray<double, xt::layout_type::column_major> x = {{1, 4}, {2, 5}, {3, 6}};
+
+        xt::xdynamic_slice_vector sv({});
+        sv.push_back(xt::all());
+        sv.push_back(xt::all());
+
+        auto res = xt::dynamic_view(x, sv);
+        xt::xarray<double, xt::layout_type::column_major> xrs = res;
+        EXPECT_EQ(x, res);
+    }
+
 }


### PR DESCRIPTION
This is fixing the bug @DavisVaughan experienced in #1517 

I also think this is (much) more correct. The previous function shouldn't have worked IMO since it calles the strides() function which is deleted in the leaf class ... 