### PR TITLE
Fixing compiler error

### DIFF
--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -174,6 +174,7 @@ namespace xt
         xbroadcast(CTA&& e, shape_type&& s);
 
         const inner_shape_type& shape() const noexcept;
+        size_type shape(size_type i) const noexcept;
         layout_type layout() const noexcept;
 
         template <class... Args>
@@ -308,6 +309,15 @@ namespace xt
     inline auto xbroadcast<CT, X>::shape() const noexcept -> const inner_shape_type&
     {
         return m_shape;
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::shape(size_type i) const noexcept -> size_type
+    {
+        return m_shape[i];
     }
 
     /**

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -649,7 +649,7 @@ namespace xt
             bool res = s == arr.dimension();
             for(std::size_t i = 0; i < s; ++i)
             {
-                res = res && (i == axis || new_shape[i] == arr.shape()[i]);
+                res = res && (i == axis || new_shape[i] == arr.shape(i));
             }
             if(!res)
             {

--- a/include/xtensor/xbuilder.hpp
+++ b/include/xtensor/xbuilder.hpp
@@ -643,13 +643,13 @@ namespace xt
         using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
         using source_shape_type = decltype(std::get<0>(t).shape());
         shape_type new_shape = xtl::forward_sequence<shape_type, source_shape_type>(std::get<0>(t).shape());
-        
+
         auto check_shape = [&axis, &new_shape](auto& arr) {
             std::size_t s = new_shape.size();
             bool res = s == arr.dimension();
             for(std::size_t i = 0; i < s; ++i)
             {
-                res = res && (i == axis || new_shape[i] == arr.shape(i));
+                res = res && (i == axis || new_shape[i] == arr.shape()[i]);
             }
             if(!res)
             {
@@ -662,7 +662,7 @@ namespace xt
             return prev + arr.shape()[axis];
         };
         new_shape[axis] += accumulate(shape_at_axis, std::size_t(0), t) - new_shape[axis];
-        
+
         return detail::make_xgenerator(detail::concatenate_impl<CT...>(std::forward<std::tuple<CT...>>(t), axis), new_shape);
     }
 

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -151,6 +151,7 @@ namespace xt
 
         size_type size() const noexcept;
         const shape_type& shape() const noexcept;
+        size_type shape(size_type i) const noexcept;
         layout_type layout() const noexcept;
         using accessible_base::dimension;
         using accessible_base::shape;
@@ -526,6 +527,12 @@ namespace xt
     {
         static std::array<size_type, 0> zero_shape;
         return zero_shape;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::shape(size_type) const noexcept -> size_type
+    {
+        return 0;
     }
 
     template <class CT>


### PR DESCRIPTION
I get a surprising compiler error (see below) which is fixed by this change. I'm a bit surprised by the error because I think the previous syntax was legal.

---------------------

Error-stream:

```none
In file included from /usr/local/include/xtensor/xview.hpp:26:
In file included from /usr/local/include/xtensor/xcontainer.hpp:23:
In file included from /usr/local/include/xtensor/xmath.hpp:27:
In file included from /usr/local/include/xtensor/xreducer.hpp:28:
/usr/local/include/xtensor/xbuilder.hpp:652:70: error: too many arguments to function call, expected 0, have 1
                res = res && (i == axis || new_shape[i] == arr.shape(i));
                                                           ~~~~~~~~~ ^
/usr/local/include/xtensor/xutils.hpp:159:31: note: in instantiation of function template specialization 'xt::concatenate(std::tuple<xbroadcast<xscalar<unsigned long>, array<unsigned long, 1> >,
      xtensor_container<uvector<unsigned long long, aligned_allocator<unsigned long long, 32> >, 1, xt::layout_type::row_major, xtensor_expression_tag> > &&, std::size_t)::(anonymous
      class)::operator()<xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> > >' requested here
            noexcept(noexcept(f(std::get<I>(t))))
                              ^
/usr/local/include/xtensor/xutils.hpp:168:27: note: in instantiation of exception specification for 'for_each_impl<0, (lambda at /usr/local/include/xtensor/xbuilder.hpp:647:28) &,
      xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> >, xt::xtensor_container<xt::uvector<unsigned long long, xsimd::aligned_allocator<unsigned long long, 32> >, 1,
      xt::layout_type::row_major, xt::xtensor_expression_tag> >' requested here
        noexcept(noexcept(detail::for_each_impl<0, F, T...>(std::forward<F>(f), t)))
                          ^
/usr/local/include/xtensor/xbuilder.hpp:659:9: note: in instantiation of exception specification for 'for_each<(lambda at /usr/local/include/xtensor/xbuilder.hpp:647:28) &, xt::xbroadcast<xt::xscalar<unsigned
      long>, std::__1::array<unsigned long, 1> >, xt::xtensor_container<xt::uvector<unsigned long long, xsimd::aligned_allocator<unsigned long long, 32> >, 1, xt::layout_type::row_major,
      xt::xtensor_expression_tag> >' requested here
        for_each(check_shape, t);
        ^
/usr/local/include/GooseFEM/MeshQuad4.hpp:1160:9: note: in instantiation of function template specialization 'xt::concatenate<xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> >,
      xt::xtensor_container<xt::uvector<unsigned long long, xsimd::aligned_allocator<unsigned long long, 32> >, 1, xt::layout_type::row_major, xt::xtensor_expression_tag> >' requested here
    xt::concatenate(xt::xtuple(xt::zeros<size_t>({1}), xt::cumsum(nhy)));
        ^
/usr/local/include/xtensor/xbroadcast.hpp:176:9: note: 'shape' declared here
        const inner_shape_type& shape() const noexcept;
        ^
In file included from /Volumes/EPFLmob/front-dynamics/CrackEvolution_stress/main.cpp:3:
In file included from /usr/local/include/xtensor/xview.hpp:24:
In file included from /usr/local/include/xtensor/xaccessible.hpp:13:
In file included from /usr/local/include/xtensor/xstrides.hpp:20:
In file included from /usr/local/include/xtensor/xshape.hpp:22:
In file included from /usr/local/include/xtensor/xstorage.hpp:21:
In file included from /usr/local/include/xtensor/xtensor_simd.hpp:14:
/usr/local/include/xtensor/xutils.hpp:161:13: error: no matching function for call to object of type '(lambda at /usr/local/include/xtensor/xbuilder.hpp:647:28)'
            f(std::get<I>(t));
            ^
/usr/local/include/xtensor/xutils.hpp:170:17: note: in instantiation of function template specialization 'xt::detail::for_each_impl<0, (lambda at /usr/local/include/xtensor/xbuilder.hpp:647:28) &,
      xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> >, xt::xtensor_container<xt::uvector<unsigned long long, xsimd::aligned_allocator<unsigned long long, 32> >, 1,
      xt::layout_type::row_major, xt::xtensor_expression_tag> >' requested here
        detail::for_each_impl<0, F, T...>(std::forward<F>(f), t);
                ^
/usr/local/include/xtensor/xbuilder.hpp:659:9: note: in instantiation of function template specialization 'xt::for_each<(lambda at /usr/local/include/xtensor/xbuilder.hpp:647:28) &,
      xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> >, xt::xtensor_container<xt::uvector<unsigned long long, xsimd::aligned_allocator<unsigned long long, 32> >, 1,
      xt::layout_type::row_major, xt::xtensor_expression_tag> >' requested here
        for_each(check_shape, t);
        ^
/usr/local/include/xtensor/xbuilder.hpp:647:28: note: candidate template ignored: substitution failure [with $0 = xt::xbroadcast<xt::xscalar<unsigned long>, std::__1::array<unsigned long, 1> >]
        auto check_shape = [&axis, &new_shape](auto& arr) {
                           ^
2 errors generated.
make[2]: *** [CMakeFiles/Run.dir/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Run.dir/all] Error 2
make: *** [all] Error 2
```