### PR TITLE
xtensorConfig.cmake.in: use cmake config variable expansion

### DIFF
--- a/xtensorConfig.cmake.in
+++ b/xtensorConfig.cmake.in
@@ -18,11 +18,11 @@
 include(CMakeFindDependencyMacro)
 find_dependency(xtl @xtl_REQUIRED_VERSION@)
 
-if(XTENSOR_USE_XSIMD)
+if(@XTENSOR_USE_XSIMD@)
     find_dependency(xsimd @xsimd_REQUIRED_VERSION@)
 endif()
 
-if(XTENSOR_USE_TBB)
+if(@XTENSOR_USE_TBB@)
     find_dependency(TBB)
 endif()
 


### PR DESCRIPTION
This PR fixes a problem with variable expansion in the cmake configuration file `xtensorConfig.cmake.in`. Without this PR, the variables remain as plain text in the installed configuration `xtensorConfig.cmake`. However since they are only defined inside `CMakeLists.txt` during build time, they are treated as `FALSE` by downstream projects.

By surrounding the variables with `@` they are correctly replaced by cmake config variable expansion, and the final config contains the reduced value `ON` or `OFF`.

This fixes a build dependency lookup of `xsimd` for me.