### PR TITLE
In tests, include the primary header first.

### DIFF
--- a/include/xtensor/xaccumulator.hpp
+++ b/include/xtensor/xaccumulator.hpp
@@ -14,6 +14,7 @@
 #include <numeric>
 #include <type_traits>
 
+#include "xtensor_config.hpp"
 #include "xexpression.hpp"
 #include "xstrides.hpp"
 #include "xtensor_forward.hpp"

--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -21,6 +21,7 @@
 #include "xtensor_forward.hpp"
 #include "xutils.hpp"
 #include "xfunction.hpp"
+#include "xtensor_config.hpp"
 
 #if defined(XTENSOR_USE_TBB)
 #include <tbb/tbb.h>

--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -25,6 +25,7 @@
 #include "xscalar.hpp"
 #include "xstrides.hpp"
 #include "xutils.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xbuffer_adaptor.hpp
+++ b/include/xtensor/xbuffer_adaptor.hpp
@@ -18,6 +18,7 @@
 #include <xtl/xclosure.hpp>
 
 #include "xstorage.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xcontainer.hpp
+++ b/include/xtensor/xcontainer.hpp
@@ -23,6 +23,7 @@
 #include "xmath.hpp"
 #include "xoperation.hpp"
 #include "xstrides.hpp"
+#include "xtensor_config.hpp"
 #include "xtensor_forward.hpp"
 
 namespace xt

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "xtensor.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xexception.hpp
+++ b/include/xtensor/xexception.hpp
@@ -14,6 +14,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "xtensor_config.hpp"
+
 namespace xt
 {
 

--- a/include/xtensor/xexpression_holder.hpp
+++ b/include/xtensor/xexpression_holder.hpp
@@ -11,11 +11,11 @@
 #define XTENSOR_XEXPRESSION_HOLDER_HPP
 
 #include <nlohmann/json.hpp>
-
-#include "xtl/xany.hpp"
+#include <xtl/xany.hpp>
 
 #include "xarray.hpp"
 #include "xjson.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -16,9 +16,10 @@
 #include <vector>
 
 #include "xcontainer.hpp"
-#include "xstrides.hpp"
-#include "xstorage.hpp"
 #include "xsemantic.hpp"
+#include "xstorage.hpp"
+#include "xstrides.hpp"
+#include "xtensor_config.hpp"
 
 namespace xtl
 {

--- a/include/xtensor/xhistogram.hpp
+++ b/include/xtensor/xhistogram.hpp
@@ -13,8 +13,9 @@
 #ifndef XTENSOR_HISTOGRAM_HPP
 #define XTENSOR_HISTOGRAM_HPP
 
-#include "xtensor.hpp"
 #include "xsort.hpp"
+#include "xtensor.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xinfo.hpp
+++ b/include/xtensor/xinfo.hpp
@@ -11,6 +11,8 @@
 
 #include <string>
 
+#include "xlayout.hpp"
+
 #ifndef _MSC_VER
 #  if __cplusplus < 201103
 #    define CONSTEXPR11_TN

--- a/include/xtensor/xjson.hpp
+++ b/include/xtensor/xjson.hpp
@@ -16,6 +16,7 @@
 #include <nlohmann/json.hpp>
 
 #include "xstrided_view.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xlayout.hpp
+++ b/include/xtensor/xlayout.hpp
@@ -9,6 +9,8 @@
 #ifndef XTENSOR_LAYOUT_HPP
 #define XTENSOR_LAYOUT_HPP
 
+#include <type_traits>
+
 // Do not include anything else here.
 // xlayout.hpp is included in xtensor_forward.hpp
 // and we don't want to bring other headers to it.

--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -11,6 +11,7 @@
 #define XTENSOR_MANIPULATION_HPP
 
 #include "xstrided_view.hpp"
+#include "xtensor_config.hpp"
 #include "xutils.hpp"
 
 namespace xt

--- a/include/xtensor/xmath.hpp
+++ b/include/xtensor/xmath.hpp
@@ -23,11 +23,12 @@
 #include <xtl/xtype_traits.hpp>
 
 #include "xaccumulator.hpp"
+#include "xeval.hpp"
 #include "xoperation.hpp"
 #include "xreducer.hpp"
 #include "xslice.hpp"
 #include "xstrided_view.hpp"
-#include "xeval.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -31,6 +31,7 @@
 #include "xtensor/xarray.hpp"
 #include "xtensor/xeval.hpp"
 #include "xtensor/xstrides.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/include/xtensor/xrandom.hpp
+++ b/include/xtensor/xrandom.hpp
@@ -20,6 +20,7 @@
 #include "xbuilder.hpp"
 #include "xgenerator.hpp"
 #include "xtensor.hpp"
+#include "xtensor_config.hpp"
 #include "xview.hpp"
 
 namespace xt

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -31,6 +31,7 @@
 #include "xgenerator.hpp"
 #include "xiterable.hpp"
 #include "xreducer.hpp"
+#include "xtensor_config.hpp"
 #include "xutils.hpp"
 
 namespace xt

--- a/include/xtensor/xslice.hpp
+++ b/include/xtensor/xslice.hpp
@@ -17,6 +17,7 @@
 #include <xtl/xtype_traits.hpp>
 
 #include "xstorage.hpp"
+#include "xtensor_config.hpp"
 #include "xutils.hpp"
 
 #ifndef XTENSOR_CONSTEXPR

--- a/include/xtensor/xstorage.hpp
+++ b/include/xtensor/xstorage.hpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 
 #include "xexception.hpp"
+#include "xtensor_config.hpp"
 #include "xtensor_simd.hpp"
 #include "xutils.hpp"
 

--- a/include/xtensor/xstrided_view_base.hpp
+++ b/include/xtensor/xstrided_view_base.hpp
@@ -12,11 +12,13 @@
 #include <type_traits>
 
 #include <xtl/xsequence.hpp>
+#include <xtl/xvariant.hpp>
 
 #include "xaccessible.hpp"
-#include "xtensor_forward.hpp"
 #include "xslice.hpp"
 #include "xstrides.hpp"
+#include "xtensor_config.hpp"
+#include "xtensor_forward.hpp"
 #include "xutils.hpp"
 
 namespace xt

--- a/include/xtensor/xstrides.hpp
+++ b/include/xtensor/xstrides.hpp
@@ -15,6 +15,7 @@
 
 #include "xexception.hpp"
 #include "xshape.hpp"
+#include "xtensor_config.hpp"
 #include "xtensor_forward.hpp"
 
 namespace xt

--- a/include/xtensor/xtensor_config.hpp
+++ b/include/xtensor/xtensor_config.hpp
@@ -13,6 +13,10 @@
 #define XTENSOR_VERSION_MINOR 20
 #define XTENSOR_VERSION_PATCH 5
 
+#include <cstdio>
+#include <cstdlib>
+
+
 // DETECT 3.6 <= clang < 3.8 for compiler bug workaround.
 #ifdef __clang__
     #if __clang_major__ == 3 && __clang_minor__ < 8

--- a/include/xtensor/xutils.hpp
+++ b/include/xtensor/xutils.hpp
@@ -390,7 +390,7 @@ namespace xt
     inline auto forward_normalize(E& expr, C&& axes)
         -> std::enable_if_t<std::is_signed<std::decay_t<decltype(*std::begin(axes))>>::value, R>
     {
-        R res;
+        R res{};
         xt::resize_container(res, xtl::sequence_size(axes));
         auto dim = expr.dimension();
         std::transform(std::begin(axes), std::end(axes), std::begin(res), [&dim](auto ax_el) {
@@ -408,7 +408,7 @@ namespace xt
     {
         static_cast<void>(expr);
 
-        R res;
+        R res{};
         xt::resize_container(res, xtl::sequence_size(axes));
         std::copy(std::begin(axes), std::end(axes), std::begin(res));
         XTENSOR_ASSERT(std::all_of(res.begin(), res.end(), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));

--- a/include/xtensor/xview.hpp
+++ b/include/xtensor/xview.hpp
@@ -27,8 +27,9 @@
 #include "xiterable.hpp"
 #include "xsemantic.hpp"
 #include "xslice.hpp"
-#include "xtensor_forward.hpp"
 #include "xtensor.hpp"
+#include "xtensor_config.hpp"
+#include "xtensor_forward.hpp"
 #include "xview_utils.hpp"
 
 

--- a/include/xtensor/xview_utils.hpp
+++ b/include/xtensor/xview_utils.hpp
@@ -11,7 +11,10 @@
 
 #include <array>
 
+#include "xarray.hpp"
 #include "xslice.hpp"
+#include "xtensor.hpp"
+#include "xtensor_config.hpp"
 
 namespace xt
 {

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -9,8 +9,11 @@
 #ifndef TEST_COMMON_HPP
 #define TEST_COMMON_HPP
 
+#include "gtest/gtest.h"
 #include "xtensor/xlayout.hpp"
 #include "xtensor/xmanipulation.hpp"
+#include "xtensor/xtensor_config.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_extended_xsort.cpp
+++ b/test/test_extended_xsort.cpp
@@ -10,10 +10,10 @@
 
 #include "gtest/gtest.h"
 
-#include <xtensor/xarray.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xview.hpp>
-#include <xtensor/xsort.hpp>
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xsort.hpp"
 
 namespace xt
 {

--- a/test/test_xaccumulator.cpp
+++ b/test/test_xaccumulator.cpp
@@ -6,8 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xaccumulator.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xbuilder.hpp"

--- a/test/test_xadapt.cpp
+++ b/test/test_xadapt.cpp
@@ -6,8 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xadapt.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xstrides.hpp"
 
 namespace xt
@@ -44,20 +45,18 @@ namespace xt
     TEST(xarray_adaptor, pointer_no_ownership)
     {
         size_t size = 4;
-        int* data = new int[size];
+        std::unique_ptr<int[]> data(new int[size]);
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s({2, 2});
 
-        auto a1 = adapt(data, size, no_ownership(), s);
+        auto a1 = adapt(data.get(), size, no_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[std::size_t(a1.strides()[1])]);
 
         shape_type str({2, 1});
-        auto a2 = adapt(data, size, no_ownership(), s, str);
+        auto a2 = adapt(data.get(), size, no_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data[2]);
-
-        delete[] data;
     }
 
     TEST(xarray_adaptor, pointer_acquire_ownership)
@@ -140,16 +139,14 @@ namespace xt
     TEST(xarray_adaptor, ptr_adapt_layout)
     {
         size_t size = 4;
-        int* data = new int[size];
+        std::unique_ptr<int[]> data(new int[size]);
 
         using shape_type = std::vector<vec_type::size_type>;
         shape_type s = { size };
 
-        auto a0 = adapt<layout_type::dynamic>(data, size, no_ownership(), s, layout_type::row_major);
+        auto a0 = adapt<layout_type::dynamic>(data.get(), size, no_ownership(), s, layout_type::row_major);
         a0(3) = 3;
         EXPECT_EQ(3, data[3]);
-
-        delete[] data;
     }
 
     TEST(xtensor_adaptor, adapt)
@@ -189,34 +186,32 @@ namespace xt
     TEST(xtensor_adaptor, pointer_no_ownership)
     {
         size_t size = 4;
-        int* data = new int[size];
+        std::unique_ptr<int[]> data(new int[size]);
 
-        auto a0 = adapt(data, size, no_ownership());
+        auto a0 = adapt(data.get(), size, no_ownership());
         a0(3) = 3;
         EXPECT_EQ(3, data[3]);
 
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = adapt(data, size, no_ownership(), s);
+        auto a1 = adapt(data.get(), size, no_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, data[a1.strides()[1]]);
 
         shape_type str = {2, 1};
-        auto a2 = adapt(data, size, no_ownership(), s, str);
+        auto a2 = adapt(data.get(), size, no_ownership(), s, str);
         a2(1, 0) = 1;
         EXPECT_EQ(1, data[2]);
-
-        delete[] data;
     }
 
     TEST(xtensor_adaptor, pointer_const_no_ownership)
     {
         size_t size = 4;
-        int* data = new int[size];
-        const int* const_data = data;
+        std::unique_ptr<int[]> data(new int[size]);
+        const int* const_data = data.get();
 
-        auto a0 = adapt(data, size, no_ownership());
+        auto a0 = adapt(data.get(), size, no_ownership());
         auto a0_view = adapt(const_data, size, no_ownership());
         a0(3) = 3;
         EXPECT_EQ(3, a0_view[3]);
@@ -224,12 +219,10 @@ namespace xt
         using shape_type = std::array<vec_type::size_type, 2>;
         shape_type s = {2, 2};
 
-        auto a1 = adapt(data, size, no_ownership(), s);
-        auto a1_view = adapt(data, size, no_ownership(), s);
+        auto a1 = adapt(data.get(), size, no_ownership(), s);
+        auto a1_view = adapt(data.get(), size, no_ownership(), s);
         a1(0, 1) = 1;
         EXPECT_EQ(1, a1_view(0, 1));
-
-        delete[] data;
     }
 
     TEST(xtensor_adaptor, pointer_acquire_ownership)
@@ -359,16 +352,14 @@ namespace xt
     TEST(xtensor_adaptor, ptr_adapt_layout)
     {
         size_t size = 4;
-        int* data = new int[size];
+        std::unique_ptr<int[]> data(new int[size]);
 
         using shape_type = std::array<vec_type::size_type, 1>;
         shape_type s = { size };
 
-        auto a0 = adapt<layout_type::dynamic>(data, size, no_ownership(), s, layout_type::column_major);
+        auto a0 = adapt<layout_type::dynamic>(data.get(), size, no_ownership(), s, layout_type::column_major);
         a0(3) = 3;
         EXPECT_EQ(3, data[3]);
-
-        delete[] data;
     }
 
     TEST(xarray_adaptor, short_syntax)

--- a/test/test_xarray.cpp
+++ b/test/test_xarray.cpp
@@ -6,8 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xmanipulation.hpp"
 #include "xtensor/xio.hpp"

--- a/test/test_xaxis_iterator.cpp
+++ b/test/test_xaxis_iterator.cpp
@@ -6,9 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xaxis_iterator.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xaxis_iterator.hpp"
 
 namespace xt
 {

--- a/test/test_xbroadcast.cpp
+++ b/test/test_xbroadcast.cpp
@@ -6,9 +6,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xbroadcast.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xbuffer_adaptor.cpp
+++ b/test/test_xbuffer_adaptor.cpp
@@ -6,8 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xbuffer_adaptor.hpp"
+
+#include "gtest/gtest.h"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xbuilder.cpp
+++ b/test/test_xbuilder.cpp
@@ -6,8 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xbuilder.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xfixed.hpp"

--- a/test/test_xcomplex.cpp
+++ b/test/test_xcomplex.cpp
@@ -6,12 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xcomplex.hpp"
 
 #include <complex>
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
-#include "xtensor/xcomplex.hpp"
 #include "xtensor/xio.hpp"
 
 namespace xt

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -6,12 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xcsv.hpp"
 
 #include <sstream>
 #include <iostream>
 
-#include "xtensor/xcsv.hpp"
+#include "gtest/gtest.h"
 #include "xtensor/xmath.hpp" 
 #include "xtensor/xio.hpp" 
 

--- a/test/test_xdynamic_view.cpp
+++ b/test/test_xdynamic_view.cpp
@@ -6,15 +6,15 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xdynamic_view.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xio.hpp"
 #include "xtensor/xnoalias.hpp"
-#include "xtensor/xdynamic_view.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xrandom.hpp"
-
 #include "xtensor/xview.hpp"
 #include "xtensor/xindex_view.hpp"
 

--- a/test/test_xeval.cpp
+++ b/test/test_xeval.cpp
@@ -6,10 +6,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xeval.hpp"
+
 #include "gtest/gtest.h"
 
 #include "xtensor/xtensor_config.hpp"
-#include "xtensor/xeval.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"

--- a/test/test_xexception.cpp
+++ b/test/test_xexception.cpp
@@ -10,10 +10,12 @@
 #define XTENSOR_ENABLE_ASSERT
 #endif
 
+#include "xtensor/xexception.hpp"
+
 #include <string>
 
 #include "gtest/gtest.h"
-#include "xtensor/xexception.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xexpression.cpp
+++ b/test/test_xexpression.cpp
@@ -6,11 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xexpression.hpp"
+
 #include <sstream>
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xexpression.hpp"
 #include "xtensor/xmath.hpp"
 #include "xtensor/xio.hpp"
 

--- a/test/test_xexpression_holder.cpp
+++ b/test/test_xexpression_holder.cpp
@@ -7,11 +7,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtensor/xarray.hpp"
 #include "xtensor/xexpression_holder.hpp"
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xio.hpp"
 #include "xtensor/xview.hpp"

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -14,15 +14,16 @@
 // an easy way to prevent compilation
 #ifndef VS_SKIP_XFIXED
 
-#include "gtest/gtest.h"
+#include "xtensor/xfixed.hpp"
 
+#include "gtest/gtest.h"
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
 #include "xtensor/xio.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xnoalias.hpp"
 #include "xtensor/xmanipulation.hpp"
+#include "test_common_macros.hpp"
 
 // On VS2015, when compiling in x86 mode, alignas(T) leads to C2718
 // when used for a function parameter, even indirectly. This means that

--- a/test/test_xfunction.cpp
+++ b/test/test_xfunction.cpp
@@ -9,10 +9,10 @@
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
-#include "test_common.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xrandom.hpp"
 #include "xtensor/xfixed.hpp"
+#include "test_common.hpp"
 
 namespace xt
 {

--- a/test/test_xhistogram.cpp
+++ b/test/test_xhistogram.cpp
@@ -6,12 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xhistogram.hpp"
+
 #include <complex>
 #include <limits>
 
 #include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xhistogram.hpp"
 #include "xtensor/xrandom.hpp"
 
 namespace xt

--- a/test/test_xindex_view.cpp
+++ b/test/test_xindex_view.cpp
@@ -6,11 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xindex_view.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xrandom.hpp"
-#include "xtensor/xindex_view.hpp"
 #include "xtensor/xbroadcast.hpp"
 #include "xtensor/xview.hpp"
 #include "test_common.hpp"

--- a/test/test_xinfo.cpp
+++ b/test/test_xinfo.cpp
@@ -6,13 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xinfo.hpp"
 
 #include <sstream>
 #include <string>
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xinfo.hpp"
 
 namespace xt
 {

--- a/test/test_xio.cpp
+++ b/test/test_xio.cpp
@@ -6,16 +6,16 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xio.hpp"
 
 #include <vector>
 #include <algorithm>
 #include <sstream>
 #include <limits>
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xio.hpp"
 #include "xtensor/xrandom.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xdynamic_view.hpp"

--- a/test/test_xjson.cpp
+++ b/test/test_xjson.cpp
@@ -6,13 +6,13 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xjson.hpp"
 
 #include <string>
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xjson.hpp"
 #include "xtensor/xview.hpp"
 
 namespace xt

--- a/test/test_xlayout.cpp
+++ b/test/test_xlayout.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xlayout.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xio.hpp"

--- a/test/test_xmanipulation.cpp
+++ b/test/test_xmanipulation.cpp
@@ -7,15 +7,15 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xmanipulation.hpp"
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xbuilder.hpp"
-#include "xtensor/xmanipulation.hpp"
 #include "xtensor/xview.hpp"
-
 #include "xtensor/xio.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xmasked_view.cpp
+++ b/test/test_xmasked_view.cpp
@@ -7,11 +7,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtensor/xoptional_assembly.hpp"
 #include "xtensor/xmasked_view.hpp"
+
+#include "gtest/gtest.h"
+#include "xtensor/xoptional_assembly.hpp"
 #include "xtensor/xio.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xmath.cpp
+++ b/test/test_xmath.cpp
@@ -6,13 +6,14 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xmath.hpp"
+
 #include <complex>
 #include <limits>
 
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xoptional_assembly.hpp"
-#include "xtensor/xmath.hpp"
 #include "xtensor/xrandom.hpp"
 
 namespace xt

--- a/test/test_xmath_result_type.cpp
+++ b/test/test_xmath_result_type.cpp
@@ -19,21 +19,21 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
-#include "xtensor/xarray.hpp"
 #include "xtensor/xmath.hpp"
+#include "xtensor/xarray.hpp"
 #include "xtensor/xrandom.hpp"
 #pragma GCC diagnostic pop
 #elif defined(_WIN32)
 #pragma warning(push)
 #pragma warning(disable: 4244)
 #pragma warning(disable: 4267)
-#include "xtensor/xarray.hpp"
 #include "xtensor/xmath.hpp"
+#include "xtensor/xarray.hpp"
 #include "xtensor/xrandom.hpp"
 #pragma warning(pop)
 #else
-#include "xtensor/xarray.hpp"
 #include "xtensor/xmath.hpp"
+#include "xtensor/xarray.hpp"
 #include "xtensor/xrandom.hpp"
 #endif
 

--- a/test/test_xmime.cpp
+++ b/test/test_xmime.cpp
@@ -6,14 +6,15 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xmime.hpp"
+
 
 #include <iostream>
 
 #include <nlohmann/json.hpp>
 
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xmime.hpp"
 
 namespace xt
 {

--- a/test/test_xnoalias.cpp
+++ b/test/test_xnoalias.cpp
@@ -6,9 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xnoalias.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
-#include "xtensor/xnoalias.hpp"
 #include "xtensor/xio.hpp"
 #include "xtensor/xview.hpp"
 #include "test_xsemantic.hpp"

--- a/test/test_xnorm.cpp
+++ b/test/test_xnorm.cpp
@@ -6,8 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xnorm.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xview.hpp"

--- a/test/test_xnpy.cpp
+++ b/test/test_xnpy.cpp
@@ -6,9 +6,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
 #include "xtensor/xnpy.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 
 #include <fstream>

--- a/test/test_xoptional.cpp
+++ b/test/test_xoptional.cpp
@@ -6,15 +6,15 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xoptional.hpp"
 
 #include <algorithm>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "gtest/gtest.h"
 #include "xtensor/xio.hpp"
-#include "xtensor/xoptional.hpp"
 
 namespace xt
 {

--- a/test/test_xoptional_assembly.cpp
+++ b/test/test_xoptional_assembly.cpp
@@ -6,13 +6,14 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtensor/xarray.hpp"
-#include "xtensor/xio.hpp"
 #include "xtensor/xoptional_assembly.hpp"
 
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+
 #include "test_common.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xoptional_assembly_adaptor.cpp
+++ b/test/test_xoptional_assembly_adaptor.cpp
@@ -6,13 +6,14 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtensor/xarray.hpp"
-#include "xtensor/xio.hpp"
 #include "xtensor/xoptional_assembly.hpp"
 
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xio.hpp"
+
 #include "test_common.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xoptional_assembly_storage.cpp
+++ b/test/test_xoptional_assembly_storage.cpp
@@ -7,11 +7,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xoptional_assembly_storage.hpp"
 
+#include "gtest/gtest.h"
 #include "xtensor/xstorage.hpp"
 #include "xtensor/xio.hpp"
-#include "xtensor/xoptional_assembly_storage.hpp"
 
 namespace xt
 {

--- a/test/test_xpad.cpp
+++ b/test/test_xpad.cpp
@@ -6,11 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xpad.hpp"
+
 #include <complex>
 #include <limits>
 
 #include "gtest/gtest.h"
-#include "xtensor/xpad.hpp"
 
 namespace xt
 {

--- a/test/test_xrandom.cpp
+++ b/test/test_xrandom.cpp
@@ -6,7 +6,7 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+
 #if (defined(__GNUC__) && !defined(__clang__))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -15,8 +15,11 @@
 #else
 #include "xtensor/xrandom.hpp"
 #endif
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xreducer.cpp
+++ b/test/test_xreducer.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xreducer.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
@@ -13,9 +15,11 @@
 #include "xtensor/xfixed.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xmath.hpp"
-#include "xtensor/xreducer.hpp"
 #include "xtensor/xview.hpp"
 #include "xtensor/xmanipulation.hpp"
+#include "xtensor/xio.hpp"
+#include "test_common_macros.hpp"
+
 #if (defined(__GNUC__) && !defined(__clang__))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -25,7 +29,6 @@
 #include "xtensor/xrandom.hpp"
 #endif
 
-#include "xtensor/xio.hpp"
 
 namespace xt
 {

--- a/test/test_xscalar.cpp
+++ b/test/test_xscalar.cpp
@@ -6,9 +6,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xscalar.hpp"
+
+#include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {

--- a/test/test_xshape.cpp
+++ b/test/test_xshape.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xshape.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xbroadcast.hpp"
 #include "xtensor/xarray.hpp"
@@ -13,7 +15,6 @@
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xfixed.hpp"
-#include "xtensor/xshape.hpp"
 
 namespace xt
 {

--- a/test/test_xsort.cpp
+++ b/test/test_xsort.cpp
@@ -6,6 +6,8 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
+#include "xtensor/xsort.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
@@ -15,7 +17,6 @@
 #include "xtensor/xview.hpp"
 #include "xtensor/xrandom.hpp"
 #include "xtensor/xslice.hpp"
-#include "xtensor/xsort.hpp"
 
 namespace xt
 {

--- a/test/test_xstorage.cpp
+++ b/test/test_xstorage.cpp
@@ -6,10 +6,14 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xstorage.hpp"
+
+#include <numeric>
+
 #include "gtest/gtest.h"
 #include "xtensor/xtensor_config.hpp"
-#include "xtensor/xstorage.hpp"
-#include <numeric>
+#include "test_common_macros.hpp"
+
 
 namespace xt
 {

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -6,6 +6,8 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xstrided_view.hpp"
+
 #include "gtest/gtest.h"
 
 #include "xtensor/xarray.hpp"
@@ -16,7 +18,10 @@
 #include "xtensor/xnoalias.hpp"
 #include "xtensor/xstrided_view.hpp"
 #include "xtensor/xtensor.hpp"
+#include "xtensor/xfixed.hpp"
 #include "xtensor/xview.hpp"
+#include "test_common_macros.hpp"
+
 
 namespace xt
 {

--- a/test/test_xtensor.cpp
+++ b/test/test_xtensor.cpp
@@ -6,12 +6,12 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xarray.hpp"
-#include "test_common.hpp"
 
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
 #include "xtensor/xio.hpp"
+#include "test_common.hpp"
 
 namespace xt
 {

--- a/test/test_xutils.cpp
+++ b/test/test_xutils.cpp
@@ -6,19 +6,22 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include "xtensor/xutils.hpp"
+
 #include <initializer_list>
 #include <type_traits>
 #include <tuple>
 #include <complex>
 
+#include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xfixed.hpp"
 #include "xtensor/xstrided_view.hpp"
 #include "xtensor/xshape.hpp"
-#include "xtensor/xutils.hpp"
 #include "xtensor/xview.hpp"
+#include "test_common_macros.hpp"
+
 
 namespace xt
 {

--- a/test/test_xvectorize.cpp
+++ b/test/test_xvectorize.cpp
@@ -6,10 +6,10 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-#include "gtest/gtest.h"
-
-#include "xtensor/xarray.hpp"
 #include "xtensor/xvectorize.hpp"
+
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
 
 namespace xt
 {

--- a/test/test_xview.cpp
+++ b/test/test_xview.cpp
@@ -6,10 +6,11 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include "xtensor/xview.hpp"
+
 #include <algorithm>
 
 #include "gtest/gtest.h"
-
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xfixed.hpp"
@@ -17,8 +18,9 @@
 #include "xtensor/xstrided_view.hpp"
 #include "xtensor/xmanipulation.hpp"
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
 #include "xtensor/xrandom.hpp"
+#include "test_common_macros.hpp"
+
 
 namespace xt
 {

--- a/test/test_xview_semantic.cpp
+++ b/test/test_xview_semantic.cpp
@@ -8,8 +8,10 @@
 
 #include "gtest/gtest.h"
 #include "xtensor/xview.hpp"
-#include "test_xsemantic.hpp"
 #include "xtensor/xnoalias.hpp"
+
+#include "test_xsemantic.hpp"
+#include "test_common_macros.hpp"
 
 namespace xt
 {


### PR DESCRIPTION
Pull request based on some minor cleanups from https://github.com/QuantStack/xtensor/pull/1476

This basically follows the include-what-you-use philosophy which also includes the .h file as the primary file in tests. Additionally:

* Adds missing <type_info> include uncovered by this reordering.
* Fixes memory leak in test by using std::unique_ptr.

(I will be splitting some of the rest of that pull request up into smaller pieces)