### PR TITLE
Allows to include xsimd without defining XTENSOR_USE_XSIMD

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -286,8 +286,8 @@ namespace xt
         // scope of these data members (since they are odr-used).
         static constexpr bool contiguous_layout() { return E1::contiguous_layout && E2::contiguous_layout; }
         static constexpr bool convertible_types() { return std::is_convertible<typename E2::value_type, typename E1::value_type>::value; }
-        static constexpr bool lhs_simd_size() { return xsimd::simd_traits<typename E1::value_type>::size > 1; }
-        static constexpr bool rhs_simd_size() { return xsimd::simd_traits<typename E2::value_type>::size > 1; }
+        static constexpr bool lhs_simd_size() { return xt_simd::simd_traits<typename E1::value_type>::size > 1; }
+        static constexpr bool rhs_simd_size() { return xt_simd::simd_traits<typename E2::value_type>::size > 1; }
         static constexpr bool simd_size() { return lhs_simd_size() && rhs_simd_size(); }
         static constexpr bool forbid_simd() { return !has_simd_interface<E2>::value; }
         static constexpr bool simd_assign() { return contiguous_layout() && convertible_types() && simd_size() && has_simd_interface<E2>::value; }
@@ -511,16 +511,16 @@ namespace xt
     template <class E1, class E2>
     inline void linear_assigner<simd_assign>::run(E1& e1, const E2& e2)
     {
-        using lhs_align_mode = xsimd::container_alignment_t<E1>;
+        using lhs_align_mode = xt_simd::container_alignment_t<E1>;
         constexpr bool is_aligned = std::is_same<lhs_align_mode, aligned_mode>::value;
         using rhs_align_mode = std::conditional_t<is_aligned, inner_aligned_mode, unaligned_mode>;
         using value_type = std::common_type_t<typename E1::value_type, typename E2::value_type>;
-        using simd_type = xsimd::simd_type<value_type>;
+        using simd_type = xt_simd::simd_type<value_type>;
         using size_type = typename E1::size_type;
         size_type size = e1.size();
         constexpr size_type simd_size = simd_type::size;
 
-        size_type align_begin = is_aligned ? 0 : xsimd::get_alignment_offset(e1.data(), size, simd_size);
+        size_type align_begin = is_aligned ? 0 : xt_simd::get_alignment_offset(e1.data(), size, simd_size);
         size_type align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
 
         for (size_type i = 0; i < align_begin; ++i)
@@ -791,7 +791,7 @@ namespace xt
         // add this when we have std::array index!
         // std::fill(idx.begin(), idx.end(), 0);
         using value_type = std::common_type_t<typename E1::value_type, typename E2::value_type>;
-        using simd_type = xsimd::simd_type<value_type>;
+        using simd_type = xt_simd::simd_type<value_type>;
 
         std::size_t simd_size = inner_loop_size / simd_type::size;
         std::size_t simd_rest = inner_loop_size % simd_type::size;

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -84,7 +84,7 @@ namespace xt
         using const_pointer = typename storage_type::const_pointer;
         using size_type = typename inner_types::size_type;
         using difference_type = typename storage_type::difference_type;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
 
         using shape_type = typename inner_types::shape_type;
         using strides_type = typename inner_types::strides_type;
@@ -102,8 +102,8 @@ namespace xt
 
         static constexpr layout_type static_layout = inner_types::layout;
         static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
-        using data_alignment = xsimd::container_alignment_t<storage_type>;
-        using simd_type = xsimd::simd_type<value_type>;
+        using data_alignment = xt_simd::container_alignment_t<storage_type>;
+        using simd_type = xt_simd::simd_type<value_type>;
 
         using storage_iterator = typename iterable_base::storage_iterator;
         using const_storage_iterator = typename iterable_base::const_storage_iterator;
@@ -172,12 +172,12 @@ namespace xt
         const_reference data_element(size_type i) const;
 
         template <class requested_type>
-        using simd_return_type = xsimd::simd_return_type<value_type, requested_type>;
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
         template <class align, class simd>
         void store_simd(size_type i, const simd& e);
         template <class align, class requested_type = value_type,
-                  std::size_t N = xsimd::simd_traits<requested_type>::size>
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
         simd_return_type<requested_type> load_simd(size_type i) const;
 
         storage_iterator storage_begin() noexcept;
@@ -706,7 +706,7 @@ namespace xt
     inline void xcontainer<D>::store_simd(size_type i, const simd& e)
     {
         using align_mode = driven_align_mode_t<alignment, data_alignment>;
-        xsimd::store_simd<value_type, typename simd::value_type>(&(storage()[i]), e, align_mode());
+        xt_simd::store_simd<value_type, typename simd::value_type>(&(storage()[i]), e, align_mode());
     }
 
     template <class D>
@@ -715,7 +715,7 @@ namespace xt
         -> simd_return_type<requested_type>
     {
         using align_mode = driven_align_mode_t<alignment, data_alignment>;
-        return xsimd::load_simd<value_type, requested_type>(&(storage()[i]), align_mode());
+        return xt_simd::load_simd<value_type, requested_type>(&(storage()[i]), align_mode());
     }
 
     template <class D>

--- a/include/xtensor/xdynamic_view.hpp
+++ b/include/xtensor/xdynamic_view.hpp
@@ -137,7 +137,7 @@ namespace xt
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
 
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
         using strides_vt = typename strides_type::value_type;
         using slice_type = xtl::variant<detail::xfake_slice<strides_vt>, xkeep_slice<strides_vt>, xdrop_slice<strides_vt>>;
         using slice_vector_type = std::vector<slice_type>;

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -93,7 +93,7 @@ namespace xt
 
         template <class V>
         struct has_simd_type
-            : std::integral_constant<bool, !std::is_same<V, xsimd::simd_type<V>>::value>
+            : std::integral_constant<bool, !std::is_same<V, xt_simd::simd_type<V>>::value>
         {
         };
 
@@ -109,7 +109,7 @@ namespace xt
                                                           has_simd_type<xvalue_type_t<std::decay_t<CT>>>...>;
             // if yes, insert correct type here
             using simd_value_type = xtl::mpl::eval_if_t<simd_arguments_exist,
-                                                        meta_identity<xsimd::simd_type<scalar_result_type>>,
+                                                        meta_identity<xt_simd::simd_type<scalar_result_type>>,
                                                         make_invalid_type<>>;
             // if all types are supported, check that the functor has a working
             // simd_apply and all arguments have the simd interface
@@ -221,7 +221,7 @@ namespace xt
         using simd_argument_type = simd_value_type;
 
         template <class requested_type>
-        using simd_return_type = xsimd::simd_return_type<value_type, requested_type>;
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
         using iterable_base = xconst_iterable<xfunction<F, CT...>>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
@@ -327,7 +327,7 @@ namespace xt
         operator value_type() const;
 
         template <class align, class requested_type = value_type,
-                  std::size_t N = xsimd::simd_traits<requested_type>::size>
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
         simd_return_type<requested_type> load_simd(size_type i) const;
 
         const tuple_type& arguments() const noexcept;
@@ -801,9 +801,9 @@ namespace xt
         struct get_simd_type
         {
             using simd_value_type = typename std::decay_t<T>::simd_value_type;
-            static constexpr bool is_arg_bool = ::xsimd::is_batch_bool<simd_value_type>::value;
-            static constexpr bool is_res_bool = ::xsimd::is_batch_bool<simd>::value;
-            static constexpr bool is_arg_cplx = ::xsimd::is_batch_complex<simd_value_type>::value;
+            static constexpr bool is_arg_bool = ::xt_simd::is_batch_bool<simd_value_type>::value;
+            static constexpr bool is_res_bool = ::xt_simd::is_batch_bool<simd>::value;
+            static constexpr bool is_arg_cplx = ::xt_simd::is_batch_complex<simd_value_type>::value;
             using type = std::conditional_t<is_res_bool,
                                             common_simd,
                                             std::conditional_t<is_arg_bool || is_arg_cplx,

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -202,7 +202,7 @@ namespace xt
         // The following functions are defined inline because otherwise signatures
         // don't match on GCC.
         template <class align, class requested_type = typename xexpression_type::value_type,
-                  std::size_t N = xsimd::simd_traits<requested_type>::size, class FCT = functor_type>
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size, class FCT = functor_type>
         auto load_simd(size_type i) const
             -> decltype(std::declval<FCT>().template proxy_simd_load<align, requested_type, N>(std::declval<undecay_expression>(), i))
         {

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -111,7 +111,7 @@ namespace xt
         using difference_type = typename subiterator_traits::difference_type;
         using size_type = typename storage_type::size_type;
         using shape_type = typename storage_type::shape_type;
-        using simd_type = xsimd::simd_type<value_type>;
+        using simd_type = xt_simd::simd_type<value_type>;
 
         xstepper() = default;
         xstepper(storage_type* c, subiterator_type it, size_type offset) noexcept;
@@ -523,7 +523,7 @@ namespace xt
     {
         R reg;
         reg.load_unaligned(&(*m_it));
-        m_it += xsimd::revert_simd_traits<R>::size;
+        m_it += xt_simd::revert_simd_traits<R>::size;
         return reg;
     }
 
@@ -532,7 +532,7 @@ namespace xt
     inline void xstepper<C>::store_simd(const R& vec)
     {
         vec.store_unaligned(&(*m_it));
-        m_it += xsimd::revert_simd_traits<R>::size;;
+        m_it += xt_simd::revert_simd_traits<R>::size;;
     }
 
     template <class C>

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -537,7 +537,7 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
             template <class A1, class A2>
             constexpr auto simd_apply(const A1& t1, const A2& t2) const noexcept
             {
-                return xsimd::select(t1 < t2, t1, t2);
+                return xt_simd::select(t1 < t2, t1, t2);
             }
         };
 
@@ -553,7 +553,7 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
             template <class A1, class A2>
             constexpr auto simd_apply(const A1& t1, const A2& t2) const noexcept
             {
-                return xsimd::select(t1 > t2, t1, t2);
+                return xt_simd::select(t1 > t2, t1, t2);
             }
         };
 
@@ -570,7 +570,7 @@ XTENSOR_INT_SPECIALIZATION_IMPL(FUNC_NAME, RETURN_VAL, unsigned long long);     
                                       const A2& lo,
                                       const A3& hi) const
             {
-                return xsimd::select(v < lo, lo, xsimd::select(hi < v, hi, v));
+                return xt_simd::select(v < lo, lo, xt_simd::select(hi < v, hi, v));
             }
         };
     }

--- a/include/xtensor/xoffset_view.hpp
+++ b/include/xtensor/xoffset_view.hpp
@@ -29,7 +29,7 @@ namespace xt
             using proxy = xtl::xproxy_wrapper<M>;
 
             template <class value_type, class requested_type>
-            using simd_return_type = xsimd::simd_return_type<value_type, requested_type>;
+            using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
             template <class T>
             decltype(auto) operator()(T&& t) const

--- a/include/xtensor/xoperation.hpp
+++ b/include/xtensor/xoperation.hpp
@@ -93,7 +93,7 @@ namespace xt
         struct conditional_ternary
         {
             template <class B>
-            using get_batch_bool = typename xsimd::simd_traits<typename xsimd::revert_simd_traits<B>::type>::bool_type;
+            using get_batch_bool = typename xt_simd::simd_traits<typename xt_simd::revert_simd_traits<B>::type>::bool_type;
 
             template <class B, class A1, class A2>
             constexpr auto operator()(const B& cond, const A1& v1, const A2& v2) const noexcept
@@ -106,7 +106,7 @@ namespace xt
                                    const B& t2,
                                    const B& t3) const noexcept
             {
-                return xsimd::select(t1, t2, t3);
+                return xt_simd::select(t1, t2, t3);
             }
         };
 

--- a/include/xtensor/xoptional_assembly_base.hpp
+++ b/include/xtensor/xoptional_assembly_base.hpp
@@ -62,7 +62,7 @@ namespace xt
         using const_pointer = typename storage_type::const_pointer;
         using size_type = typename raw_value_expression::size_type;
         using difference_type = typename raw_value_expression::difference_type;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
 
         using shape_type = typename raw_value_expression::shape_type;
         using strides_type = typename raw_value_expression::strides_type;

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -103,7 +103,7 @@ namespace xt
         using const_pointer = const value_type*;
         using size_type = typename inner_types::size_type;
         using difference_type = std::ptrdiff_t;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
 
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
@@ -280,8 +280,8 @@ namespace xt
         template <class align, class simd = simd_value_type>
         void store_simd(size_type i, const simd& e);
         template <class align, class requested_type = value_type,
-                  std::size_t N = xsimd::simd_traits<requested_type>::size>
-        xsimd::simd_return_type<value_type, requested_type>
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
+        xt_simd::simd_return_type<value_type, requested_type>
         load_simd(size_type i) const;
 
     private:
@@ -922,9 +922,9 @@ namespace xt
     template <class CT>
     template <class align, class requested_type, std::size_t N>
     inline auto xscalar<CT>::load_simd(size_type) const
-        -> xsimd::simd_return_type<value_type, requested_type>
+        -> xt_simd::simd_return_type<value_type, requested_type>
     {
-        return xsimd::set_simd<value_type, requested_type>(m_value);
+        return xt_simd::set_simd<value_type, requested_type>(m_value);
     }
 
     template <class T>

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -601,7 +601,7 @@ namespace xt
         };
 
         template <class T, std::size_t A>
-        struct allocator_alignment<xsimd::aligned_allocator<T, A>>
+        struct allocator_alignment<xt_simd::aligned_allocator<T, A>>
         {
             constexpr static std::size_t value = A;
         };
@@ -1346,7 +1346,7 @@ namespace xt
         // Note: this is for alignment detection. The allocator serves no other purpose than
         //       that of a trait here.
         using allocator_type = std::conditional_t<Align != 0,
-                                                  xsimd::aligned_allocator<T, Align>,
+                                                  xt_simd::aligned_allocator<T, Align>,
                                                   std::allocator<T>>;
     };
 

--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -154,7 +154,7 @@ namespace xt
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
 
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
 
         template <class CTA>
         xstrided_view(CTA&& e, S&& shape, strides_type&& strides, std::size_t offset, layout_type layout) noexcept;

--- a/include/xtensor/xtensor_simd.hpp
+++ b/include/xtensor/xtensor_simd.hpp
@@ -17,9 +17,60 @@
 
 #include <xsimd/xsimd.hpp>
 
+namespace xt_simd
+{
+    template <class T, std::size_t A>
+    using aligned_allocator = xsimd::aligned_allocator<T, A>;
+
+    using aligned_mode = xsimd::aligned_mode;
+    using unaligned_mode = xsimd::unaligned_mode;
+
+    template <class A>
+    using allocator_alignment = xsimd::allocator_alignment<A>;
+
+    template <class A>
+    using allocator_alignment_t = xsimd::allocator_alignment_t<A>;
+
+    template <class C>
+    using container_alignment = xsimd::container_alignment<C>;
+
+    template <class C>
+    using container_alignment_t = xsimd::container_alignment_t<C>;
+
+    template <class T>
+    using simd_traits = xsimd::simd_traits<T>;
+
+    template <class T>
+    using revert_simd_traits = xsimd::revert_simd_traits<T>;
+
+    template <class T>
+    using simd_type = xsimd::simd_type<T>;
+
+    template <class T>
+    using simd_bool_type = xsimd::simd_bool_type<T>;
+
+    template <class T>
+    using revert_simd_type = xsimd::revert_simd_type<T>;
+
+    using xsimd::set_simd;
+    using xsimd::load_simd;
+    using xsimd::store_simd;
+    using xsimd::select;
+    using xsimd::get_alignment_offset;
+
+    template <class T1, class T2>
+    using simd_return_type = xsimd::simd_return_type<T1, T2>;
+
+    template <class V>
+    using is_batch_bool = xsimd::is_batch_bool<V>;
+
+    template <class V>
+    using is_batch_complex = xsimd::is_batch_complex<V>;
+}
+
 #else  // XTENSOR_USE_XSIMD
 
-namespace xsimd
+namespace xt_simd
 {
     template <class T, std::size_t A>
     class aligned_allocator;
@@ -135,8 +186,8 @@ namespace xsimd
 
 namespace xt
 {
-    using xsimd::aligned_mode;
-    using xsimd::unaligned_mode;
+    using xt_simd::aligned_mode;
+    using xt_simd::unaligned_mode;
 
     struct inner_aligned_mode
     {
@@ -147,7 +198,7 @@ namespace xt
         template <class A1, class A2>
         struct driven_align_mode_impl
         {
-            using type = std::conditional_t<std::is_same<A1, A2>::value, A1, ::xsimd::unaligned_mode>;
+            using type = std::conditional_t<std::is_same<A1, A2>::value, A1, ::xt_simd::unaligned_mode>;
         };
 
         template <class A>

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -349,7 +349,7 @@ namespace xt
 
         static constexpr bool is_const = std::is_const<std::remove_reference_t<CT>>::value;
         using value_type = typename xexpression_type::value_type;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
         using reference = typename inner_types::reference;
         using const_reference = typename inner_types::const_reference;
         using pointer = std::conditional_t<is_const,
@@ -576,7 +576,7 @@ namespace xt
         //
 
         template <class requested_type>
-        using simd_return_type = xsimd::simd_return_type<value_type, requested_type>;
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
         template <class T, class R>
         using enable_simd_interface = std::enable_if_t<has_simd_interface<T>::value && is_strided_view, R>;
@@ -585,7 +585,7 @@ namespace xt
         enable_simd_interface<T, void> store_simd(size_type i, const simd& e);
 
         template <class align, class requested_type = value_type,
-                  std::size_t N = xsimd::simd_traits<requested_type>::size,
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size,
                   class T = xexpression_type>
         enable_simd_interface<T, simd_return_type<requested_type>> load_simd(size_type i) const;
 
@@ -1330,14 +1330,14 @@ namespace xt
     template <class align, class simd, class T>
     inline auto xview<CT, S...>::store_simd(size_type i, const simd& e) -> enable_simd_interface<T, void>
     {
-        return m_e.template store_simd<xsimd::unaligned_mode>(data_offset() + i, e);
+        return m_e.template store_simd<xt_simd::unaligned_mode>(data_offset() + i, e);
     }
 
     template <class CT, class... S>
     template <class align, class requested_type, std::size_t N, class T>
     inline auto xview<CT, S...>::load_simd(size_type i) const -> enable_simd_interface<T, simd_return_type<requested_type>>
     {
-        return m_e.template load_simd<xsimd::unaligned_mode, requested_type>(data_offset() + i);
+        return m_e.template load_simd<xt_simd::unaligned_mode, requested_type>(data_offset() + i);
     }
 
     template <class CT, class... S>

--- a/test/test_xfunctor_adaptor.cpp
+++ b/test/test_xfunctor_adaptor.cpp
@@ -57,7 +57,7 @@ namespace xt
         using const_pointer = bool*;
 
         template <class value_type, class requested_type>
-        using simd_return_type = xsimd::simd_return_type<value_type, requested_type>;
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
         const_reference operator()(const bool& in) const
         {
@@ -150,26 +150,26 @@ namespace xt
         xarray<std::complex<double>> e = {{3.0       , 1.0 + 1.0i},
                                           {1.0 - 1.0i, 2.0       }};
         auto iview = xt::imag(e);
-        auto loaded_batch = iview.template load_simd<xsimd::aligned_mode, double, 4>(0);
+        auto loaded_batch = iview.template load_simd<xt_simd::aligned_mode, double, 4>(0);
         EXPECT_TRUE(xsimd::all(xsimd::batch<double, 4>(0, 1, -1, 0) == loaded_batch));
         auto newbatch = loaded_batch + 5;
 
-        iview.template store_simd<xsimd::aligned_mode>(0, newbatch);
+        iview.template store_simd<xt_simd::aligned_mode>(0, newbatch);
         xarray<std::complex<double>> exp1 = {{3.0 + 5.0i, 1.0 + 6.0i},
                                              {1.0 + 4.0i, 2.0 + 5.0i }};
         EXPECT_EQ(exp1, e);
 
         auto rview = xt::real(e);
-        auto loaded_batch2 = rview.template load_simd<xsimd::aligned_mode, double, 4>(0);
+        auto loaded_batch2 = rview.template load_simd<xt_simd::aligned_mode, double, 4>(0);
         EXPECT_TRUE(xsimd::all(xsimd::batch<double, 4>(3, 1, 1, 2) == loaded_batch2));
         newbatch = loaded_batch2 + 5;
-        rview.template store_simd<xsimd::aligned_mode>(0, newbatch);
+        rview.template store_simd<xt_simd::aligned_mode>(0, newbatch);
         xarray<std::complex<double>> exp2 = {{8.0 + 5.0i, 6.0 + 6.0i},
                                              {6.0 + 4.0i, 7.0 + 5.0i }};
         EXPECT_EQ(exp2, e);
 
         auto f = xt::sin(xt::imag(e));
-        auto b = f.load_simd<xsimd::aligned_mode>(0);
+        auto b = f.load_simd<xt_simd::aligned_mode>(0);
         static_cast<void>(b);
         using assign_to_view = xassign_traits<decltype(iview), decltype(f)>;
         EXPECT_TRUE(assign_to_view::convertible_types());


### PR DESCRIPTION
Fixes #1484 