### PR TITLE
Allows (de)serialization of xexpressions in NumPy formatted strings and streams

### DIFF
--- a/include/xtensor/xnpy.hpp
+++ b/include/xtensor/xnpy.hpp
@@ -674,6 +674,36 @@ namespace xt
     }
 
     /**
+     * Save xexpression to NumPy npy format in a string
+     *
+     * @param e the xexpression
+     */
+    template <typename E>
+    inline std::string dump_npy(const xexpression<E>& e)
+    {
+        std::stringstream stream;
+        detail::dump_npy_stream(stream, e);
+        return stream.str();
+    }
+
+    /**
+     * Loads a npy file (the numpy storage format)
+     *
+     * @param stream An input stream from which to load the file
+     * @tparam T select the type of the npy file (note: currently there is
+     *           no dynamic casting if types do not match)
+     * @tparam L select layout_type::column_major if you stored data in
+     *           Fortran format
+     * @return xarray with contents from npy file
+     */
+    template <typename T, layout_type L = layout_type::dynamic>
+    inline auto load_npy(std::istream& stream)
+    {
+        detail::npy_file file = detail::load_npy_file(stream);
+        return std::move(file).cast<T, L>();
+    }
+
+    /**
      * Loads a npy file (the numpy storage format)
      *
      * @param filename The filename or path to the file
@@ -691,8 +721,7 @@ namespace xt
         {
             throw std::runtime_error("io error: failed to open a file.");
         }
-        detail::npy_file file = detail::load_npy_file(stream);
-        return std::move(file).cast<T, L>();
+        return load_npy<T, L>(stream);
     }
 
 }  // namespace xt

--- a/test/test_xnpy.cpp
+++ b/test/test_xnpy.cpp
@@ -43,8 +43,20 @@ namespace xt
         auto darr_loaded = load_npy<double>("files/xnpy_files/double.npy");
         EXPECT_TRUE(all(isclose(darr, darr_loaded)));
 
+        std::ifstream dstream("files/xnpy_files/double.npy");
+        auto darr_loaded_stream = load_npy<double>(dstream);
+        EXPECT_TRUE(all(isclose(darr, darr_loaded_stream)))
+            << "Loading double numpy array from stream failed";
+        dstream.close();
+
         auto barr_loaded = load_npy<bool>("files/xnpy_files/bool.npy");
         EXPECT_TRUE(all(equal(barr, barr_loaded)));
+
+        std::ifstream bstream("files/xnpy_files/bool.npy");
+        auto barr_loaded_stream = load_npy<bool>(bstream);
+        EXPECT_TRUE(all(isclose(barr, barr_loaded_stream)))
+            << "Loading boolean numpy array from stream failed";
+        bstream.close();
 
         auto dfarr_loaded = load_npy<double, layout_type::column_major>("files/xnpy_files/double_fortran.npy");
         EXPECT_TRUE(all(isclose(darr, dfarr_loaded)));
@@ -72,6 +84,11 @@ namespace xt
         return filename;
     }
 
+    std::string read_file(const std::string& name)
+    {
+        return (std::stringstream() << std::ifstream(name).rdbuf()).str();
+    }
+
     TEST(xnpy, dump)
     {
         std::string filename = get_filename(0);
@@ -95,6 +112,11 @@ namespace xt
         }
 
         EXPECT_TRUE(compare_binary_files(filename, compare_name));
+
+        std::string barr_str = dump_npy(barr);
+        std::string barr_disk = read_file(compare_name);
+        EXPECT_EQ(barr_str, barr_disk) << "Dumping boolean numpy file to string failed";
+
         std::remove(filename.c_str());
 
         filename = get_filename(1);
@@ -109,6 +131,11 @@ namespace xt
         }
 
         EXPECT_TRUE(compare_binary_files(filename, compare_name));
+
+        std::string ularr_str = dump_npy(ularr);
+        std::string ularr_disk = read_file(compare_name);
+        EXPECT_EQ(ularr_str, ularr_disk) << "Dumping boolean numpy file to string failed";
+
         std::remove(filename.c_str());
     }
 

--- a/test/test_xnpy.cpp
+++ b/test/test_xnpy.cpp
@@ -54,7 +54,7 @@ namespace xt
 
         std::ifstream bstream("files/xnpy_files/bool.npy");
         auto barr_loaded_stream = load_npy<bool>(bstream);
-        EXPECT_TRUE(all(isclose(barr, barr_loaded_stream)))
+        EXPECT_TRUE(all(equal(barr, barr_loaded_stream)))
             << "Loading boolean numpy array from stream failed";
         bstream.close();
 
@@ -86,7 +86,7 @@ namespace xt
 
     std::string read_file(const std::string& name)
     {
-        return (std::stringstream() << std::ifstream(name).rdbuf()).str();
+        return static_cast<std::stringstream const&>(std::stringstream() << std::ifstream(name).rdbuf()).str();
     }
 
     TEST(xnpy, dump)


### PR DESCRIPTION
- Implements an overload of `xt::dump_npy` which returns a
NumPy-formatted file as a bytestring.
- Implements an overload of `xt::load_npy` which returns an xexpression
from a NumPy-formatted input stream.
- Adds tests for both above methods, which are implemented in terms of
existing methods in the `xnpy.hpp` file.

Support for reading and writing directly to C++ strings and/or streams
is useful for moving NumPy-formatted files around in memory or via
file-like objects other than a normal on-disk file (such as a pipe or
socket).