### PR TITLE
Added shape print tip to docs

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -85,7 +85,7 @@ The following minimal ``CMakeLists.txt`` is enough to build the first example:
     # find_package(xsimd REQUIRED)
 
     add_executable(first_example src/example.cpp)
-    
+
     if(MSVC)
         target_compile_options(first_example PRIVATE /EHsc /MP /bigobj)
         set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
@@ -152,6 +152,15 @@ When compiled and run, this produces the following output:
     {{1, 2, 3},
      {4, 5, 6},
      {7, 8, 9}}
+
+.. tip::
+
+  To print the shape to the standard output you can use
+
+  .. code-block:: cpp
+
+      const auto& s = arr.shape();
+      std::copy(s.cbegin(), s.cend(), std::ostream_iterator<double>(std::cout, " "));
 
 Third example: index access
 ---------------------------


### PR DESCRIPTION
Based on the question in #1688.

However...

In stead of adding this tip to the docs, shouldn't we consider adding `<<` overloads to be able to do:
```cpp
xt::xarray<int> arr {1, 2, 3, 4, 5, 6, 7, 8, 9};
std::cout << arr.shape() << std::endl;
```
?