### PR TITLE
Remove unused type alias

### DIFF
--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -780,7 +780,6 @@ namespace xt
     template <class EC, class S, layout_type L, class Tag>
     inline auto xfixed_adaptor<EC, S, L, Tag>::operator=(temporary_type&& rhs) -> self_type&
     {
-        using origin_type = decltype(std::move(rhs.storage()));
         m_storage.resize(rhs.storage().size());
         std::copy(rhs.storage().cbegin(), rhs.storage().cend(), m_storage.begin());
         return *this;


### PR DESCRIPTION
This was throwing the following warning:

```
   In file included from /Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xadapt.hpp:21:
   /Library/Frameworks/R.framework/Versions/3.5/Resources/library/xtensor/include/xtensor/xfixed.hpp:783:15: warning: unused type alias 'origin_type' [-Wunused-local-typedef]
           using origin_type = decltype(std::move(rhs.storage()));
                 ^
   1 warning generated.
```