### PR TITLE
Fix typos and wording in documentation

### DIFF
--- a/docs/source/adaptor.rst
+++ b/docs/source/adaptor.rst
@@ -44,7 +44,7 @@ the corresponding value in ``v``:
 Adapting C-style arrays
 -----------------------
 
-`xtensor` provides two ways for adapting C-style array; the first one does not take the
+`xtensor` provides two ways for adapting a C-style array; the first one does not take the
 ownership of the array:
 
 .. code::

--- a/docs/source/api/expression_index.rst
+++ b/docs/source/api/expression_index.rst
@@ -7,8 +7,8 @@
 Expressions and semantic
 ========================
 
-``xexpression`` and the semantic classes contain all the methods required to perform evaluation anf
-assignment of expressions. They defined the computed assignment operators, the assignment methods for
+``xexpression`` and the semantic classes contain all the methods required to perform evaluation and
+assignment of expressions. They define the computed assignment operators, the assignment methods for
 ``noalias`` and the downcast methods.
 
 .. toctree::

--- a/docs/source/build-options.rst
+++ b/docs/source/build-options.rst
@@ -13,7 +13,7 @@ Configuration
 -------------
 
 ``xtensor`` can be configured via macros which must be defined *before* including
-any of its header. This can be achieved the following ways:
+any of its headers. This can be achieved the following ways:
 
 - either define them in the CMakeLists of your project, with ``target_compile_definitions``
   cmake command.
@@ -47,9 +47,9 @@ requirements):
 
 - ``XTENSOR_USE_XSIMD``: enables SIMD acceleration in ``xtensor``. This requires that you have xsimd_ installed
   on your system.
-- ``XTENSOR_USE_TBB``: enables parallel assignment loop. This requires that you have you have tbb_ installed
+- ``XTENSOR_USE_TBB``: enables parallel assignment loop. This requires that you have tbb_ installed
   on your system.
-- ``XTENSOR_USE_OPENMP``: enables parallel assignment loop using OpenMP. This requires that OpenMP is avaliable on your system.
+- ``XTENSOR_USE_OPENMP``: enables parallel assignment loop using OpenMP. This requires that OpenMP is available on your system.
 
 Defining these macros in the CMakeLists of your project before searching for ``xtensor`` will trigger automatic finding
 of dependencies, so you don't have to include the ``find_package(xsimd)`` and ``find_package(TBB)`` commands in your
@@ -88,7 +88,7 @@ If you defined ``XTENSOR_USE_XSIMD``, you must also specify which instruction se
     # OR
     target_compile_options(target_name PRIVATE /arch:ARMv7VE)
 
-If you build on an old system that do not support ny of these instruction set, you don't have to specify
+If you build on an old system that does not support any of these instruction sets, you don't have to specify
 anything, the system will do its best to enable the most recent supported instruction set.
 
 Linux/OSX

--- a/docs/source/builder.rst
+++ b/docs/source/builder.rst
@@ -17,7 +17,7 @@ Ones and zeros
 - ``zeros(shape)``: generates an expression containing zeros of the specified shape.
 - ``ones(shape)``: generates an expression containing ones of the specified shape.
 - ``eye(shape, k=0)``: generates an expression of the specified shape, with ones on the k-th diagonal.
-- ``eye(n, k = 0)``: generates an expression with ones on the k-th diagonal.
+- ``eye(n, k = 0)``: generates an expression of shape ``(n, n)`` with ones on the k-th diagonal.
 
 Numerical ranges
 ----------------

--- a/docs/source/container.rst
+++ b/docs/source/container.rst
@@ -132,7 +132,7 @@ values in the ``shape``:
 Performance
 -----------
 
-The dynamic dimensionality of ``xarray`` comes at a cost. Since the dimension is unknown at build time, the sequences holding shape and strides of ``xarray`` instances are heap-allocated, which makes it significantly more expansive than ``xtensor``. Shape and strides of ``xtensor`` are stack-allocated which makes them more efficient.
+The dynamic dimensionality of ``xarray`` comes at a cost. Since the dimension is unknown at build time, the sequences holding shape and strides of ``xarray`` instances are heap-allocated, which makes it significantly more expensive than ``xtensor``. Shape and strides of ``xtensor`` are stack-allocated which makes them more efficient.
 
 More generally, the library implements a ``promote_shape`` mechanism at build time to determine the optimal sequence type to hold the shape of an expression. The shape type of a broadcasting expression whose members have a dimensionality determined at compile time will have a stack-allocated shape. If a single member of a broadcasting expression has a dynamic dimension (for example an ``xarray``), it bubbles up to the entire broadcasting expression which will have a heap-allocated shape. The same hold for views, broadcast expressions, etc...
 

--- a/docs/source/indices.rst
+++ b/docs/source/indices.rst
@@ -66,7 +66,7 @@ which prints
      {2, 2},
      {2, 3}}
 
-Here we observe that to work print we need to convert the ``std::vector`` to a ``xt::xtensor<size_t, 2>`` array, which is done using ``xt::from_indices``.
+To print the ``std::vector``, it is converted to a ``xt::xtensor<size_t, 2>`` array, which is done using ``xt::from_indices``.
 
 From array indices to flat indices
 ----------------------------------

--- a/docs/source/missing.rst
+++ b/docs/source/missing.rst
@@ -7,7 +7,7 @@
 Missing values
 ==============
 
-``xtensor`` handles missing values and comprises specialized container types for an optimized support of missing values.
+``xtensor`` handles missing values and provides specialized container types for an optimized support of missing values.
 
 Optional expressions
 --------------------
@@ -83,8 +83,7 @@ of the two expressions while the last one holds a reference on at least one of t
         {{ true, true  },
          { true, false }};
 
-    xoptional_assembly<xarray<double>, xarray<bool>>
-    assembly(v, hv);
+    xoptional_assembly<xarray<double>, xarray<bool>> assembly(v, hv);
     std::cout << assembly << std::endl;
 
 outputs:

--- a/docs/source/operator.rst
+++ b/docs/source/operator.rst
@@ -52,8 +52,8 @@ logical operators, `xtensor` provides two reducing boolean functions:
 
 and an element-wise ternary function (similar to the ``: ?`` ternary operator):
 
-- ``where(E&& b, E1&& e&, E2&& e2)`` returns an ``xexpression`` whose elements
-  are those of ``e1`` when corresponding elements of ``b`` are thruthy, and
+- ``where(E&& b, E1&& e1, E2&& e2)`` returns an ``xexpression`` whose elements
+  are those of ``e1`` when corresponding elements of ``b`` are truthy, and
   those of ``e2`` otherwise.
 
 .. code::

--- a/docs/source/quickref/basic.rst
+++ b/docs/source/quickref/basic.rst
@@ -52,7 +52,7 @@ Tensor with fixed shape:
 
     #include "xfixed.hpp"
 
-    xt::xtensor_fixed<double, xt::xshape<2, 3>> = {{1., 2., 3.}, {4., 5., 6.}},
+    xt::xtensor_fixed<double, xt::xshape<2, 3>> = {{1., 2., 3.}, {4., 5., 6.}};
 
 Output
 ------

--- a/docs/source/quickref/builder.rst
+++ b/docs/source/quickref/builder.rst
@@ -91,12 +91,12 @@ filled with the specified value:
 Ones like
 ---------
 
-``ones_like(e)`` isquivalent to ``full_like(e, 1.)``.
+``ones_like(e)`` is equivalent to ``full_like(e, 1.)``.
 
 Zeros like
 ----------
 
-``zeros_like(e)`` isquivalent to ``full_like(e, 0.)``.
+``zeros_like(e)`` is equivalent to ``full_like(e, 0.)``.
 
 Eye
 ---
@@ -120,7 +120,7 @@ Generates an array with ones on the specified diagonal:
 Arange
 ------
 
-Generates numbers evenly spaced:
+Generates evenly spaced numbers:
 
 .. code::
 
@@ -128,8 +128,8 @@ Generates numbers evenly spaced:
     std::cout << e << std::endl;
     // Outputs {0., 2., 4., 6., 8.}
 
-A common pattern is to used ``arange`` followed by reshape to initialize
-tensor with arbitrary number of dimensions:
+A common pattern is to use ``arange`` followed by reshape to initialize
+a tensor with an arbitrary number of dimensions:
 
 .. code::
 
@@ -144,7 +144,7 @@ Linspace
 
     auto a = xt::linspace<double>(0., 10., 5);
     std::cout << a << std::endl;
-    // Ouputs {0., 2.5, 5., 7.5, 10.}
+    // Outputs {0., 2.5, 5., 7.5, 10.}
 
 Logspace
 --------
@@ -170,7 +170,7 @@ Concatenate
 Stack
 -----
 
-``stack`` always create a new dimension along which elements are stacked:
+``stack`` always creates a new dimension along which elements are stacked:
 
 .. code::
 

--- a/docs/source/scalar.rst
+++ b/docs/source/scalar.rst
@@ -11,7 +11,7 @@ Assignment
 ----------
 
 In ``xtensor``, scalars are handled as if they were 0-dimensional expressions. This means that when assigning
-a scalar value to an ``xarray``, this last one is **not filled** with that value, but resized to become a 0-D
+a scalar value to an ``xarray``, the array is **not filled** with that value, but resized to become a 0-D
 array containing the scalar value:
 
 .. code::
@@ -92,7 +92,7 @@ Then, somewhere in your program:
     // ...
     // later
     eval_mean(a, b);
-    // Now b is a 0-D container holding 21.
+    // Now b is a 0-D container holding 3.5.
 
 After that, ``b`` is a 0-dimensional array containing the mean of the elements of ``a``. Indeed, ``sum(a) / e1.size()`` is a
 0-D expression, thus when assigned to ``b``, this latter is resized. Later, you realize that you also need the sum of the elements

--- a/docs/source/view.rst
+++ b/docs/source/view.rst
@@ -164,7 +164,7 @@ Flatten views
 -------------
 
 It is sometimes useful to have a one-dimensional view of all the elements of an expression. ``xtensor`` provides two functions
-for that, ``ravel`` and ``flatten``. The former one let you specify the order used to read the elements while the latter one
+for that, ``ravel`` and ``flatten``. The former one lets you specify the order used to read the elements while the latter one
 uses the layout of the expression.
 
 .. code::
@@ -209,7 +209,7 @@ Dynamic views
 -------------
 
 The dynamic view is like the strided view, but with support of the slices returned by the ``keep`` and ``drop`` functions.
-However, this support has a cost and the dynamic view is slower than the strided view, even when no keeping or dropping
+However, this support has a cost and the dynamic view is slower than the strided view, even when no keeping or dropping of a 
 slice is involved.
 
 .. code::
@@ -320,7 +320,7 @@ Masked views are multidimensional views that apply a mask on an ``xexpression``.
 Broadcasting views
 ------------------
 
-Another type of view provided by `xtensor` is *broadcasting view*. Such a view broadcast an expression to the specified
+Another type of view provided by `xtensor` is *broadcasting view*. Such a view broadcasts an expression to the specified
 shape. As long as the view is not assigned to an array, no memory allocation or copy occurs. Broadcasting views should be
 built with the ``broadcast`` helper function.
 
@@ -340,7 +340,7 @@ built with the ``broadcast`` helper function.
 Complex views
 -------------
 
-In the case of tensor containing complex numbers, `xtensor` provides views returning ``xexpression`` corresponding to the real
+In the case of a tensor containing complex numbers, `xtensor` provides views returning ``xexpression`` corresponding to the real
 and imaginary parts of the complex numbers. Like for other views, the elements of the underlying ``xexpression`` are not copied.
 
 Functions ``xt::real`` and ``xt::imag`` respectively return views on the real and imaginary part of a complex expression.
@@ -369,8 +369,8 @@ The returned value is an expression holding a closure on the passed argument.
 Assigning to a view
 -------------------
 
-When assigning an expression ``rhs`` to a container such as ``xarray``, this last one is resized so its shape is the same as the one
-of ``RHS``. However, since views *cannot be resized*, when assigning an expression to a view, broadcasting rules are applied:
+When assigning an expression ``rhs`` to a container such as ``xarray``, the container is resized so its shape is the same as the one
+of ``rhs``. However, since views *cannot be resized*, when assigning an expression to a view, broadcasting rules are applied:
 
 .. code::
 


### PR DESCRIPTION
Hello, 
When I read the documentation, I found some typos and errors, which I corrected to the best of my ability. I didn't check every page or explicitly looked for them, so there are probably things I have missed.
