### PR TITLE
flatten now returns new type xtensor_view

### DIFF
--- a/include/xtensor/xmanipulation.hpp
+++ b/include/xtensor/xmanipulation.hpp
@@ -224,7 +224,7 @@ namespace xt
         using const_iterator = decltype(e.template cbegin<L>());
         using adaptor_type = xiterator_adaptor<iterator, const_iterator>;
         constexpr layout_type layout = std::is_pointer<iterator>::value ? L : layout_type::dynamic;
-        using type = xtensor_adaptor<adaptor_type, 1, layout, extension::get_expression_tag_t<E>>;
+        using type = xtensor_view<adaptor_type, 1, layout, extension::get_expression_tag_t<E>>;
         return type(adaptor_type(e.template begin<L>(), e.template cbegin<L>(), e.size()), { e.size() });
     }
 

--- a/include/xtensor/xoptional.hpp
+++ b/include/xtensor/xoptional.hpp
@@ -428,6 +428,26 @@ namespace xt
         };
     }
 
+    /***************************************
+     * xtensor_view extension for optional *
+     ***************************************/
+
+    namespace extension
+    {
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_view_optional_traits : xtensor_optional_traits<EC, N, L>
+        {
+            using derived_type = xtensor_view<EC, N, L, xoptional_expression_tag>;
+        };
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_view_base<EC, N, L, xoptional_expression_tag>
+        {
+            using traits = xtensor_view_optional_traits<EC, N, L>;
+            using type = xcontainer_optional_base<traits>;
+        };
+    }
+
     /************************************************
      * xfunction extension for optional expressions *
      ************************************************/

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -137,6 +137,9 @@ namespace xt
     template <class EC, std::size_t N, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
     class xtensor_adaptor;
 
+    template <class EC, std::size_t N, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    class xtensor_view;
+
     template <std::size_t... N>
     class fixed_shape;
 

--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -908,7 +908,19 @@ namespace xt
         xt::xarray<int> x = {{1, 2, 3}, {4, 5, 6}};
         auto x_view = xt::strided_view(x, {xt::range(0, 1), xt::range(0, 1)});
         auto x_flat = xt::flatten<xt::layout_type::column_major>(x_view);
-        x_flat = {10};
-        EXPECT_EQ(x(0, 0), 10);
+        x_flat = 10;
+        xt::xarray<int> exp = {{10, 2, 3}, {4, 5, 6}};
+        EXPECT_EQ(x, exp);
+
+        auto x_view2 = xt::strided_view(x, {xt::range(0, 1), xt::range(0, 2)});
+        auto x_flat2 = xt::flatten<xt::layout_type::column_major>(x_view2);
+        x_flat2 = 15;
+        xt::xarray<int> exp2 = {{15, 15, 3}, {4, 5, 6}};
+        EXPECT_EQ(x, exp2);
+
+        xt::xarray<int> b = {20, 25};
+        x_flat2 = b;
+        xt::xarray<int> exp3 = {{20, 25, 3}, {4, 5, 6}};
+        EXPECT_EQ(x, exp3);
     }
 }


### PR DESCRIPTION
Fixes #1662 

@DavisVaughan with this PR, the type returned by `flatten` / `ravel` has `view_semantic`:

```cpp
xt::xarray<int> x = {{1, 2, 3}, {4, 5, 6}};
auto x_view2 = xt::strided_view(x, {xt::range(0, 1), xt::range(0, 2)});
auto x_flat2 = xt::flatten<xt::layout_type::column_major>(x_view2);
x_flat2 = 15;
// x is now {{15, 15, 3}, {4, 5, 6}};
```