### PR TITLE
Iterator

### DIFF
--- a/include/xtensor/xassign.hpp
+++ b/include/xtensor/xassign.hpp
@@ -471,7 +471,7 @@ namespace xt
         for (size_type i = 0; i < s; ++i)
         {
             *m_lhs = conditional_cast<is_narrowing, result_type>(*m_rhs);
-            stepper_tools<L>::increment_stepper(*this, m_index, m_e1.shape());
+            stepper_tools<L>::increment_stepper(*this, m_index, m_e1.shape(), L);
         }
     }
 

--- a/include/xtensor/xfunctor_view.hpp
+++ b/include/xtensor/xfunctor_view.hpp
@@ -217,60 +217,60 @@ namespace xt
         }
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto begin() noexcept;
+        auto begin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto end() noexcept;
+        auto end(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto begin() const noexcept;
+        auto begin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto end() const noexcept;
+        auto end(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto cbegin() const noexcept;
+        auto cbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto cend() const noexcept;
+        auto cend(layout_type l = L) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto rbegin() noexcept;
+        auto rbegin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto rend() noexcept;
+        auto rend(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto rbegin() const noexcept;
+        auto rbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto rend() const noexcept;
+        auto rend(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto crbegin() const noexcept;
+        auto crbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        auto crend() const noexcept;
+        auto crend(layout_type l = L) const noexcept;
 
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        broadcast_iterator<S, L> begin(const S& shape) noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        broadcast_iterator<S, L> end(const S& shape) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        broadcast_iterator<S, L> end(const S& shape, layout_type l = L) noexcept;
 
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> end(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> cbegin(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> cend(const S& shape, layout_type l = L) const noexcept;
 
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) noexcept;
 
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape, layout_type l = L) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape, layout_type l = L) const noexcept;
 
         storage_iterator storage_begin() noexcept;
         storage_iterator storage_end() noexcept;
@@ -844,75 +844,81 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::begin() noexcept
+    inline auto xfunctor_applier_base<D>::begin(layout_type l) noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template begin<L>())>
-            (m_e.template begin<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template begin<L>(l))>
+            (m_e.template begin<L>(l), &m_functor);
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::end() noexcept
+    inline auto xfunctor_applier_base<D>::end(layout_type l) noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template end<L>())>
-            (m_e.template end<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template end<L>(l))>
+            (m_e.template end<L>(l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::begin() const noexcept
+    inline auto xfunctor_applier_base<D>::begin(layout_type l) const noexcept
     {
-        return this->template cbegin<L>();
+        return this->template cbegin<L>(l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::end() const noexcept
+    inline auto xfunctor_applier_base<D>::end(layout_type l) const noexcept
     {
-        return this->template cend<L>();
+        return this->template cend<L>(l);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::cbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::cbegin(layout_type l) const noexcept
     {
-        return xfunctor_iterator<const functor_type, decltype(m_e.template cbegin<L>())>
-            (m_e.template cbegin<L>(), &m_functor);
+        return xfunctor_iterator<const functor_type, decltype(m_e.template cbegin<L>(l))>
+            (m_e.template cbegin<L>(l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::cend() const noexcept
+    inline auto xfunctor_applier_base<D>::cend(layout_type l) const noexcept
     {
-        return xfunctor_iterator<const functor_type, decltype(m_e.template cend<L>())>
-            (m_e.template cend<L>(), &m_functor);
+        return xfunctor_iterator<const functor_type, decltype(m_e.template cend<L>(l))>
+            (m_e.template cend<L>(l), &m_functor);
     }
     //@}
 
@@ -924,84 +930,90 @@ namespace xt
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::begin(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(m_e.template begin<S, L>(shape), &m_functor);
+        return broadcast_iterator<S, L>(m_e.template begin<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::end(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(m_e.template end<S, L>(shape), &m_functor);
+        return broadcast_iterator<S, L>(m_e.template end<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::begin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cbegin<S, L>(shape);
+        return cbegin<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::end(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cend<S, L>(shape);
+        return cend<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::cbegin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(m_e.template cbegin<S, L>(shape), &m_functor);
+        return const_broadcast_iterator<S, L>(m_e.template cbegin<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::cend(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(m_e.template cend<S, L>(shape), &m_functor);
+        return const_broadcast_iterator<S, L>(m_e.template cend<L, S>(shape, l), &m_functor);
     }
     //@}
 
@@ -1011,75 +1023,81 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::rbegin() noexcept
+    inline auto xfunctor_applier_base<D>::rbegin(layout_type l) noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
-            (m_e.template rbegin<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>(l))>
+            (m_e.template rbegin<L>(l), &m_functor);
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::rend() noexcept
+    inline auto xfunctor_applier_base<D>::rend(layout_type l) noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
-            (m_e.template rend<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>(l))>
+            (m_e.template rend<L>(l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::rbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::rbegin(layout_type l) const noexcept
     {
-        return this->template crbegin<L>();
+        return this->template crbegin<L>(l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::rend() const noexcept
+    inline auto xfunctor_applier_base<D>::rend(layout_type l) const noexcept
     {
-        return this->template crend<L>();
+        return this->template crend<L>(l);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::crbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::crbegin(layout_type l) const noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
-            (m_e.template rbegin<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>(l))>
+            (m_e.template rbegin<L>(l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xfunctor_applier_base<D>::crend() const noexcept
+    inline auto xfunctor_applier_base<D>::crend(layout_type l) const noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
-            (m_e.template rend<L>(), &m_functor);
+        return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>(l))>
+            (m_e.template rend<L>(l), &m_functor);
     }
     //@}
 
@@ -1090,84 +1108,90 @@ namespace xt
      * Returns an iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::rbegin(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(m_e.template rbegin<S, L>(shape), &m_functor);
+        return reverse_broadcast_iterator<S, L>(m_e.template rbegin<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns an iterator to the element following the last element of the
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::rend(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(m_e.template rend<S, L>(shape), &m_functor);
+        return reverse_broadcast_iterator<S, L>(m_e.template rend<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::rbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crbegin<S, L>(shape);
+        return crbegin<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::rend(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::rend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crend<S, L>();
+        return crend<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::crbegin(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::crbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(m_e.template crbegin<S, L>(), &m_functor);
+        return const_reverse_broadcast_iterator<S, L>(m_e.template crbegin<L, S>(shape, l), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L.
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
-    inline auto xfunctor_applier_base<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    template <layout_type L, class S>
+    inline auto xfunctor_applier_base<D>::crend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(m_e.template crend<S, L>(shape), &m_functor);
+        return const_reverse_broadcast_iterator<S, L>(m_e.template crend<L, S>(shape, l), &m_functor);
     }
     //@}
 

--- a/include/xtensor/xiterable.hpp
+++ b/include/xtensor/xiterable.hpp
@@ -73,40 +73,40 @@ namespace xt
         using const_reverse_iterator = const_reverse_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_layout_iterator<L> begin() const noexcept;
+        const_layout_iterator<L> begin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_layout_iterator<L> end() const noexcept;
+        const_layout_iterator<L> end(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_layout_iterator<L> cbegin() const noexcept;
+        const_layout_iterator<L> cbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_layout_iterator<L> cend() const noexcept;
+        const_layout_iterator<L> cend(layout_type l = L) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_layout_iterator<L> rbegin() const noexcept;
+        const_reverse_layout_iterator<L> rbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_layout_iterator<L> rend() const noexcept;
+        const_reverse_layout_iterator<L> rend(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_layout_iterator<L> crbegin() const noexcept;
+        const_reverse_layout_iterator<L> crbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_layout_iterator<L> crend() const noexcept;
+        const_reverse_layout_iterator<L> crend(layout_type l = L) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> end(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cbegin(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cend(const S& shape, layout_type l = L) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape, layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape, layout_type l = L) const noexcept;
 
     protected:
 
@@ -115,14 +115,14 @@ namespace xt
     private:
 
         template <layout_type L>
-        const_layout_iterator<L> get_cbegin(bool end_index) const noexcept;
+        const_layout_iterator<L> get_cbegin(bool end_index, layout_type l) const noexcept;
         template <layout_type L>
-        const_layout_iterator<L> get_cend(bool end_index) const noexcept;
+        const_layout_iterator<L> get_cend(bool end_index, layout_type l) const noexcept;
 
         template <layout_type L, class S>
-        const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool end_index) const noexcept;
+        const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool end_index, layout_type l) const noexcept;
         template <layout_type L, class S>
-        const_broadcast_iterator<S, L> get_cend(const S& shape, bool end_index) const noexcept;
+        const_broadcast_iterator<S, L> get_cend(const S& shape, bool end_index, layout_type l) const noexcept;
 
         template <class S>
         const_stepper get_stepper_begin(const S& shape) const noexcept;
@@ -191,36 +191,36 @@ namespace xt
         using base_type::rend;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        layout_iterator<L> begin() noexcept;
+        layout_iterator<L> begin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        layout_iterator<L> end() noexcept;
+        layout_iterator<L> end(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_layout_iterator<L> rbegin() noexcept;
+        reverse_layout_iterator<L> rbegin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_layout_iterator<L> rend() noexcept;
+        reverse_layout_iterator<L> rend(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        broadcast_iterator<S, L> end(const S& shape) noexcept;
+        broadcast_iterator<S, L> end(const S& shape, layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
-        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+        reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) noexcept;
 
     private:
 
         template <layout_type L>
-        layout_iterator<L> get_begin(bool end_index) noexcept;
+        layout_iterator<L> get_begin(bool end_index, layout_type l) noexcept;
         template <layout_type L>
-        layout_iterator<L> get_end(bool end_index) noexcept;
+        layout_iterator<L> get_end(bool end_index, layout_type l) noexcept;
 
         template <layout_type L, class S>
-        broadcast_iterator<S, L> get_begin(const S& shape, bool end_index) noexcept;
+        broadcast_iterator<S, L> get_begin(const S& shape, bool end_index, layout_type l) noexcept;
         template <layout_type L, class S>
-        broadcast_iterator<S, L> get_end(const S& shape, bool end_index) noexcept;
+        broadcast_iterator<S, L> get_end(const S& shape, bool end_index, layout_type l) noexcept;
 
         template <class S>
         stepper get_stepper_begin(const S& shape) noexcept;
@@ -418,48 +418,52 @@ namespace xt
     //@{
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::begin() const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::begin(layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return this->template cbegin<L>();
+        return this->template cbegin<L>(l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::end() const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::end(layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return this->template cend<L>();
+        return this->template cend<L>(l);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::cbegin() const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::cbegin(layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return this->template get_cbegin<L>(false);
+        return this->template get_cbegin<L>(false, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::cend() const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::cend(layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return this->template get_cend<L>(true);
+        return this->template get_cend<L>(true, l);
     }
     //@}
 
@@ -469,48 +473,52 @@ namespace xt
     //@{
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::rbegin() const noexcept -> const_reverse_layout_iterator<L>
+    inline auto xconst_iterable<D>::rbegin(layout_type l) const noexcept -> const_reverse_layout_iterator<L>
     {
-        return this->template crbegin<L>();
+        return this->template crbegin<L>(l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::rend() const noexcept -> const_reverse_layout_iterator<L>
+    inline auto xconst_iterable<D>::rend(layout_type l) const noexcept -> const_reverse_layout_iterator<L>
     {
-        return this->template crend<L>();
+        return this->template crend<L>(l);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::crbegin() const noexcept -> const_reverse_layout_iterator<L>
+    inline auto xconst_iterable<D>::crbegin(layout_type l) const noexcept -> const_reverse_layout_iterator<L>
     {
-        return const_reverse_layout_iterator<L>(get_cend<L>(true));
+        return const_reverse_layout_iterator<L>(get_cend<L>(true, l));
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::crend() const noexcept -> const_reverse_layout_iterator<L>
+    inline auto xconst_iterable<D>::crend(layout_type l) const noexcept -> const_reverse_layout_iterator<L>
     {
-        return const_reverse_layout_iterator<L>(get_cbegin<L>(false));
+        return const_reverse_layout_iterator<L>(get_cbegin<L>(false, l));
     }
     //@}
 
@@ -522,56 +530,60 @@ namespace xt
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::begin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cbegin<L>(shape);
+        return cbegin<L>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::end(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cend<L>(shape);
+        return cend<L>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L 
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::cbegin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cbegin<L, S>(shape, false);
+        return get_cbegin<L, S>(shape, false, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::cend(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cend<L, S>(shape, true);
+        return get_cend<L, S>(shape, true, l);
     }
     //@}
 
@@ -583,85 +595,89 @@ namespace xt
      * Returns a constant iterator to the first element of the reversed expression.
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::rbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crbegin<L, S>(shape);
+        return crbegin<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::rend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crend<L, S>(shape);
+        return crend<L, S>(shape, l);
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::crbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(get_cend<L, S>(shape, true));
+        return const_reverse_broadcast_iterator<S, L>(get_cend<L, S>(shape, true, l));
     }
 
     /**
      * Returns a constant iterator to the element following the last element of the
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::crend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(get_cbegin<L, S>(shape, false));
+        return const_reverse_broadcast_iterator<S, L>(get_cbegin<L, S>(shape, false, l));
     }
     //@}
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cbegin(bool end_index) const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::get_cbegin(bool end_index, layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return const_layout_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), end_index);
+        return const_layout_iterator<L>(get_stepper_begin(get_shape()), &get_shape(), end_index, l);
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xconst_iterable<D>::get_cend(bool end_index) const noexcept -> const_layout_iterator<L>
+    inline auto xconst_iterable<D>::get_cend(bool end_index, layout_type l) const noexcept -> const_layout_iterator<L>
     {
-        return const_layout_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), end_index);
+        return const_layout_iterator<L>(get_stepper_end(get_shape(), L), &get_shape(), end_index, l);
     }
 
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool end_index, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
+        return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index, l);
     }
 
     template <class D>
     template <layout_type L, class S>
-    inline auto xconst_iterable<D>::get_cend(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xconst_iterable<D>::get_cend(const S& shape, bool end_index, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
+        return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index, l);
     }
 
     template <class D>
@@ -700,25 +716,27 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::begin() noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::begin(layout_type l) noexcept -> layout_iterator<L>
     {
-        return get_begin<L>(false);
+        return get_begin<L>(false, l);
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::end() noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::end(layout_type l) noexcept -> layout_iterator<L>
     {
-        return get_end<L>(true);
+        return get_end<L>(true, l);
     }
     //@}
 
@@ -728,25 +746,27 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::rbegin() noexcept -> reverse_layout_iterator<L>
+    inline auto xiterable<D>::rbegin(layout_type l) noexcept -> reverse_layout_iterator<L>
     {
-        return reverse_layout_iterator<L>(get_end<L>(true));
+        return reverse_layout_iterator<L>(get_end<L>(true, l));
     }
 
     /**
      * Returns an iterator to the element following the last element
      * of the reversed expression.
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::rend() noexcept -> reverse_layout_iterator<L>
+    inline auto xiterable<D>::rend(layout_type l) noexcept -> reverse_layout_iterator<L>
     {
-        return reverse_layout_iterator<L>(get_begin<L>(false));
+        return reverse_layout_iterator<L>(get_begin<L>(false, l));
     }
     //@}
 
@@ -758,28 +778,30 @@ namespace xt
      * Returns an iterator to the first element of the expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::begin(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return get_begin<L, S>(shape, false);
+        return get_begin<L, S>(shape, false, l);
     }
 
     /**
      * Returns an iterator to the element following the last element of the
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::end(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return get_end<L, S>(shape, true);
+        return get_end<L, S>(shape, true, l);
     }
     //@}
 
@@ -791,57 +813,59 @@ namespace xt
      * Returns an iterator to the first element of the reversed expression. The
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xiterable<D>::rbegin(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(get_end<L, S>(shape, true));
+        return reverse_broadcast_iterator<S, L>(get_end<L, S>(shape, true, l));
     }
 
     /**
      * Returns an iterator to the element following the last element of the
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
+     * @param l dynamic layout used for the traversal, default value is \c L
      * @tparam S type of the \c shape parameter.
      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xiterable<D>::rend(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(get_begin<L, S>(shape, false));
+        return reverse_broadcast_iterator<S, L>(get_begin<L, S>(shape, false, l));
     }
     //@}
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_begin(bool end_index) noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::get_begin(bool end_index, layout_type l) noexcept -> layout_iterator<L>
     {
-        return layout_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), end_index);
+        return layout_iterator<L>(get_stepper_begin(this->get_shape()), &(this->get_shape()), end_index, l);
     }
 
     template <class D>
     template <layout_type L>
-    inline auto xiterable<D>::get_end(bool end_index) noexcept -> layout_iterator<L>
+    inline auto xiterable<D>::get_end(bool end_index, layout_type l) noexcept -> layout_iterator<L>
     {
-        return layout_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), end_index);
+        return layout_iterator<L>(get_stepper_end(this->get_shape(), L), &(this->get_shape()), end_index, l);
     }
 
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::get_begin(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::get_begin(const S& shape, bool end_index, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
+        return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index, l);
     }
 
     template <class D>
     template <layout_type L, class S>
-    inline auto xiterable<D>::get_end(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
+    inline auto xiterable<D>::get_end(const S& shape, bool end_index, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
+        return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index, l);
     }
 
     template <class D>

--- a/include/xtensor/xiterator.hpp
+++ b/include/xtensor/xiterator.hpp
@@ -151,24 +151,28 @@ namespace xt
         template <class S, class IT, class ST>
         static void increment_stepper(S& stepper,
                                       IT& index,
-                                      const ST& shape);
+                                      const ST& shape,
+                                      layout_type l);
 
         template <class S, class IT, class ST>
         static void decrement_stepper(S& stepper,
                                       IT& index,
-                                      const ST& shape);
+                                      const ST& shape,
+                                      layout_type l);
 
         template <class S, class IT, class ST>
         static void increment_stepper(S& stepper,
                                       IT& index,
                                       const ST& shape,
-                                      typename S::size_type n);
+                                      typename S::size_type n,
+                                      layout_type l);
 
         template <class S, class IT, class ST>
         static void decrement_stepper(S& stepper,
                                       IT& index,
                                       const ST& shape,
-                                      typename S::size_type n);
+                                      typename S::size_type n,
+                                      layout_type l);
     };
 
     /********************
@@ -266,9 +270,6 @@ namespace xt
 
             const S* p_shape;
         };
-
-        template <layout_type L>
-        struct LAYOUT_FORBIDEN_FOR_XITERATOR;
     }
 
     template <class St, class S, layout_type L>
@@ -299,7 +300,7 @@ namespace xt
         xiterator() = default;
 
         // end_index means either reverse_iterator && !end or !reverse_iterator && end
-        xiterator(St st, shape_param_type shape, bool end_index);
+        xiterator(St st, shape_param_type shape, bool end_index, layout_type l);
 
         self_type& operator++();
         self_type& operator--();
@@ -320,8 +321,7 @@ namespace xt
         stepper_type m_st;
         index_type m_index;
         difference_type m_linear_index;
-
-        using checking_type = typename detail::LAYOUT_FORBIDEN_FOR_XITERATOR<L>::type;
+        layout_type m_layout;
     };
 
     template <class St, class S, layout_type L>
@@ -545,7 +545,8 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper,
                                                                   IT& index,
-                                                                  const ST& shape)
+                                                                  const ST& shape,
+                                                                  layout_type)
     {
         using size_type = typename S::size_type;
         size_type i = index.size();
@@ -579,7 +580,8 @@ namespace xt
     void stepper_tools<layout_type::row_major>::increment_stepper(S& stepper,
                                                                   IT& index,
                                                                   const ST& shape,
-                                                                  typename S::size_type n)
+                                                                  typename S::size_type n,
+                                                                  layout_type)
     {
         using size_type = typename S::size_type;
         size_type i = index.size();
@@ -624,7 +626,8 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::row_major>::decrement_stepper(S& stepper,
                                                                   IT& index,
-                                                                  const ST& shape)
+                                                                  const ST& shape,
+                                                                  layout_type)
     {
         using size_type = typename S::size_type;
         size_type i = index.size();
@@ -657,7 +660,8 @@ namespace xt
     void stepper_tools<layout_type::row_major>::decrement_stepper(S& stepper,
                                                                   IT& index,
                                                                   const ST& shape,
-                                                                  typename S::size_type n)
+                                                                  typename S::size_type n,
+                                                                  layout_type)
     {
         using size_type = typename S::size_type;
         size_type i = index.size();
@@ -701,7 +705,8 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper,
                                                                      IT& index,
-                                                                     const ST& shape)
+                                                                     const ST& shape,
+                                                                     layout_type)
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
@@ -736,7 +741,8 @@ namespace xt
     void stepper_tools<layout_type::column_major>::increment_stepper(S& stepper,
                                                                      IT& index,
                                                                      const ST& shape,
-                                                                     typename S::size_type n)
+                                                                     typename S::size_type n,
+                                                                     layout_type)
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
@@ -783,7 +789,8 @@ namespace xt
     template <class S, class IT, class ST>
     void stepper_tools<layout_type::column_major>::decrement_stepper(S& stepper,
                                                                      IT& index,
-                                                                     const ST& shape)
+                                                                     const ST& shape,
+                                                                     layout_type)
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
@@ -817,7 +824,8 @@ namespace xt
     void stepper_tools<layout_type::column_major>::decrement_stepper(S& stepper,
                                                                      IT& index,
                                                                      const ST& shape,
-                                                                     typename S::size_type n)
+                                                                     typename S::size_type n,
+                                                                     layout_type)
     {
         using size_type = typename S::size_type;
         size_type size = index.size();
@@ -856,6 +864,80 @@ namespace xt
         if (i == size)
         {
             stepper.to_begin();
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::dynamic>::increment_stepper(S& stepper,
+                                                                IT& index,
+                                                                const ST& shape,
+                                                                layout_type l)
+    {
+        XTENSOR_ASSERT(l == layout_type::row_major || l == layout_type::column_major);
+        if(l == layout_type::row_major)
+        {
+            stepper_tools<layout_type::row_major>::increment_stepper(stepper, index, shape, l);
+        }
+        else
+        {
+            stepper_tools<layout_type::column_major>::increment_stepper(stepper, index, shape, l);
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::dynamic>::increment_stepper(S& stepper,
+                                                                IT& index,
+                                                                const ST& shape,
+                                                                typename S::size_type n,
+                                                                layout_type l)
+    {
+        XTENSOR_ASSERT(l == layout_type::row_major || l == layout_type::column_major);
+        if(l == layout_type::row_major)
+        {
+            stepper_tools<layout_type::row_major>::increment_stepper(stepper, index, shape, n, l);
+        }
+        else
+        {
+            stepper_tools<layout_type::column_major>::increment_stepper(stepper, index, shape, n, l);
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::dynamic>::decrement_stepper(S& stepper,
+                                                                IT& index,
+                                                                const ST& shape,
+                                                                layout_type l)
+    {
+        XTENSOR_ASSERT(l == layout_type::row_major || l == layout_type::column_major);
+        if(l == layout_type::row_major)
+        {
+            stepper_tools<layout_type::row_major>::decrement_stepper(stepper, index, shape, l);
+        }
+        else
+        {
+            stepper_tools<layout_type::column_major>::decrement_stepper(stepper, index, shape, l);
+        }
+    }
+
+    template <>
+    template <class S, class IT, class ST>
+    void stepper_tools<layout_type::dynamic>::decrement_stepper(S& stepper,
+                                                                IT& index,
+                                                                const ST& shape,
+                                                                typename S::size_type n,
+                                                                layout_type l)
+    {
+        XTENSOR_ASSERT(l == layout_type::row_major || l == layout_type::column_major);
+        if(l == layout_type::row_major)
+        {
+            stepper_tools<layout_type::row_major>::decrement_stepper(stepper, index, shape, n, l);
+        }
+        else
+        {
+            stepper_tools<layout_type::column_major>::decrement_stepper(stepper, index, shape, n, l);
         }
     }
 
@@ -957,27 +1039,18 @@ namespace xt
         {
             return *p_shape;
         }
-
-        template <>
-        struct LAYOUT_FORBIDEN_FOR_XITERATOR<layout_type::row_major>
-        {
-            using type = int;
-        };
-
-        template <>
-        struct LAYOUT_FORBIDEN_FOR_XITERATOR<layout_type::column_major>
-        {
-            using type = int;
-        };
     }
 
     template <class St, class S, layout_type L>
-    inline xiterator<St, S, L>::xiterator(St st, shape_param_type shape, bool end_index)
-        : private_base(shape), m_st(st),
-          m_index(end_index ? xtl::forward_sequence<index_type, const shape_type&>(this->shape())
-                            : xtl::make_sequence<index_type>(this->shape().size(), size_type(0))),
-          m_linear_index(0)
+    inline xiterator<St, S, L>::xiterator(St st, shape_param_type shape, bool end_index, layout_type l)
+        : private_base(shape)
+        , m_st(st)
+        , m_index(end_index ? xtl::forward_sequence<index_type, const shape_type&>(this->shape())
+                            : xtl::make_sequence<index_type>(this->shape().size(), size_type(0)))
+        , m_linear_index(0)
+        , m_layout(l)
     {
+        XTENSOR_ASSERT(l == layout_type::row_major || l == layout_type::column_major);
         // end_index means either reverse_iterator && !end or !reverse_iterator && end
         if (end_index)
         {
@@ -995,7 +1068,7 @@ namespace xt
     template <class St, class S, layout_type L>
     inline auto xiterator<St, S, L>::operator++() -> self_type&
     {
-        stepper_tools<L>::increment_stepper(m_st, m_index, this->shape());
+        stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), m_layout);
         ++m_linear_index;
         return *this;
     }
@@ -1003,7 +1076,7 @@ namespace xt
     template <class St, class S, layout_type L>
     inline auto xiterator<St, S, L>::operator--() -> self_type&
     {
-        stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape());
+        stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), m_layout);
         --m_linear_index;
         return *this;
     }
@@ -1013,11 +1086,11 @@ namespace xt
     {
         if (n >= 0)
         {
-            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n));
+            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n), m_layout);
         }
         else
         {
-            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n));
+            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n), m_layout);
         }
         m_linear_index += n;
         return *this;
@@ -1028,11 +1101,11 @@ namespace xt
     {
         if (n >= 0)
         {
-            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n));
+            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n), m_layout);
         }
         else
         {
-            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n));
+            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n), m_layout);
         }
         m_linear_index -= n;
         return *this;
@@ -1060,7 +1133,7 @@ namespace xt
     inline bool xiterator<St, S, L>::equal(const xiterator& rhs) const
     {
         XTENSOR_ASSERT(this->shape() == rhs.shape());
-        return m_linear_index == rhs.m_linear_index;
+        return m_linear_index == rhs.m_linear_index && m_layout == rhs.m_layout;
     }
 
     template <class St, class S, layout_type L>

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -186,61 +186,61 @@ namespace xt
         bool has_linear_assign(const S& strides) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        iterator begin() noexcept;
+        iterator begin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        iterator end() noexcept;
+        iterator end(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_iterator begin() const noexcept;
+        const_iterator begin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_iterator end() const noexcept;
+        const_iterator end(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_iterator cbegin() const noexcept;
+        const_iterator cbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_iterator cend() const noexcept;
+        const_iterator cend(layout_type l = L) const noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_iterator rbegin() noexcept;
+        reverse_iterator rbegin(layout_type l = L) noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_iterator rend() noexcept;
+        reverse_iterator rend(layout_type l = L) noexcept;
 
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator rend(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crbegin(layout_type l = L) const noexcept;
         template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_iterator crend() const noexcept;
+        const_reverse_iterator crend(layout_type l = L) const noexcept;
 
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        broadcast_iterator<S, L> end(const S& shape) noexcept;
+        broadcast_iterator<S, L> end(const S& shape, layout_type l = L) noexcept;
 
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> begin(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> end(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cbegin(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+        const_broadcast_iterator<S, L> cend(const S& shape, layout_type l = L) const noexcept;
 
 
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+        reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) noexcept;
 
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape, layout_type l = L) const noexcept;
         template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
-        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape, layout_type l = L) const noexcept;
 
         iterator storage_begin() noexcept;
         iterator storage_end() noexcept;
@@ -606,86 +606,86 @@ namespace xt
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::begin() noexcept -> iterator
+    inline auto xscalar<CT>::begin(layout_type) noexcept -> iterator
     {
         return &m_value;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::end() noexcept -> iterator
+    inline auto xscalar<CT>::end(layout_type) noexcept -> iterator
     {
         return &m_value + 1;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::begin() const noexcept -> const_iterator
+    inline auto xscalar<CT>::begin(layout_type) const noexcept -> const_iterator
     {
         return &m_value;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::end() const noexcept -> const_iterator
+    inline auto xscalar<CT>::end(layout_type) const noexcept -> const_iterator
     {
         return &m_value + 1;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::cbegin() const noexcept -> const_iterator
+    inline auto xscalar<CT>::cbegin(layout_type) const noexcept -> const_iterator
     {
         return &m_value;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::cend() const noexcept -> const_iterator
+    inline auto xscalar<CT>::cend(layout_type) const noexcept -> const_iterator
     {
         return &m_value + 1;
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::rbegin() noexcept -> reverse_iterator
+    inline auto xscalar<CT>::rbegin(layout_type l) noexcept -> reverse_iterator
     {
-        return reverse_iterator(end());
+        return reverse_iterator(end(l));
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::rend() noexcept -> reverse_iterator
+    inline auto xscalar<CT>::rend(layout_type l) noexcept -> reverse_iterator
     {
-        return reverse_iterator(begin());
+        return reverse_iterator(begin(l));
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::rbegin() const noexcept -> const_reverse_iterator
+    inline auto xscalar<CT>::rbegin(layout_type l) const noexcept -> const_reverse_iterator
     {
-        return crbegin();
+        return crbegin(l);
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::rend() const noexcept -> const_reverse_iterator
+    inline auto xscalar<CT>::rend(layout_type l) const noexcept -> const_reverse_iterator
     {
-        return crend();
+        return crend(l);
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::crbegin() const noexcept -> const_reverse_iterator
+    inline auto xscalar<CT>::crbegin(layout_type l) const noexcept -> const_reverse_iterator
     {
-        return const_reverse_iterator(cend());
+        return const_reverse_iterator(cend(l));
     }
 
     template <class CT>
     template <layout_type L>
-    inline auto xscalar<CT>::crend() const noexcept -> const_reverse_iterator
+    inline auto xscalar<CT>::crend(layout_type l) const noexcept -> const_reverse_iterator
     {
-        return const_reverse_iterator(cbegin());
+        return const_reverse_iterator(cbegin(l));
     }
 
     /*****************************
@@ -694,86 +694,86 @@ namespace xt
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xscalar<CT>::begin(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return iterable_base::template begin<S, L>(shape);
+        return iterable_base::template begin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xscalar<CT>::end(const S& shape, layout_type l) noexcept -> broadcast_iterator<S, L>
     {
-        return iterable_base::template end<S, L>(shape);
+        return iterable_base::template end<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::begin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return iterable_base::template begin<S, L>(shape);
+        return iterable_base::template begin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::end(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return iterable_base::template end<S, L>(shape);
+        return iterable_base::template end<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::cbegin(const S& shape, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return iterable_base::template cbegin<S, L>(shape);
+        return iterable_base::template cbegin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::cend(const S& shapen, layout_type l) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return iterable_base::template cend<S, L>(shape);
+        return iterable_base::template cend<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::rbegin(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template rbegin<S, L>(shape);
+        return iterable_base::template rbegin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::rend(const S& shape, layout_type l) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template rend<S, L>(shape);
+        return iterable_base::template rend<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::rbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template rbegin<S, L>(shape);
+        return iterable_base::template rbegin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::rend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template rend<S, L>(shape);
+        return iterable_base::template rend<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::crbegin(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template crbegin<S, L>(shape);
+        return iterable_base::template crbegin<S, L>(shape, l);
     }
 
     template <class CT>
     template <class S, layout_type L>
-    inline auto xscalar<CT>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xscalar<CT>::crend(const S& shape, layout_type l) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return iterable_base::template crend<S, L>(shape);
+        return iterable_base::template crend<S, L>(shape, l);
     }
 
     template <class CT>


### PR DESCRIPTION
This is a prerequisite to fix #1494

For an obscure reason, gcc seems to mix up `begin` overloads in `xfunctor_view`: `m_e.template begin<L>(l)` should call the overload with a single parameter; it seems that the second one is called, with `l` as `shape` and default parameter for second parameter. This result in instantiating an `xiterator` with illegal types (layout_type instead of shape type).

EDIT: forgot to update methods from `xcontiguous_iterator` ...