### PR TITLE
Add numpy-like parameters in 'load_csv'.

### DIFF
--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -29,7 +29,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1);
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const unsigned long skip_rows = 0, const long long max_rows = -1);
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -111,7 +111,7 @@ namespace xt
      * @param read max_rows lines of content after skip_rows lines; the default is to read all the lines. [default: -1]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows)
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const unsigned long skip_rows, const long long max_rows)
     {
         using tensor_type = xcsv_tensor<T, A>;
         using storage_type = typename tensor_type::storage_type;
@@ -132,14 +132,10 @@ namespace xt
                     ++nhead;
                     continue;
                 }
-                if (std::equal(comments.begin(), comments.end(), row.begin()))
-                {
+                if (std::equal(comments.begin(), comments.end(), row.begin())) 
                     continue;
-                }
                 if (0 < max_rows && max_rows <= static_cast<const long long>(nbrow))
-                {
                     break;
-                }
                 std::stringstream row_stream(row);
                 nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell, delimiter);
                 ++nbrow;

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -29,7 +29,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const unsigned long skip_rows = 0, const long long max_rows = -1);
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const std::size_t skip_rows = 0, const ptrdiff_t max_rows = -1);
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -111,7 +111,7 @@ namespace xt
      * @param read max_rows lines of content after skip_rows lines; the default is to read all the lines. [default: -1]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const unsigned long skip_rows, const long long max_rows)
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows)
     {
         using tensor_type = xcsv_tensor<T, A>;
         using storage_type = typename tensor_type::storage_type;
@@ -132,10 +132,14 @@ namespace xt
                     ++nhead;
                     continue;
                 }
-                if (std::equal(comments.begin(), comments.end(), row.begin())) 
+                if (std::equal(comments.begin(), comments.end(), row.begin()))
+                {
                     continue;
+                }
                 if (0 < max_rows && max_rows <= static_cast<const long long>(nbrow))
+                {
                     break;
+                }
                 std::stringstream row_stream(row);
                 nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell, delimiter);
                 ++nbrow;

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -29,7 +29,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const std::size_t skip_rows = 0, const ptrdiff_t max_rows = -1);
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const ptrdiff_t max_rows = -1, const std::string comments = "#");
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -105,13 +105,13 @@ namespace xt
      * 
      * Returns an \ref xexpression for the parsed CSV
      * @param stream the input stream containing the CSV encoded values
-     * @param comments the string used to indicate the start of a comment. [default: "#"]
      * @param delimiter the character used to separate values. [default: ',']
      * @param skip the first skip_rows lines. [default: 0]
      * @param read max_rows lines of content after skip_rows lines; the default is to read all the lines. [default: -1]
+     * @param comments the string used to indicate the start of a comment. [default: "#"]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows)
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows, const std::string comments)
     {
         using tensor_type = xcsv_tensor<T, A>;
         using storage_type = typename tensor_type::storage_type;

--- a/include/xtensor/xcsv.hpp
+++ b/include/xtensor/xcsv.hpp
@@ -29,7 +29,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const unsigned long skip_rows = 0, const long long max_rows = -1);
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments = "#", const char delimiter = ',', const std::size_t skip_rows = 0, const std::ptrdiff_t max_rows = -1);
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -111,7 +111,7 @@ namespace xt
      * @param read max_rows lines of content after skip_rows lines; the default is to read all the lines. [default: -1]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const unsigned long skip_rows, const long long max_rows)
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const std::string comments, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows)
     {
         using tensor_type = xcsv_tensor<T, A>;
         using storage_type = typename tensor_type::storage_type;
@@ -132,10 +132,14 @@ namespace xt
                     ++nhead;
                     continue;
                 }
-                if (std::equal(comments.begin(), comments.end(), row.begin())) 
+                if (std::equal(comments.begin(), comments.end(), row.begin()))
+                {
                     continue;
+                }
                 if (0 < max_rows && max_rows <= static_cast<const long long>(nbrow))
+                {
                     break;
+                }
                 std::stringstream row_stream(row);
                 nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell, delimiter);
                 ++nbrow;

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -45,7 +45,7 @@ namespace xt
 
         std::stringstream source_stream(source);
 
-        auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
+        auto res = load_csv<double>(source_stream, ' ', 1, 2, "#");
 
         xtensor<double, 2> exp
             {{ 1.0,  2.0,  3.0,  4.0},

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -34,6 +34,26 @@ namespace xt
         ASSERT_TRUE(all(equal(res, exp)));
     }
 
+    TEST(xcsv, load_double_with_options)
+    {
+        std::string source =
+            "A B C D\n"
+            "#0.0 1.0 1.1 1.2\n"
+            "1.0 2.0 3.0 4.0\n"
+            "10.0 12.0 15.0 18.0\n"
+            "9.0, 8.0, 7.0, 6.";
+
+        std::stringstream source_stream(source);
+
+       auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
+
+        xtensor<double, 2> exp
+            {{ 1.0,  2.0,  3.0,  4.0},
+             {10.0, 12.0, 15.0, 18.0}};
+
+        ASSERT_TRUE(all(equal(res, exp)));
+    }
+
     TEST(xcsv, dump_double)
     {
         xtensor<double, 2> data

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -45,7 +45,7 @@ namespace xt
 
         std::stringstream source_stream(source);
 
-        auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
+       auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
 
         xtensor<double, 2> exp
             {{ 1.0,  2.0,  3.0,  4.0},

--- a/test/test_xcsv.cpp
+++ b/test/test_xcsv.cpp
@@ -45,7 +45,7 @@ namespace xt
 
         std::stringstream source_stream(source);
 
-       auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
+        auto res = load_csv<double>(source_stream, "#", ' ', 1, 2);
 
         xtensor<double, 2> exp
             {{ 1.0,  2.0,  3.0,  4.0},


### PR DESCRIPTION
This pull request adds following numpy-like parameters in 'load_csv' to improve compatibility with 'numpy. loadtxt'. 
New parameters:
- 'comments': The string used to indicate the start of a comment. 
- 'delimiter': The character used to separate values.
- 'skip_rows': Skip the first skip_rows lines.
- 'max_rows': Read max_rows lines of content after skip_rows lines. The default is to read all the lines.

Please see ['numpy. loadtxt'](https://docs.scipy.org/doc/numpy/reference/generated/numpy.loadtxt.html ). 