### PR TITLE
Shared

### DIFF
--- a/include/xtensor/xbroadcast.hpp
+++ b/include/xtensor/xbroadcast.hpp
@@ -136,7 +136,7 @@ namespace xt
      * @sa broadcast
      */
     template <class CT, class X>
-    class xbroadcast : public xexpression<xbroadcast<CT, X>>,
+    class xbroadcast : public xsharable_expression<xbroadcast<CT, X>>,
                        public xconst_iterable<xbroadcast<CT, X>>,
                        public xconst_accessible<xbroadcast<CT, X>>,
                        public extension::xbroadcast_base_t<CT, X>

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -183,13 +183,13 @@ namespace xt
     using has_xexpression = xtl::disjunction<is_xexpression<E>...>;
 
     template <class E>
-    using is_xsharable = is_crtp_base_of<xsharable_expression, E>;
+    using is_xsharable_expression = is_crtp_base_of<xsharable_expression, E>;
 
     template <class E, class R = void>
-    using enable_xsharable = typename std::enable_if<is_xsharable<E>::value, R>::type;
+    using enable_xsharable_expression = typename std::enable_if<is_xsharable_expression<E>::value, R>::type;
 
     template <class E, class R = void>
-    using disable_xsharable = typename std::enable_if<!is_xsharable<E>::value, R>::type;
+    using disable_xsharable_expression = typename std::enable_if<!is_xsharable_expression<E>::value, R>::type;
 
     /***********************
      * evaluation_strategy *
@@ -719,7 +719,7 @@ namespace xt
     template <class E>
     inline xshared_expression<E> make_xshared(xexpression<E>&& expr)
     {
-        static_assert(is_xsharable<E>::value, "make_shared requires E to inherit from xsharable_expression");
+        static_assert(is_xsharable_expression<E>::value, "make_shared requires E to inherit from xsharable_expression");
         return detail::make_xshared_impl(std::move(expr.derived_cast()));
     }
 

--- a/include/xtensor/xexpression.hpp
+++ b/include/xtensor/xexpression.hpp
@@ -25,15 +25,6 @@
 namespace xt
 {
 
-    template <class D>
-    class xexpression;
-    
-    template <class E>
-    class xshared_expression;
-
-    template <class E>
-    xshared_expression<E> make_xshared(xexpression<E>&&);
-
     /***************************
      * xexpression declaration *
      ***************************/
@@ -63,7 +54,7 @@ namespace xt
 
     protected:
 
-        xexpression();
+        xexpression() = default;
         ~xexpression() = default;
 
         xexpression(const xexpression&) = default;
@@ -71,23 +62,48 @@ namespace xt
 
         xexpression(xexpression&&) = default;
         xexpression& operator=(xexpression&&) = default;
+    };
+
+    /************************************
+     * xsharable_expression declaration *
+     ************************************/
+
+    template <class E>
+    class xshared_expression;
+
+    template <class E>
+    class xsharable_expression;
+
+    namespace detail
+    {
+        template <class E>
+        xshared_expression<E> make_xshared_impl(xsharable_expression<E>&&);
+    }
+
+    template <class D>
+    class xsharable_expression : public xexpression<D>
+    {
+    protected:
+
+        xsharable_expression();
+        ~xsharable_expression() = default;
+
+        xsharable_expression(const xsharable_expression&) = default;
+        xsharable_expression& operator=(const xsharable_expression&) = default;
+
+        xsharable_expression(xsharable_expression&&) = default;
+        xsharable_expression& operator=(xsharable_expression&&) = default;
 
     private:
 
         std::shared_ptr<D> p_shared;
 
-        friend xshared_expression<D> make_xshared<D>(xexpression<D>&&);
+        friend xshared_expression<D> detail::make_xshared_impl<D>(xsharable_expression<D>&&);
     };
 
     /******************************
      * xexpression implementation *
      ******************************/
-
-    template <class D>
-    inline xexpression<D>::xexpression()
-        : p_shared(nullptr)
-    {
-    }
 
     /**
      * @name Downcast functions
@@ -121,14 +137,25 @@ namespace xt
     }
     //@}
 
-    /* is_crtp_base_of<B, E>
-    * Resembles std::is_base_of, but adresses the problem of whether _some_ instantiation
-    * of a CRTP templated class B is a base of class E. A CRTP templated class is correctly
-    * templated with the most derived type in the CRTP hierarchy. Using this assumption,
-    * this implementation deals with either CRTP final classes (checks for inheritance
-    * with E as the CRTP parameter of B) or CRTP base classes (which are singly templated
-    * by the most derived class, and that's pulled out to use as a templete parameter for B).
-    */
+    /***************************************
+     * xsharable_expression implementation *
+     ***************************************/
+
+    template <class D>
+    inline xsharable_expression<D>::xsharable_expression()
+        : p_shared(nullptr)
+    {
+    }
+
+    /**
+     * is_crtp_base_of<B, E>
+     * Resembles std::is_base_of, but adresses the problem of whether _some_ instantiation
+     * of a CRTP templated class B is a base of class E. A CRTP templated class is correctly
+     * templated with the most derived type in the CRTP hierarchy. Using this assumption,
+     * this implementation deals with either CRTP final classes (checks for inheritance
+     * with E as the CRTP parameter of B) or CRTP base classes (which are singly templated
+     * by the most derived class, and that's pulled out to use as a templete parameter for B).
+     */
 
     namespace detail
     {
@@ -154,6 +181,15 @@ namespace xt
 
     template <class... E>
     using has_xexpression = xtl::disjunction<is_xexpression<E>...>;
+
+    template <class E>
+    using is_xsharable = is_crtp_base_of<xsharable_expression, E>;
+
+    template <class E, class R = void>
+    using enable_xsharable = typename std::enable_if<is_xsharable<E>::value, R>::type;
+
+    template <class E, class R = void>
+    using disable_xsharable = typename std::enable_if<!is_xsharable<E>::value, R>::type;
 
     /***********************
      * evaluation_strategy *
@@ -661,6 +697,19 @@ namespace xt
         return m_ptr.use_count();
     }
 
+    namespace detail
+    {
+        template <class E>
+        inline xshared_expression<E> make_xshared_impl(xsharable_expression<E>&& expr)
+        {
+            if(expr.p_shared == nullptr)
+            {
+                expr.p_shared = std::make_shared<E>(std::move(expr).derived_cast());
+            }
+            return xshared_expression<E>(expr.p_shared);
+        }
+    }
+
     /**
      * Helper function to create shared expression from any xexpression
      *
@@ -670,11 +719,8 @@ namespace xt
     template <class E>
     inline xshared_expression<E> make_xshared(xexpression<E>&& expr)
     {
-        if(expr.p_shared == nullptr)
-        {
-            expr.p_shared = std::make_shared<E>(std::move(expr).derived_cast());
-        }
-        return xshared_expression<E>(expr.p_shared);
+        static_assert(is_xsharable<E>::value, "make_shared requires E to inherit from xsharable_expression");
+        return detail::make_xshared_impl(std::move(expr.derived_cast()));
     }
 
     /**

--- a/include/xtensor/xfixed.hpp
+++ b/include/xtensor/xfixed.hpp
@@ -46,7 +46,7 @@ namespace xt
      * xfixed declaration *
      **********************/
 
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     class xfixed_container;
 
     namespace detail
@@ -239,8 +239,8 @@ namespace xt
     template <class V, class S>
     using get_init_type_t = typename get_init_type<V, S>::type;
 
-    template <class ET, class S, layout_type L, class Tag>
-    struct xcontainer_inner_types<xfixed_container<ET, S, L, Tag>>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    struct xcontainer_inner_types<xfixed_container<ET, S, L, SH, Tag>>
     {
         using shape_type = S;
         using inner_shape_type = typename S::cast_type;
@@ -260,13 +260,13 @@ namespace xt
         using reference = typename storage_type::reference;
         using const_reference = typename storage_type::const_reference;
         using size_type = typename storage_type::size_type;
-        using temporary_type = xfixed_container<ET, S, L, Tag>;
+        using temporary_type = xfixed_container<ET, S, L, SH, Tag>;
         static constexpr layout_type layout = L;
     };
 
-    template <class ET, class S, layout_type L, class Tag>
-    struct xiterable_inner_types<xfixed_container<ET, S, L, Tag>>
-        : xcontainer_iterable_types<xfixed_container<ET, S, L, Tag>>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    struct xiterable_inner_types<xfixed_container<ET, S, L, SH, Tag>>
+        : xcontainer_iterable_types<xfixed_container<ET, S, L, SH, Tag>>
     {
     };
 
@@ -281,16 +281,17 @@ namespace xt
      * @tparam ET The type of the elements.
      * @tparam S The xshape template paramter of the container. 
      * @tparam L The layout_type of the tensor.
+     * @tparam SH Wether the tensor can be used as a shared expression.
      * @tparam Tag The expression tag.
      * @sa xtensor_fixed
      */
-    template <class ET, class S, layout_type L, class Tag>
-    class xfixed_container : public xcontainer<xfixed_container<ET, S, L, Tag>>,
-                             public xcontainer_semantic<xfixed_container<ET, S, L, Tag>>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    class xfixed_container : public xcontainer<xfixed_container<ET, S, L, SH, Tag>>,
+                             public xcontainer_semantic<xfixed_container<ET, S, L, SH, Tag>>
     {
     public:
 
-        using self_type = xfixed_container<ET, S, L, Tag>;
+        using self_type = xfixed_container<ET, S, L, SH, Tag>;
         using base_type = xcontainer<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
 
@@ -367,30 +368,30 @@ namespace xt
         XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides_impl() const noexcept;
         XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides_impl() const noexcept;
 
-        friend class xcontainer<xfixed_container<ET, S, L, Tag>>;
+        friend class xcontainer<xfixed_container<ET, S, L, SH, Tag>>;
     };
 
 #ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
     // Out of line definitions to prevent linker errors prior to C++17
-    template <class ET, class S, layout_type L, class Tag>
-    constexpr typename xfixed_container<ET, S, L, Tag>::inner_shape_type xfixed_container<ET, S, L, Tag>::m_shape;
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_container<ET, S, L, SH, Tag>::inner_shape_type xfixed_container<ET, S, L, SH, Tag>::m_shape;
 
-    template <class ET, class S, layout_type L, class Tag>
-    constexpr typename xfixed_container<ET, S, L, Tag>::inner_strides_type xfixed_container<ET, S, L, Tag>::m_strides;
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_container<ET, S, L, SH, Tag>::inner_strides_type xfixed_container<ET, S, L, SH, Tag>::m_strides;
 
-    template <class ET, class S, layout_type L, class Tag>
-    constexpr typename xfixed_container<ET, S, L, Tag>::inner_backstrides_type xfixed_container<ET, S, L, Tag>::m_backstrides;
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_container<ET, S, L, SH, Tag>::inner_backstrides_type xfixed_container<ET, S, L, SH, Tag>::m_backstrides;
 #endif
 
     /****************************************
      * xfixed_container_adaptor declaration *
      ****************************************/
 
-    template <class EC, class S, layout_type L, class Tag>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
     class xfixed_adaptor;
 
-    template <class EC, class S, layout_type L, class Tag>
-    struct xcontainer_inner_types<xfixed_adaptor<EC, S, L, Tag>>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    struct xcontainer_inner_types<xfixed_adaptor<EC, S, L, SH, Tag>>
     {
         using storage_type = std::remove_reference_t<EC>;
         using reference = typename storage_type::reference;
@@ -402,13 +403,13 @@ namespace xt
         using backstrides_type = strides_type;
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
-        using temporary_type = xfixed_container<typename storage_type::value_type, S, L, Tag>;
+        using temporary_type = xfixed_container<typename storage_type::value_type, S, L, SH, Tag>;
         static constexpr layout_type layout = L;
     };
 
-    template <class EC, class S, layout_type L, class Tag>
-    struct xiterable_inner_types<xfixed_adaptor<EC, S, L, Tag>>
-        : xcontainer_iterable_types<xfixed_adaptor<EC, S, L, Tag>>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    struct xiterable_inner_types<xfixed_adaptor<EC, S, L, SH, Tag>>
+        : xcontainer_iterable_types<xfixed_adaptor<EC, S, L, SH, Tag>>
     {
     };
 
@@ -425,17 +426,18 @@ namespace xt
      * @tparam EC The closure for the container type to adapt.
      * @tparam S The xshape template parameter for the fixed shape of the adaptor
      * @tparam L The layout_type of the adaptor.
+     * @tparam SH Wether the adaptor can be used as a shared expression.
      * @tparam Tag The expression tag.
      */
-    template <class EC, class S, layout_type L, class Tag>
-    class xfixed_adaptor : public xcontainer<xfixed_adaptor<EC, S, L, Tag>>,
-                           public xcontainer_semantic<xfixed_adaptor<EC, S, L, Tag>>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    class xfixed_adaptor : public xcontainer<xfixed_adaptor<EC, S, L, SH, Tag>>,
+                           public xcontainer_semantic<xfixed_adaptor<EC, S, L, SH, Tag>>
     {
     public:
 
         using container_closure_type = EC;
 
-        using self_type = xfixed_adaptor<EC, S, L, Tag>;
+        using self_type = xfixed_adaptor<EC, S, L, SH, Tag>;
         using base_type = xcontainer<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
         using storage_type = typename base_type::storage_type;
@@ -498,19 +500,19 @@ namespace xt
         XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides_impl() const noexcept;
         XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides_impl() const noexcept;
 
-        friend class xcontainer<xfixed_adaptor<EC, S, L, Tag>>;
+        friend class xcontainer<xfixed_adaptor<EC, S, L, SH, Tag>>;
     };
 
 #ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
     // Out of line definitions to prevent linker errors prior to C++17
-    template <class EC, class S, layout_type L, class Tag>
-    constexpr typename xfixed_adaptor<EC, S, L, Tag>::inner_shape_type xfixed_adaptor<EC, S, L, Tag>::m_shape;
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_shape_type xfixed_adaptor<EC, S, L, SH, Tag>::m_shape;
 
-    template <class EC, class S, layout_type L, class Tag>
-    constexpr typename xfixed_adaptor<EC, S, L, Tag>::inner_strides_type xfixed_adaptor<EC, S, L, Tag>::m_strides;
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_strides_type xfixed_adaptor<EC, S, L, SH, Tag>::m_strides;
 
-    template <class EC, class S, layout_type L, class Tag>
-    constexpr typename xfixed_adaptor<EC, S, L, Tag>::inner_backstrides_type xfixed_adaptor<EC, S, L, Tag>::m_backstrides;
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    constexpr typename xfixed_adaptor<EC, S, L, SH, Tag>::inner_backstrides_type xfixed_adaptor<EC, S, L, SH, Tag>::m_backstrides;
 #endif
 
     /************************************
@@ -530,8 +532,8 @@ namespace xt
      * @param shape the shape of the xfixed_container (unused!)
      * @param l the layout_type of the xfixed_container (unused!)
      */
-    template <class ET, class S, layout_type L, class Tag>
-    inline xfixed_container<ET, S, L, Tag>::xfixed_container(const inner_shape_type& shape, layout_type l)
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    inline xfixed_container<ET, S, L, SH, Tag>::xfixed_container(const inner_shape_type& shape, layout_type l)
     {
         (void)(shape);
         (void)(l);
@@ -539,8 +541,8 @@ namespace xt
         XTENSOR_ASSERT(L == l);
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    inline xfixed_container<ET, S, L, Tag>::xfixed_container(const value_type& v)
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    inline xfixed_container<ET, S, L, SH, Tag>::xfixed_container(const value_type& v)
     {
         if (this->size() != 1)
         {
@@ -558,8 +560,8 @@ namespace xt
      * @param v the fill value
      * @param l the layout_type of the xfixed_container (unused!)
      */
-    template <class ET, class S, layout_type L, class Tag>
-    inline xfixed_container<ET, S, L, Tag>::xfixed_container(const inner_shape_type& shape, value_type v, layout_type l)
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    inline xfixed_container<ET, S, L, SH, Tag>::xfixed_container(const inner_shape_type& shape, value_type v, layout_type l)
     {
         (void)(shape);
         (void)(l);
@@ -597,9 +599,9 @@ namespace xt
         };
     }
 
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline xfixed_container<ET, S, L, Tag> xfixed_container<ET, S, L, Tag>::from_shape(ST&& shape)
+    inline xfixed_container<ET, S, L, SH, Tag> xfixed_container<ET, S, L, SH, Tag>::from_shape(ST&& shape)
     {
         (void) shape;
         self_type tmp;
@@ -614,9 +616,9 @@ namespace xt
      * time to prevent errors.
      * Note: for clang < 3.8 this is an initializer_list and the size is not checked at compile-or runtime.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class IX, class EN>
-    inline xfixed_container<ET, S, L, Tag>::xfixed_container(nested_initializer_list_t<value_type, N> t)
+    inline xfixed_container<ET, S, L, SH, Tag>::xfixed_container(nested_initializer_list_t<value_type, N> t)
     {
         XTENSOR_ASSERT_MSG(detail::check_initializer_list_shape<N>::run(t, this->shape()) == true, "initializer list shape does not match fixed shape");
         L == layout_type::row_major ? nested_copy(m_storage.begin(), t) : nested_copy(this->template begin<layout_type::row_major>(), t);
@@ -630,9 +632,9 @@ namespace xt
     /**
      * The extended copy constructor.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class E>
-    inline xfixed_container<ET, S, L, Tag>::xfixed_container(const xexpression<E>& e)
+    inline xfixed_container<ET, S, L, SH, Tag>::xfixed_container(const xexpression<E>& e)
     {
         semantic_base::assign(e);
     }
@@ -640,9 +642,9 @@ namespace xt
     /**
      * The extended assignment operator.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class E>
-    inline auto xfixed_container<ET, S, L, Tag>::operator=(const xexpression<E>& e) -> self_type&
+    inline auto xfixed_container<ET, S, L, SH, Tag>::operator=(const xexpression<E>& e) -> self_type&
     {
         return semantic_base::operator=(e);
     }
@@ -652,9 +654,9 @@ namespace xt
      * Note that the xfixed_container **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_container<ET, S, L, Tag>::resize(ST&& shape, bool) const
+    inline void xfixed_container<ET, S, L, SH, Tag>::resize(ST&& shape, bool) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         XTENSOR_ASSERT(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size());
@@ -664,9 +666,9 @@ namespace xt
      * Note that the xfixed_container **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_container<ET, S, L, Tag>::resize(ST&& shape, layout_type l) const
+    inline void xfixed_container<ET, S, L, SH, Tag>::resize(ST&& shape, layout_type l) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         (void)(l);
@@ -677,9 +679,9 @@ namespace xt
      * Note that the xfixed_container **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_container<ET, S, L, Tag>::resize(ST&& shape, const strides_type& strides) const
+    inline void xfixed_container<ET, S, L, SH, Tag>::resize(ST&& shape, const strides_type& strides) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         (void)(strides);
@@ -690,9 +692,9 @@ namespace xt
     /**
      * Note that the xfixed_container **cannot** be reshaped to a shape different from ``S``.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_container<ET, S, L, Tag>::reshape(ST&& shape, layout_type layout) const
+    inline void xfixed_container<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
     {
         if (!(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && layout == L))
         {
@@ -700,45 +702,45 @@ namespace xt
         }
     }
 
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline bool xfixed_container<ET, S, L, Tag>::broadcast_shape(ST& shape, bool) const
+    inline bool xfixed_container<ET, S, L, SH, Tag>::broadcast_shape(ST& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    constexpr layout_type xfixed_container<ET, S, L, Tag>::layout() const noexcept
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    constexpr layout_type xfixed_container<ET, S, L, SH, Tag>::layout() const noexcept
     {
         return base_type::static_layout;
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    inline auto xfixed_container<ET, S, L, Tag>::storage_impl() noexcept -> storage_type&
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_container<ET, S, L, SH, Tag>::storage_impl() noexcept -> storage_type&
     {
         return m_storage;
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    inline auto xfixed_container<ET, S, L, Tag>::storage_impl() const noexcept -> const storage_type&
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_container<ET, S, L, SH, Tag>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, Tag>::shape_impl() const noexcept -> const inner_shape_type&
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, Tag>::strides_impl() const noexcept -> const inner_strides_type&
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::strides_impl() const noexcept -> const inner_strides_type&
     {
         return m_strides;
     }
 
-    template <class ET, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, Tag>::backstrides_impl() const noexcept -> const inner_backstrides_type&
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_container<ET, S, L, SH, Tag>::backstrides_impl() const noexcept -> const inner_backstrides_type&
     {
         return m_backstrides;
     }
@@ -755,8 +757,8 @@ namespace xt
      * Constructs an xfixed_adaptor of the given stl-like container.
      * @param data the container to adapt
      */
-    template <class EC, class S, layout_type L, class Tag>
-    inline xfixed_adaptor<EC, S, L, Tag>::xfixed_adaptor(storage_type&& data)
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline xfixed_adaptor<EC, S, L, SH, Tag>::xfixed_adaptor(storage_type&& data)
         : base_type(), m_storage(std::move(data))
     {
     }
@@ -765,8 +767,8 @@ namespace xt
      * Constructs an xfixed_adaptor of the given stl-like container.
      * @param data the container to adapt
      */
-    template <class EC, class S, layout_type L, class Tag>
-    inline xfixed_adaptor<EC, S, L, Tag>::xfixed_adaptor(const storage_type& data)
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline xfixed_adaptor<EC, S, L, SH, Tag>::xfixed_adaptor(const storage_type& data)
         : base_type(), m_storage(data)
     {
     }
@@ -776,32 +778,32 @@ namespace xt
      * with the specified shape and layout_type.
      * @param data the container to adapt
      */
-    template <class EC, class S, layout_type L, class Tag>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
     template <class D>
-    inline xfixed_adaptor<EC, S, L, Tag>::xfixed_adaptor(D&& data)
+    inline xfixed_adaptor<EC, S, L, SH, Tag>::xfixed_adaptor(D&& data)
         : base_type(), m_storage(std::forward<D>(data))
     {
     }
     //@}
 
-    template <class EC, class S, layout_type L, class Tag>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::operator=(const xfixed_adaptor& rhs) -> self_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::operator=(const xfixed_adaptor& rhs) -> self_type&
     {
         base_type::operator=(rhs);
         m_storage = rhs.m_storage;
         return *this;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::operator=(xfixed_adaptor&& rhs) -> self_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::operator=(xfixed_adaptor&& rhs) -> self_type&
     {
         base_type::operator=(std::move(rhs));
         m_storage = rhs.m_storage;
         return *this;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::operator=(temporary_type&& rhs) -> self_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::operator=(temporary_type&& rhs) -> self_type&
     {
         m_storage.resize(rhs.storage().size());
         std::copy(rhs.storage().cbegin(), rhs.storage().cend(), m_storage.begin());
@@ -815,9 +817,9 @@ namespace xt
     /**
      * The extended assignment operator.
      */
-    template <class EC, class S, layout_type L, class Tag>
+    template <class EC, class S, layout_type L, bool SH, class Tag>
     template <class E>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::operator=(const xexpression<E>& e) -> self_type&
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::operator=(const xexpression<E>& e) -> self_type&
     {
         return semantic_base::operator=(e);
     }
@@ -827,9 +829,9 @@ namespace xt
      * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, bool) const
+    inline void xfixed_adaptor<ET, S, L, SH, Tag>::resize(ST&& shape, bool) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         XTENSOR_ASSERT(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size());
@@ -839,9 +841,9 @@ namespace xt
      * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, layout_type l) const
+    inline void xfixed_adaptor<ET, S, L, SH, Tag>::resize(ST&& shape, layout_type l) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         (void)(l);
@@ -852,9 +854,9 @@ namespace xt
      * Note that the xfixed_adaptor **cannot** be resized. Attempting to resize with a different
      * size throws an assert in debug mode.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_adaptor<ET, S, L, Tag>::resize(ST&& shape, const strides_type& strides) const
+    inline void xfixed_adaptor<ET, S, L, SH, Tag>::resize(ST&& shape, const strides_type& strides) const
     {
         (void)(shape);  // remove unused parameter warning if XTENSOR_ASSERT undefined
         (void)(strides);
@@ -865,9 +867,9 @@ namespace xt
     /**
      * Note that the xfixed_container **cannot** be reshaped to a shape different from ``S``.
      */
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline void xfixed_adaptor<ET, S, L, Tag>::reshape(ST&& shape, layout_type layout) const
+    inline void xfixed_adaptor<ET, S, L, SH, Tag>::reshape(ST&& shape, layout_type layout) const
     {
         if (!(std::equal(shape.begin(), shape.end(), m_shape.begin()) && shape.size() == m_shape.size() && layout == L))
         {
@@ -875,45 +877,45 @@ namespace xt
         }
     }
 
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     template <class ST>
-    inline bool xfixed_adaptor<ET, S, L, Tag>::broadcast_shape(ST& shape, bool) const
+    inline bool xfixed_adaptor<ET, S, L, SH, Tag>::broadcast_shape(ST& shape, bool) const
     {
         return xt::broadcast_shape(m_shape, shape);
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::storage_impl() noexcept -> storage_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::storage_impl() noexcept -> storage_type&
     {
         return m_storage;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    inline auto xfixed_adaptor<EC, S, L, Tag>::storage_impl() const noexcept -> const storage_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    inline auto xfixed_adaptor<EC, S, L, SH, Tag>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    constexpr layout_type xfixed_adaptor<EC, S, L, Tag>::layout() const noexcept
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    constexpr layout_type xfixed_adaptor<EC, S, L, SH, Tag>::layout() const noexcept
     {
         return base_type::static_layout;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, Tag>::shape_impl() const noexcept -> const inner_shape_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::shape_impl() const noexcept -> const inner_shape_type&
     {
         return m_shape;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, Tag>::strides_impl() const noexcept -> const inner_strides_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::strides_impl() const noexcept -> const inner_strides_type&
     {
         return m_strides;
     }
 
-    template <class EC, class S, layout_type L, class Tag>
-    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, Tag>::backstrides_impl() const noexcept -> const inner_backstrides_type&
+    template <class EC, class S, layout_type L, bool SH, class Tag>
+    XTENSOR_CONSTEXPR_RETURN auto xfixed_adaptor<EC, S, L, SH, Tag>::backstrides_impl() const noexcept -> const inner_backstrides_type&
     {
         return m_backstrides;
     }

--- a/include/xtensor/xfunction.hpp
+++ b/include/xtensor/xfunction.hpp
@@ -192,7 +192,7 @@ namespace xt
      */
     template <class F, class... CT>
     class xfunction : private xconst_iterable<xfunction<F, CT...>>,
-                      public xexpression<xfunction<F, CT...>>,
+                      public xsharable_expression<xfunction<F, CT...>>,
                       private xconst_accessible<xfunction<F, CT...>>,
                       public extension::xfunction_base_t<F, CT...>
     {

--- a/include/xtensor/xgenerator.hpp
+++ b/include/xtensor/xgenerator.hpp
@@ -87,7 +87,7 @@ namespace xt
      * @tparam S the shape type of the generator
      */
     template <class F, class R, class S>
-    class xgenerator : public xexpression<xgenerator<F, R, S>>,
+    class xgenerator : public xsharable_expression<xgenerator<F, R, S>>,
                        public xconst_iterable<xgenerator<F, R, S>>,
                        public xconst_accessible<xgenerator<F, R, S>>,
                        public extension::xgenerator_base_t<F, R, S>

--- a/include/xtensor/xmime.hpp
+++ b/include/xtensor/xmime.hpp
@@ -295,11 +295,11 @@ namespace xt
         return mime_bundle_repr_impl(expr);
     }
 
-    template <class ET, class S, layout_type L, class Tag>
+    template <class ET, class S, layout_type L, bool SH, class Tag>
     class xfixed_container;
 
-    template <class ET, class S, layout_type L, class Tag>
-    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, Tag>& expr)
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, SH, Tag>& expr)
     {
         return mime_bundle_repr_impl(expr);
     }

--- a/include/xtensor/xreducer.hpp
+++ b/include/xtensor/xreducer.hpp
@@ -671,7 +671,7 @@ namespace xt
      * @sa reduce
      */
     template <class F, class CT, class X, class O>
-    class xreducer : public xexpression<xreducer<F, CT, X, O>>,
+    class xreducer : public xsharable_expression<xreducer<F, CT, X, O>>,
                      public xconst_iterable<xreducer<F, CT, X, O>>,
                      public xaccessible<xreducer<F, CT, X, O>>,
                      public extension::xreducer_base_t<F, CT, X, O>

--- a/include/xtensor/xscalar.hpp
+++ b/include/xtensor/xscalar.hpp
@@ -82,7 +82,7 @@ namespace xt
     };
 
     template <class CT>
-    class xscalar : public xexpression<xscalar<CT>>,
+    class xscalar : public xsharable_expression<xscalar<CT>>,
                     private xiterable<xscalar<CT>>,
                     private xaccessible<xscalar<CT>>,
                     public extension::xscalar_base_t<CT>

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -17,6 +17,32 @@
 
 namespace xt
 {
+    namespace detail
+    {
+        template <class D>
+        struct is_sharable
+        {
+            static constexpr bool value = true;
+        };
+
+        template <class ET, class S, layout_type L, bool SH, class Tag>
+        struct is_sharable<xfixed_container<ET, S, L, SH, Tag>>
+        {
+            static constexpr bool value = SH;
+        };
+
+        template <class ET, class S, layout_type L, bool SH, class Tag>
+        struct is_sharable<xfixed_adaptor<ET, S, L, SH, Tag>>
+        {
+            static constexpr bool value = SH;
+        };
+    }
+
+    template <class D>
+    using select_expression_base_t = std::conditional_t<detail::is_sharable<D>::value,
+                                                        xsharable_expression<D>,
+                                                        xexpression<D>>;
+
     /**
      * @class xsemantic_base
      * @brief Base interface for assignable xexpressions.
@@ -28,11 +54,11 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xsemantic_base : public xsharable_expression<D>
+    class xsemantic_base : public select_expression_base_t<D>
     {
     public:
 
-        using base_type = xexpression<D>;
+        using base_type = select_expression_base_t<D>;
         using derived_type = typename base_type::derived_type;
 
         using temporary_type = typename xcontainer_inner_types<D>::temporary_type;

--- a/include/xtensor/xsemantic.hpp
+++ b/include/xtensor/xsemantic.hpp
@@ -28,7 +28,7 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xsemantic_base : public xexpression<D>
+    class xsemantic_base : public xsharable_expression<D>
     {
     public:
 

--- a/include/xtensor/xtensor_forward.hpp
+++ b/include/xtensor/xtensor_forward.hpp
@@ -150,10 +150,10 @@ namespace xt
     template <std::size_t... N>
     using xshape = fixed_shape<N...>;
 
-    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, bool Sharable = true, class Tag = xtensor_expression_tag>
     class xfixed_container;
 
-    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, bool Sharable = true, class Tag = xtensor_expression_tag>
     class xfixed_adaptor;
 
     /**
@@ -174,12 +174,13 @@ namespace xt
      * @tparam T The value type of the elements.
      * @tparam FSH A xshape template shape.
      * @tparam L The layout_type of the tensor (default: XTENSOR_DEFAULT_LAYOUT).
-     * @tparam A The allocator of the containers holding the elements.
+     * @tparam Sharable Wether the tnesor can be used in shared expression.
      */
     template <class T,
               class FSH,
-              layout_type L = XTENSOR_DEFAULT_LAYOUT>
-    using xtensor_fixed = xfixed_container<T, FSH, L>;
+              layout_type L = XTENSOR_DEFAULT_LAYOUT,
+              bool Sharable = true>
+    using xtensor_fixed = xfixed_container<T, FSH, L, Sharable>;
 
     /**
      * @typedef xtensor_optional

--- a/test/test_xfixed.cpp
+++ b/test/test_xfixed.cpp
@@ -293,6 +293,13 @@ namespace xt
         out << a + b;
         EXPECT_EQ("{1, 2}", out.str());
     }
+
+    TEST(xtensor_fixed, unsharable)
+    {
+        using fixed_tensor = xtensor_fixed<double, xshape<2>, layout_type::row_major, true>;
+        using tiny_tensor = xtensor_fixed<double, xshape<2>, layout_type::row_major, false>;
+        EXPECT_GT(sizeof(fixed_tensor), sizeof(tiny_tensor)); 
+    }
 }
 
 #endif


### PR DESCRIPTION
Fixes #1628 

@friendnick @emmenlau this PR adds a new template parameter to the existing `xfixed_container` and `xfixed_adaptor` classes that allows to disable the sharable property (in that case the container does not inherit from a structure containing the shared pointer and there is no memory overhead).

Typical usage is

```cpp
template <class T, class FSH>
using tiny_vector = xtensor_fixed<T, FSH, layout_type::row_major, false>;

tiny_vector<double, xshape<2>> a = //.....
// same API as xtensor_fixed
```