### PR TITLE
Fix lvalue npy_file heap corruption in MSVC (was Pair allocator allocation and deallocation)

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -489,7 +489,7 @@ namespace xt
             {
                 if (m_buffer != nullptr)
                 {
-                    delete m_buffer;
+                    std::allocator<char>{}.deallocate(m_buffer, m_n_bytes);
                 }
             }
 


### PR DESCRIPTION
std::allocator supports combine or optimize away heap allocations
beyond ::operator new, which means, they use the same heap only
when they use heap, but they may not be using heap.  So it's
reasonable for MSVC to require pairing new and delete, allocate
and deallocate.

fixes: QuantStack/xtensor-io#59