### PR TITLE
Add layout parameter to `reshape_view()`

### DIFF
--- a/include/xtensor/xstrided_view.hpp
+++ b/include/xtensor/xstrided_view.hpp
@@ -593,15 +593,15 @@ namespace xt
         return view_type(std::forward<E>(e), std::move(args.new_shape), std::move(args.new_strides), args.new_offset, args.new_layout);
     }
 
-    template <class E, class S>
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class E, class S>
     inline auto reshape_view(E&& e, S&& shape)
     {
         using shape_type = std::decay_t<S>;
         get_strides_t<shape_type> strides;
 
         xt::resize_container(strides, shape.size());
-        compute_strides(shape, XTENSOR_DEFAULT_LAYOUT, strides);
-        using view_type = xstrided_view<xclosure_t<E>, shape_type, std::decay_t<E>::static_layout, detail::flat_adaptor_getter<xclosure_t<E>>>;
+        compute_strides(shape, L, strides);
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, XTENSOR_DEFAULT_LAYOUT, detail::flat_adaptor_getter<xclosure_t<E>>>;
         return view_type(std::forward<E>(e), std::forward<S>(shape), std::move(strides), 0, e.layout());
     }
 
@@ -638,18 +638,18 @@ namespace xt
         return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape), l);
     }
 
-    template <class E, class I, std::size_t N>
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class E, class I, std::size_t N>
     inline auto reshape_view(E&& e, const I(&shape)[N])
     {
         using shape_type = std::array<std::size_t, N>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 #else
-    template <class E, class I>
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class E, class I>
     inline auto reshape_view(E&& e, const std::initializer_list<I>& shape)
     {
         using shape_type = xt::dynamic_shape<std::size_t>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
     template <class E, class I>


### PR DESCRIPTION
Feel free to take over @SylvainCorlay but this was my first thought. Seemed to work for me.

```cpp
// [[Rcpp::depends(xtensor)]]
// [[Rcpp::plugins(cpp14)]]

#include <xtensor/xarray.hpp>
#include <xtensor-r/rarray.hpp>
#include <xtensor/xstrided_view.hpp>
#include <xtensor/xio.hpp>

// [[Rcpp::export]]
SEXP flat_to_3d() {

  xt::xarray<int, xt::layout_type::column_major> x = {1, 2, 3, 4, 5, 6};

  auto x_view = xt::reshape_view<xt::layout_type::column_major>(x, {1, 3, 2});

  std::cout << "x_view" << std::endl << x_view << std::endl;

  const xt::rarray<int>& res = x_view;

  std::cout << "res" << std::endl << res << std::endl;

  return res;
}
```

```r
> flat_to_3d()
x_view
{{{1, 4},
  {2, 5},
  {3, 6}}}
res
{{{1, 4},
  {2, 5},
  {3, 6}}}
, , 1

     [,1] [,2] [,3]
[1,]    1    2    3

, , 2

     [,1] [,2] [,3]
[1,]    4    5    6
```

I just assumed that `compute_strides()` was the only place where this mattered, as that seems to be the only place `order` is used for numpy. 

Passed through here:
https://github.com/numpy/numpy/blob/1ba4173d20f16348f793c1d87f8cc03cd87588ad/numpy/core/src/multiarray/shape.c#L245

Used here to "compute new strides"
https://github.com/numpy/numpy/blob/1ba4173d20f16348f793c1d87f8cc03cd87588ad/numpy/core/src/multiarray/shape.c#L422