### PR TITLE
Added `reflect` mode to xt::pad, added OpenCV-to-xtensor documentation for xt::pad

### DIFF
--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -119,11 +119,11 @@ namespace xt
                     }
                 }
                 else if (mode == pad_mode::symmetric_101) {
-                    XTENSOR_ASSERT(out.shape()[axis]>1);
-                    XTENSOR_ASSERT(nb <= out.shape()[axis]-1);
-                    XTENSOR_ASSERT(ne <= out.shape()[axis]-1);
+                    XTENSOR_ASSERT(out.shape()[axis] > 1);
+                    XTENSOR_ASSERT(nb <= out.shape()[axis] - 1);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis] - 1);
                     sv_bgn[axis] = xt::range(nb, 0, -1);
-                    if (ne == out.shape()[axis]-1) {
+                    if (ne == out.shape()[axis] - 1) {
                         sv_end[axis] = xt::range(out.shape()[axis]-2, _, -1);
                     }
                     else {

--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -20,13 +20,27 @@ using namespace xt::placeholders;  // to enable _ syntax
 namespace xt
 {
     /**
-     * @brief Defines different algorithms to be used in ``xt::pad``
+     * @brief Defines different algorithms to be used in ``xt::pad``:
+     * - ``constant``: Pads with a constant value.
+     * - ``symmetric``: Pads with the reflection of the vector mirrored along the edge of the array.
+     * - ``reflect``: Pads with the reflection of the vector mirrored on the first and last values
+     *   of the vector along each axis.
+     * - ``wrap``: Pads with the wrap of the vector along the axis. The first values are used to pad
+     *   the end and the end values are used to pad the beginning.
+     * - ``periodic`` : ``== wrap`` (pads with periodic repetitions of the vector).
+     *
+     * OpenCV to xtensor:
+     * - ``BORDER_CONSTANT == constant``
+     * - ``BORDER_REFLECT == symmetric``
+     * - ``BORDER_REFLECT_101 == reflect``
+     * - ``BORDER_WRAP == wrap``
      */
     enum class pad_mode
     {
         constant,
         symmetric,
-        symmetric_101,
+        reflect,
+        wrap,
         periodic
     };
 
@@ -90,7 +104,7 @@ namespace xt
                 xt::xstrided_slice_vector sv_bgn(e.shape().size(), xt::all());
                 xt::xstrided_slice_vector sv_end(e.shape().size(), xt::all());
 
-                if (mode == pad_mode::periodic)
+                if (mode == pad_mode::wrap || mode == pad_mode::periodic)
                 {
                     XTENSOR_ASSERT(nb <= out.shape()[axis]);
                     XTENSOR_ASSERT(ne <= out.shape()[axis]);
@@ -118,15 +132,18 @@ namespace xt
                         sv_end[axis] = xt::range(out.shape()[axis], out.shape()[axis]-ne-1, -1);
                     }
                 }
-                else if (mode == pad_mode::symmetric_101) {
+                else if (mode == pad_mode::reflect)
+                {
                     XTENSOR_ASSERT(out.shape()[axis] > 1);
                     XTENSOR_ASSERT(nb <= out.shape()[axis] - 1);
                     XTENSOR_ASSERT(ne <= out.shape()[axis] - 1);
                     sv_bgn[axis] = xt::range(nb, 0, -1);
-                    if (ne == out.shape()[axis] - 1) {
+                    if (ne == out.shape()[axis] - 1)
+                    {
                         sv_end[axis] = xt::range(out.shape()[axis]-2, _, -1);
                     }
-                    else {
+                    else
+                    {
                         sv_end[axis] = xt::range(out.shape()[axis]-2, out.shape()[axis]-ne-2, -1);
                     }
                 }

--- a/include/xtensor/xpad.hpp
+++ b/include/xtensor/xpad.hpp
@@ -26,6 +26,7 @@ namespace xt
     {
         constant,
         symmetric,
+        symmetric_101,
         periodic
     };
 
@@ -115,6 +116,18 @@ namespace xt
                     else
                     {
                         sv_end[axis] = xt::range(out.shape()[axis], out.shape()[axis]-ne-1, -1);
+                    }
+                }
+                else if (mode == pad_mode::symmetric_101) {
+                    XTENSOR_ASSERT(out.shape()[axis]>1);
+                    XTENSOR_ASSERT(nb <= out.shape()[axis]-1);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis]-1);
+                    sv_bgn[axis] = xt::range(nb, 0, -1);
+                    if (ne == out.shape()[axis]-1) {
+                        sv_end[axis] = xt::range(out.shape()[axis]-2, _, -1);
+                    }
+                    else {
+                        sv_end[axis] = xt::range(out.shape()[axis]-2, out.shape()[axis]-ne-2, -1);
                     }
                 }
 

--- a/test/test_xpad.cpp
+++ b/test/test_xpad.cpp
@@ -187,4 +187,60 @@ namespace xt
 
         EXPECT_EQ(b, c);
     }
+
+    TEST(xpad, symmetric_101_a)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{5, 4, 3, 4, 5, 4, 3},
+                                    {2, 1, 0, 1, 2, 1, 0},
+                                    {5, 4, 3, 4, 5, 4, 3},
+                                    {2, 1, 0, 1, 2, 1, 0}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,1}, {2,2}}, xt::pad_mode::symmetric_101);
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, symmetric_101_b)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, 0, xt::pad_mode::symmetric_101);
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, symmetric_101_c)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{0, 1, 2, 1, 0},
+                                    {3, 4, 5, 4, 3},
+                                    {0, 1, 2, 1, 0}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{0,1}, {0,2}}, xt::pad_mode::symmetric_101);
+
+        EXPECT_EQ(b, c);
+    }
+
+    TEST(xpad, symmetric_101_d)
+    {
+        xt::xtensor<size_t, 2> a = {{0, 1, 2},
+                                    {3, 4, 5}};
+
+        xt::xtensor<size_t, 2> b = {{5, 4, 3, 4, 5},
+                                    {2, 1, 0, 1, 2},
+                                    {5, 4, 3, 4, 5}};
+
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,0}, {2,0}}, xt::pad_mode::symmetric_101);
+
+        EXPECT_EQ(b, c);
+    }
 }

--- a/test/test_xpad.cpp
+++ b/test/test_xpad.cpp
@@ -72,7 +72,7 @@ namespace xt
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, periodic_a)
+    TEST(xpad, wrap_a)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -84,12 +84,12 @@ namespace xt
                                     {0, 1, 2, 0, 1, 2, 0, 1, 2},
                                     {3, 4, 5, 3, 4, 5, 3, 4, 5}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{2,2}, {3,3}}, xt::pad_mode::periodic);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{2,2}, {3,3}}, xt::pad_mode::wrap);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, periodic_b)
+    TEST(xpad, wrap_b)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -97,12 +97,12 @@ namespace xt
         xt::xtensor<size_t, 2> b = {{0, 1, 2},
                                     {3, 4, 5}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, 0, xt::pad_mode::periodic);
+        xt::xtensor<size_t, 2> c = xt::pad(a, 0, xt::pad_mode::wrap);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, periodic_c)
+    TEST(xpad, wrap_c)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -111,12 +111,12 @@ namespace xt
                                     {3, 4, 5, 3, 4},
                                     {0, 1, 2, 0, 1}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{0,1}, {0,2}}, xt::pad_mode::periodic);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{0,1}, {0,2}}, xt::pad_mode::wrap);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, periodic_d)
+    TEST(xpad, wrap_d)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -125,7 +125,7 @@ namespace xt
                                     {1, 2, 0, 1, 2},
                                     {4, 5, 3, 4, 5}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,0}, {2,0}}, xt::pad_mode::periodic);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,0}, {2,0}}, xt::pad_mode::wrap);
 
         EXPECT_EQ(b, c);
     }
@@ -188,7 +188,7 @@ namespace xt
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, symmetric_101_a)
+    TEST(xpad, reflect_a)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -198,12 +198,12 @@ namespace xt
                                     {5, 4, 3, 4, 5, 4, 3},
                                     {2, 1, 0, 1, 2, 1, 0}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,1}, {2,2}}, xt::pad_mode::symmetric_101);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,1}, {2,2}}, xt::pad_mode::reflect);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, symmetric_101_b)
+    TEST(xpad, reflect_b)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -211,12 +211,12 @@ namespace xt
         xt::xtensor<size_t, 2> b = {{0, 1, 2},
                                     {3, 4, 5}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, 0, xt::pad_mode::symmetric_101);
+        xt::xtensor<size_t, 2> c = xt::pad(a, 0, xt::pad_mode::reflect);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, symmetric_101_c)
+    TEST(xpad, reflect_c)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -225,12 +225,12 @@ namespace xt
                                     {3, 4, 5, 4, 3},
                                     {0, 1, 2, 1, 0}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{0,1}, {0,2}}, xt::pad_mode::symmetric_101);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{0,1}, {0,2}}, xt::pad_mode::reflect);
 
         EXPECT_EQ(b, c);
     }
 
-    TEST(xpad, symmetric_101_d)
+    TEST(xpad, reflect_d)
     {
         xt::xtensor<size_t, 2> a = {{0, 1, 2},
                                     {3, 4, 5}};
@@ -239,7 +239,7 @@ namespace xt
                                     {2, 1, 0, 1, 2},
                                     {5, 4, 3, 4, 5}};
 
-        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,0}, {2,0}}, xt::pad_mode::symmetric_101);
+        xt::xtensor<size_t, 2> c = xt::pad(a, {{1,0}, {2,0}}, xt::pad_mode::reflect);
 
         EXPECT_EQ(b, c);
     }


### PR DESCRIPTION
Just like BORDER_REFLECT_101 in OpenCV