### PR TITLE
adding alias to check if type is xsemantic_base.

### DIFF
--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -127,6 +127,15 @@ namespace xt
         derived_type& operator=(const xexpression<E>&);
     };
 
+    template <class E>
+    using is_assignable = is_crtp_base_of<xsemantic_base, E>;
+
+    template <class E, class R = void>
+    using enable_assignable = typename std::enable_if<is_assignable<E>::value, R>::type;
+
+    template <class E, class R = void>
+    using disable_assignable = typename std::enable_if<!is_assignable<E>::value, R>::type;
+
     /**
      * @class xcontainer_semantic
      * @brief Implementation of the xsemantic_base interface


### PR DESCRIPTION
This adds a convenience method to check for assignable container types. Please review and merge if useful.