### PR TITLE
Fixed step_simd when underlying iterator holds an xscalar_stepper

### DIFF
--- a/test/test_xstrided_view.cpp
+++ b/test/test_xstrided_view.cpp
@@ -748,6 +748,13 @@ namespace xt
         EXPECT_EQ(v(2), 2.0);
     }
 
+    TEST(xstrided_view, on_broadcasted_scalar)
+    {
+        xarray<double> expected = { 1, 1, 1, 1, 1, 1, 1, 1 };
+        xarray<double> a = xt::squeeze(xt::ones<double>({8, 1}));
+        EXPECT_EQ(a, expected);
+    }
+
     TEST(xstrided_view, on_transpose)
     {
         xt::xarray<double> arr


### PR DESCRIPTION
Fixes #1722 